### PR TITLE
Add per-user Pushover notifications

### DIFF
--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -89,6 +89,10 @@ func serve(args []string) error {
 		}
 		log.Printf("dev auth user: %s (%s)", user.DisplayName, user.ID)
 	}
+	var pushNotifier httpapi.PushNotifier
+	if cfg.PushoverAPIToken != "" {
+		pushNotifier = httpapi.NewPushoverNotifier(cfg.PushoverAPIToken)
+	}
 	log.Printf("ClickClack listening on %s", displayURL(cfg.Addr))
 	server := httpapi.New(st, realtime.NewHub(), httpapi.Options{
 		UploadDir:      filepath.Join(cfg.Data, "uploads"),
@@ -99,6 +103,7 @@ func serve(args []string) error {
 			PublicURL:    cfg.PublicURL,
 			AllowedOrg:   cfg.GitHubAllowedOrg,
 		},
+		PushNotifier: pushNotifier,
 	})
 	return httpapi.ListenAndServe(ctx, cfg.Addr, server.Handler())
 }

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	GitHubClientID     string `json:"github_client_id"`
 	GitHubClientSecret string `json:"github_client_secret"`
 	GitHubAllowedOrg   string `json:"github_allowed_org"`
+	PushoverAPIToken   string `json:"pushover_api_token"`
 }
 
 func Defaults() Config {
@@ -50,6 +51,9 @@ func Load(path string) (Config, error) {
 	}
 	if env := os.Getenv("CLICKCLACK_GITHUB_ALLOWED_ORG"); env != "" {
 		cfg.GitHubAllowedOrg = env
+	}
+	if env := os.Getenv("CLICKCLACK_PUSHOVER_API_TOKEN"); env != "" {
+		cfg.PushoverAPIToken = env
 	}
 	if path == "" {
 		return cfg, nil

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -15,11 +15,12 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_ID", "client")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_SECRET", "secret")
 	t.Setenv("CLICKCLACK_GITHUB_ALLOWED_ORG", "openclaw")
+	t.Setenv("CLICKCLACK_PUSHOVER_API_TOKEN", "app-token")
 	cfg, err := Load("")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Addr != ":9000" || cfg.Data != "/tmp/clickclack" || cfg.DB != "sqlite:///tmp/clickclack.db" || cfg.PublicURL != "https://clickclack.test" || cfg.DevBootstrap || cfg.GitHubClientID != "client" || cfg.GitHubClientSecret != "secret" || cfg.GitHubAllowedOrg != "openclaw" {
+	if cfg.Addr != ":9000" || cfg.Data != "/tmp/clickclack" || cfg.DB != "sqlite:///tmp/clickclack.db" || cfg.PublicURL != "https://clickclack.test" || cfg.DevBootstrap || cfg.GitHubClientID != "client" || cfg.GitHubClientSecret != "secret" || cfg.GitHubAllowedOrg != "openclaw" || cfg.PushoverAPIToken != "app-token" {
 		t.Fatalf("unexpected env config: %#v", cfg)
 	}
 
@@ -43,6 +44,7 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_ID", "")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_SECRET", "")
 	t.Setenv("CLICKCLACK_GITHUB_ALLOWED_ORG", "")
+	t.Setenv("CLICKCLACK_PUSHOVER_API_TOKEN", "")
 	emptyPath := filepath.Join(t.TempDir(), "empty.json")
 	if err := os.WriteFile(emptyPath, []byte(`{}`), 0o644); err != nil {
 		t.Fatal(err)

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -212,6 +212,7 @@ func (s *Server) createDirectMessage(w http.ResponseWriter, r *http.Request) {
 	message, event, err := s.store.CreateDirectMessage(r.Context(), store.CreateDirectMessageInput{ConversationID: chi.URLParam(r, "conversation_id"), AuthorID: user.ID, Body: body.Body, QuotedMessageID: optionalString(body.QuotedMessageID), Nonce: body.Nonce})
 	if err == nil && event.ID != "" {
 		s.hub.Publish(event)
+		s.notifyMessageCreated(r.Context(), message)
 	}
 	writeMessageCreateResult(w, message, event, err)
 }
@@ -232,6 +233,7 @@ func (s *Server) mattermostWebhook(w http.ResponseWriter, r *http.Request) {
 	message, event, err := s.store.CreateMessage(r.Context(), store.CreateMessageInput{ChannelID: chi.URLParam(r, "channel_id"), AuthorID: user.ID, Body: body.Text})
 	if err == nil {
 		s.hub.Publish(event)
+		s.notifyMessageCreated(r.Context(), message)
 	}
 	writeResultStatus(w, http.StatusCreated, map[string]any{"message": message, "event": event}, err)
 }
@@ -256,6 +258,7 @@ func (s *Server) slashCommand(w http.ResponseWriter, r *http.Request) {
 	message, event, err := s.store.CreateMessage(r.Context(), store.CreateMessageInput{ChannelID: chi.URLParam(r, "channel_id"), AuthorID: user.ID, Body: body})
 	if err == nil {
 		s.hub.Publish(event)
+		s.notifyMessageCreated(r.Context(), message)
 	}
 	writeResultStatus(w, http.StatusCreated, map[string]any{
 		"response_type": "in_channel",

--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -43,8 +43,24 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	notifier := &recordingNotifier{}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads"), PushNotifier: notifier}).Handler())
 	t.Cleanup(server.Close)
+
+	second, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Second", Email: "second@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspaces[0].ID, second.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
+		UserID:          second.ID,
+		PushoverEnabled: true,
+		PushoverUserKey: "u12345678901234567890123456789",
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	updatedChannel := patchJSON[struct {
 		Channel store.Channel `json:"channel"`
@@ -56,6 +72,9 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	message := postJSON[struct {
 		Message store.Message `json:"message"`
 	}](t, server.URL+"/api/channels/"+channels[0].ID+"/messages", map[string]string{"body": "original"}).Message
+	if len(notifier.notifications) != 1 || notifier.notifications[0].RecipientKey != "u12345678901234567890123456789" {
+		t.Fatalf("expected one pushover notification, got %#v", notifier.notifications)
+	}
 	updatedMessage := patchJSON[struct {
 		Message store.Message `json:"message"`
 		Event   store.Event   `json:"event"`
@@ -81,6 +100,23 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	}](t, server.URL+"/api/realtime/ephemeral", map[string]any{"workspace_id": workspaces[0].ID, "type": "presence.changed", "payload": map[string]any{"status": "afk"}})
 	if presence.Event.Type != "presence.changed" {
 		t.Fatalf("unexpected presence event: %#v", presence.Event)
+	}
+	notifier.err = errors.New("pushover unavailable")
+	postJSON[struct {
+		Message store.Message `json:"message"`
+	}](t, server.URL+"/api/channels/"+channels[0].ID+"/messages", map[string]string{"body": "still succeeds"})
+	notifier.err = nil
+	updatedMe := patchJSON[struct {
+		User store.User `json:"user"`
+	}](t, server.URL+"/api/me", map[string]any{
+		"display_name": "Owner",
+		"notification_settings": map[string]any{
+			"pushover_enabled":  true,
+			"pushover_user_key": "u98765432109876543210987654321",
+		},
+	})
+	if updatedMe.User.NotificationSettings == nil || !updatedMe.User.NotificationSettings.PushoverEnabled || updatedMe.User.NotificationSettings.PushoverUserKey == "" {
+		t.Fatalf("expected profile notification settings, got %#v", updatedMe.User)
 	}
 	expectStatus(t, http.MethodPatch, server.URL+"/api/channels/"+channels[0].ID, bytes.NewReader([]byte(`{`)), http.StatusBadRequest)
 	expectStatus(t, http.MethodPatch, server.URL+"/api/channels/missing", bytes.NewReader([]byte(`{"name":"missing"}`)), http.StatusBadRequest)
@@ -221,6 +257,16 @@ func readEventTypeWithin(t *testing.T, conn *websocket.Conn, eventType string, t
 			return event, true
 		}
 	}
+}
+
+type recordingNotifier struct {
+	notifications []PushNotification
+	err           error
+}
+
+func (r *recordingNotifier) Notify(_ context.Context, notification PushNotification) error {
+	r.notifications = append(r.notifications, notification)
+	return r.err
 }
 
 func patchJSON[T any](t *testing.T, endpoint string, body any) T {

--- a/apps/api/internal/httpapi/notifications.go
+++ b/apps/api/internal/httpapi/notifications.go
@@ -1,0 +1,67 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+type PushNotification struct {
+	RecipientKey string
+	Title        string
+	Message      string
+}
+
+type PushNotifier interface {
+	Notify(ctx context.Context, notification PushNotification) error
+}
+
+func (s *Server) notifyMessageCreated(ctx context.Context, message store.Message) {
+	if s.pushNotifier == nil {
+		return
+	}
+	recipients, err := s.store.ListPushNotificationRecipients(ctx, message.ID)
+	if err != nil {
+		log.Printf("push notification recipient lookup failed: %v", err)
+		return
+	}
+	for _, recipient := range recipients {
+		notification := PushNotification{
+			RecipientKey: recipient.PushoverUserKey,
+			Title:        notificationTitle(message),
+			Message:      notificationBody(message),
+		}
+		if err := s.pushNotifier.Notify(ctx, notification); err != nil {
+			log.Printf("push notification failed for user %s: %v", recipient.UserID, err)
+		}
+	}
+}
+
+func notificationTitle(message store.Message) string {
+	if message.DirectConversationID != "" {
+		return "ClickClack DM"
+	}
+	if message.ParentMessageID != nil {
+		return "ClickClack thread"
+	}
+	return "ClickClack"
+}
+
+func notificationBody(message store.Message) string {
+	author := message.AuthorID
+	if message.Author != nil && strings.TrimSpace(message.Author.DisplayName) != "" {
+		author = message.Author.DisplayName
+	}
+	body := strings.TrimSpace(message.Body)
+	bodyRunes := []rune(body)
+	if len(bodyRunes) > 500 {
+		body = string(bodyRunes[:500]) + "..."
+	}
+	if body == "" {
+		return fmt.Sprintf("%s sent a message", author)
+	}
+	return fmt.Sprintf("%s: %s", author, body)
+}

--- a/apps/api/internal/httpapi/pushover.go
+++ b/apps/api/internal/httpapi/pushover.go
@@ -1,0 +1,69 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const pushoverMessagesURL = "https://api.pushover.net/1/messages.json"
+
+type PushoverNotifier struct {
+	Token  string
+	Client *http.Client
+}
+
+func NewPushoverNotifier(token string) *PushoverNotifier {
+	return &PushoverNotifier{
+		Token:  strings.TrimSpace(token),
+		Client: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func (p *PushoverNotifier) Notify(ctx context.Context, notification PushNotification) error {
+	if p == nil || p.Token == "" {
+		return errors.New("pushover token is not configured")
+	}
+	user := strings.TrimSpace(notification.RecipientKey)
+	if user == "" {
+		return errors.New("pushover user key is required")
+	}
+	form := url.Values{}
+	form.Set("token", p.Token)
+	form.Set("user", user)
+	form.Set("title", notification.Title)
+	form.Set("message", notification.Message)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, pushoverMessagesURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := p.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Status int      `json:"status"`
+		Errors []string `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+	if resp.StatusCode >= 300 || result.Status != 1 {
+		if len(result.Errors) > 0 {
+			return fmt.Errorf("pushover rejected notification: %s", strings.Join(result.Errors, "; "))
+		}
+		return fmt.Errorf("pushover rejected notification with status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/apps/api/internal/httpapi/pushover_test.go
+++ b/apps/api/internal/httpapi/pushover_test.go
@@ -1,0 +1,64 @@
+package httpapi
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestPushoverNotifierPostsForm(t *testing.T) {
+	var body string
+	notifier := NewPushoverNotifier("app-token")
+	notifier.Client = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Method != http.MethodPost || req.URL.String() != pushoverMessagesURL {
+			t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+		}
+		if got := req.Header.Get("Content-Type"); got != "application/x-www-form-urlencoded" {
+			t.Fatalf("unexpected content type %q", got)
+		}
+		raw, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body = string(raw)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"status":1}`)),
+		}, nil
+	})}
+	if err := notifier.Notify(context.Background(), PushNotification{
+		RecipientKey: "user-key",
+		Title:        "ClickClack",
+		Message:      "Owner: hello",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"token=app-token", "user=user-key", "title=ClickClack", "message=Owner%3A+hello"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected form to contain %q, got %q", want, body)
+		}
+	}
+}
+
+func TestPushoverNotifierReportsFailures(t *testing.T) {
+	notifier := NewPushoverNotifier("app-token")
+	notifier.Client = &http.Client{Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"status":0,"errors":["bad user"]}`)),
+		}, nil
+	})}
+	if err := notifier.Notify(context.Background(), PushNotification{RecipientKey: "user-key", Message: "hello"}); err == nil {
+		t.Fatal("expected pushover failure")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -25,12 +25,14 @@ type Server struct {
 	uploadDir      string
 	githubOAuth    GitHubOAuthConfig
 	disableDevAuth bool
+	pushNotifier   PushNotifier
 }
 
 type Options struct {
 	UploadDir      string
 	GitHubOAuth    GitHubOAuthConfig
 	DisableDevAuth bool
+	PushNotifier   PushNotifier
 }
 
 func New(st store.Store, hub *realtime.Hub, options Options) *Server {
@@ -40,6 +42,7 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 		uploadDir:      options.UploadDir,
 		githubOAuth:    options.GitHubOAuth.withDefaults(),
 		disableDevAuth: options.DisableDevAuth,
+		pushNotifier:   options.PushNotifier,
 	}
 }
 
@@ -110,9 +113,10 @@ func (s *Server) updateMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		DisplayName string `json:"display_name"`
-		Handle      string `json:"handle"`
-		AvatarURL   string `json:"avatar_url"`
+		DisplayName          string                      `json:"display_name"`
+		Handle               string                      `json:"handle"`
+		AvatarURL            string                      `json:"avatar_url"`
+		NotificationSettings *store.NotificationSettings `json:"notification_settings"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -124,6 +128,16 @@ func (s *Server) updateMe(w http.ResponseWriter, r *http.Request) {
 		Handle:      body.Handle,
 		AvatarURL:   body.AvatarURL,
 	})
+	if err == nil && body.NotificationSettings != nil {
+		_, err = s.store.UpdateNotificationSettings(r.Context(), store.UpdateNotificationSettingsInput{
+			UserID:          user.ID,
+			PushoverEnabled: body.NotificationSettings.PushoverEnabled,
+			PushoverUserKey: body.NotificationSettings.PushoverUserKey,
+		})
+		if err == nil {
+			updated, err = s.store.GetUser(r.Context(), user.ID)
+		}
+	}
 	writeResult(w, map[string]any{"user": updated}, err)
 }
 
@@ -224,6 +238,7 @@ func (s *Server) createMessage(w http.ResponseWriter, r *http.Request) {
 	message, event, err := s.store.CreateMessage(r.Context(), store.CreateMessageInput{ChannelID: chi.URLParam(r, "channel_id"), AuthorID: user.ID, Body: body.Body, QuotedMessageID: optionalString(body.QuotedMessageID), Nonce: body.Nonce})
 	if err == nil && event.ID != "" {
 		s.hub.Publish(event)
+		s.notifyMessageCreated(r.Context(), message)
 	}
 	writeMessageCreateResult(w, message, event, err)
 }
@@ -255,6 +270,7 @@ func (s *Server) createThreadReply(w http.ResponseWriter, r *http.Request) {
 	message, state, events, err := s.store.CreateThreadReply(r.Context(), store.CreateThreadReplyInput{RootMessageID: chi.URLParam(r, "message_id"), AuthorID: user.ID, Body: body.Body, QuotedMessageID: optionalString(body.QuotedMessageID)})
 	if err == nil {
 		s.hub.PublishMany(events)
+		s.notifyMessageCreated(r.Context(), message)
 	}
 	writeResultStatus(w, http.StatusCreated, map[string]any{"message": message, "thread_state": state, "events": events}, err)
 }

--- a/apps/api/internal/store/sqlite/export.go
+++ b/apps/api/internal/store/sqlite/export.go
@@ -15,7 +15,7 @@ func (s *Store) Backup(ctx context.Context, outPath string) error {
 func (s *Store) ExportJSON(ctx context.Context, writer io.Writer) error {
 	out := map[string]any{}
 	tables := []string{
-		"users", "identities", "workspaces", "workspace_members", "channels",
+		"users", "user_notification_settings", "identities", "workspaces", "workspace_members", "channels",
 		"messages", "thread_state", "reactions", "events", "uploads",
 		"message_attachments", "direct_conversations", "direct_conversation_members",
 		"invites", "auth_magic_links", "sessions",

--- a/apps/api/internal/store/sqlite/identity.go
+++ b/apps/api/internal/store/sqlite/identity.go
@@ -21,7 +21,7 @@ func (s *Store) UpsertIdentityUser(ctx context.Context, input store.UpsertIdenti
 		JOIN users u ON u.id = i.user_id
 		WHERE i.provider = ? AND i.provider_subject = ?`, provider, subject))
 	if err == nil {
-		return user, nil
+		return s.hydrateUserNotificationSettings(ctx, user)
 	}
 	if !errors.Is(err, sql.ErrNoRows) {
 		return store.User{}, err
@@ -53,5 +53,8 @@ func (s *Store) UpsertIdentityUser(ctx context.Context, input store.UpsertIdenti
 	if err != nil {
 		return store.User{}, err
 	}
-	return user, tx.Commit()
+	if err := tx.Commit(); err != nil {
+		return store.User{}, err
+	}
+	return s.hydrateUserNotificationSettings(ctx, user)
 }

--- a/apps/api/internal/store/sqlite/migrations/0006_user_notification_settings.sql
+++ b/apps/api/internal/store/sqlite/migrations/0006_user_notification_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS user_notification_settings (
+  user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  pushover_enabled INTEGER NOT NULL DEFAULT 0,
+  pushover_user_key TEXT NOT NULL DEFAULT ''
+);

--- a/apps/api/internal/store/sqlite/misc_test.go
+++ b/apps/api/internal/store/sqlite/misc_test.go
@@ -62,6 +62,27 @@ func TestStoreMiscBranches(t *testing.T) {
 	if _, err := st.UpdateUserProfile(ctx, store.UpdateUserProfileInput{UserID: "usr_missing", DisplayName: "Missing"}); err == nil {
 		t.Fatal("expected missing profile user error")
 	}
+	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{UserID: owner.ID, PushoverEnabled: true}); err == nil {
+		t.Fatal("expected missing pushover key error")
+	}
+	settings, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
+		UserID:          owner.ID,
+		PushoverEnabled: true,
+		PushoverUserKey: "u12345678901234567890123456789",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !settings.PushoverEnabled || settings.PushoverUserKey == "" {
+		t.Fatalf("unexpected notification settings: %#v", settings)
+	}
+	ownerWithSettings, err := st.GetUser(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ownerWithSettings.NotificationSettings == nil || !ownerWithSettings.NotificationSettings.PushoverEnabled {
+		t.Fatalf("expected hydrated notification settings: %#v", ownerWithSettings)
+	}
 	identityUser, err := st.UpsertIdentityUser(ctx, store.UpsertIdentityUserInput{
 		Provider:        "github",
 		ProviderSubject: "42",
@@ -135,6 +156,13 @@ func TestStoreMiscBranches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	recipients, err := st.ListPushNotificationRecipients(ctx, root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recipients) != 0 {
+		t.Fatalf("author should not receive own push notification: %#v", recipients)
+	}
 	if _, err := st.db.ExecContext(ctx, `UPDATE messages SET edited_at = created_at, deleted_at = created_at WHERE id = ?`, root.ID); err != nil {
 		t.Fatal(err)
 	}
@@ -180,6 +208,13 @@ func TestStoreMiscBranches(t *testing.T) {
 	}
 	if len(replies) != 6 || len(threadState.LastReplyAuthorIDs) != 3 {
 		t.Fatalf("unexpected thread compaction: replies=%d state=%#v", len(replies), threadState)
+	}
+	recipients, err = st.ListPushNotificationRecipients(ctx, reply.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recipients) != 1 || recipients[0].UserID != owner.ID {
+		t.Fatalf("expected opted-in non-author recipient, got %#v", recipients)
 	}
 	if replies[len(replies)-1].EditedAt == nil || replies[len(replies)-1].DeletedAt == nil {
 		t.Fatalf("expected edited/deleted reply fields, got %#v", replies[len(replies)-1])

--- a/apps/api/internal/store/sqlite/notifications.go
+++ b/apps/api/internal/store/sqlite/notifications.go
@@ -1,0 +1,122 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+var pushoverUserKeyRE = regexp.MustCompile(`^[A-Za-z0-9]{30}$`)
+
+func (s *Store) UpdateNotificationSettings(ctx context.Context, input store.UpdateNotificationSettingsInput) (store.NotificationSettings, error) {
+	userKey := strings.TrimSpace(input.PushoverUserKey)
+	if input.PushoverEnabled && userKey == "" {
+		return store.NotificationSettings{}, errors.New("pushover_user_key is required when pushover notifications are enabled")
+	}
+	if userKey != "" && !pushoverUserKeyRE.MatchString(userKey) {
+		return store.NotificationSettings{}, errors.New("pushover_user_key must be 30 alphanumeric characters")
+	}
+	enabled := 0
+	if input.PushoverEnabled {
+		enabled = 1
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO user_notification_settings (user_id, pushover_enabled, pushover_user_key)
+		VALUES (?, ?, ?)
+		ON CONFLICT(user_id) DO UPDATE SET
+			pushover_enabled = excluded.pushover_enabled,
+			pushover_user_key = excluded.pushover_user_key`, input.UserID, enabled, userKey)
+	if err != nil {
+		return store.NotificationSettings{}, err
+	}
+	return store.NotificationSettings{PushoverEnabled: input.PushoverEnabled, PushoverUserKey: userKey}, nil
+}
+
+func (s *Store) hydrateUserNotificationSettings(ctx context.Context, user store.User) (store.User, error) {
+	settings, err := s.getNotificationSettings(ctx, user.ID)
+	if err != nil {
+		return store.User{}, err
+	}
+	user.NotificationSettings = &settings
+	return user, nil
+}
+
+func (s *Store) getNotificationSettings(ctx context.Context, userID string) (store.NotificationSettings, error) {
+	var settings store.NotificationSettings
+	var enabled int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT pushover_enabled, pushover_user_key
+		FROM user_notification_settings
+		WHERE user_id = ?`, userID).Scan(&enabled, &settings.PushoverUserKey)
+	if errors.Is(err, sql.ErrNoRows) {
+		return settings, nil
+	}
+	if err != nil {
+		return store.NotificationSettings{}, err
+	}
+	settings.PushoverEnabled = enabled == 1
+	return settings, nil
+}
+
+func (s *Store) ListPushNotificationRecipients(ctx context.Context, messageID string) ([]store.PushNotificationRecipient, error) {
+	message, err := getMessage(ctx, s.db, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if message.DirectConversationID != "" {
+		return s.listDirectPushNotificationRecipients(ctx, message)
+	}
+	return s.listWorkspacePushNotificationRecipients(ctx, message)
+}
+
+func (s *Store) listWorkspacePushNotificationRecipients(ctx context.Context, message store.Message) ([]store.PushNotificationRecipient, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT u.id, u.display_name, uns.pushover_user_key
+		FROM workspace_members wm
+		JOIN users u ON u.id = wm.user_id
+		JOIN user_notification_settings uns ON uns.user_id = u.id
+		WHERE wm.workspace_id = ?
+		  AND u.id <> ?
+		  AND uns.pushover_enabled = 1
+		  AND uns.pushover_user_key <> ''
+		ORDER BY u.id`, message.WorkspaceID, message.AuthorID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPushNotificationRecipients(rows)
+}
+
+func (s *Store) listDirectPushNotificationRecipients(ctx context.Context, message store.Message) ([]store.PushNotificationRecipient, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT u.id, u.display_name, uns.pushover_user_key
+		FROM direct_conversation_members dcm
+		JOIN users u ON u.id = dcm.user_id
+		JOIN user_notification_settings uns ON uns.user_id = u.id
+		WHERE dcm.conversation_id = ?
+		  AND u.id <> ?
+		  AND uns.pushover_enabled = 1
+		  AND uns.pushover_user_key <> ''
+		ORDER BY u.id`, message.DirectConversationID, message.AuthorID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanPushNotificationRecipients(rows)
+}
+
+func scanPushNotificationRecipients(rows *sql.Rows) ([]store.PushNotificationRecipient, error) {
+	out := []store.PushNotificationRecipient{}
+	for rows.Next() {
+		var recipient store.PushNotificationRecipient
+		if err := rows.Scan(&recipient.UserID, &recipient.DisplayName, &recipient.PushoverUserKey); err != nil {
+			return nil, err
+		}
+		out = append(out, recipient)
+	}
+	return out, rows.Err()
+}

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -146,11 +146,19 @@ func (s *Store) CreateUser(ctx context.Context, input store.CreateUserInput) (st
 }
 
 func (s *Store) FirstUser(ctx context.Context) (store.User, error) {
-	return scanUser(s.db.QueryRowContext(ctx, `SELECT id, display_name, handle, avatar_url, created_at FROM users ORDER BY created_at LIMIT 1`))
+	user, err := scanUser(s.db.QueryRowContext(ctx, `SELECT id, display_name, handle, avatar_url, created_at FROM users ORDER BY created_at LIMIT 1`))
+	if err != nil {
+		return store.User{}, err
+	}
+	return s.hydrateUserNotificationSettings(ctx, user)
 }
 
 func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
-	return scanUser(s.db.QueryRowContext(ctx, `SELECT id, display_name, handle, avatar_url, created_at FROM users WHERE id = ?`, id))
+	user, err := scanUser(s.db.QueryRowContext(ctx, `SELECT id, display_name, handle, avatar_url, created_at FROM users WHERE id = ?`, id))
+	if err != nil {
+		return store.User{}, err
+	}
+	return s.hydrateUserNotificationSettings(ctx, user)
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -15,11 +15,29 @@ var ErrQuotedMessageOutOfScope = errors.New("quoted message is not in this chann
 var ErrClientNonceConflict = errors.New("client nonce was already used for a different message")
 
 type User struct {
-	ID          string `json:"id"`
-	DisplayName string `json:"display_name"`
-	Handle      string `json:"handle"`
-	AvatarURL   string `json:"avatar_url"`
-	CreatedAt   string `json:"created_at"`
+	ID                   string                `json:"id"`
+	DisplayName          string                `json:"display_name"`
+	Handle               string                `json:"handle"`
+	AvatarURL            string                `json:"avatar_url"`
+	CreatedAt            string                `json:"created_at"`
+	NotificationSettings *NotificationSettings `json:"notification_settings,omitempty"`
+}
+
+type NotificationSettings struct {
+	PushoverEnabled bool   `json:"pushover_enabled"`
+	PushoverUserKey string `json:"pushover_user_key"`
+}
+
+type UpdateNotificationSettingsInput struct {
+	UserID          string
+	PushoverEnabled bool
+	PushoverUserKey string
+}
+
+type PushNotificationRecipient struct {
+	UserID          string
+	DisplayName     string
+	PushoverUserKey string
 }
 
 type Workspace struct {
@@ -263,6 +281,8 @@ type Store interface {
 	CreateUser(ctx context.Context, input CreateUserInput) (User, error)
 	UpsertIdentityUser(ctx context.Context, input UpsertIdentityUserInput) (User, error)
 	UpdateUserProfile(ctx context.Context, input UpdateUserProfileInput) (User, error)
+	UpdateNotificationSettings(ctx context.Context, input UpdateNotificationSettingsInput) (NotificationSettings, error)
+	ListPushNotificationRecipients(ctx context.Context, messageID string) ([]PushNotificationRecipient, error)
 	AddWorkspaceMember(ctx context.Context, workspaceID, userID, role string) error
 	EnsureDefaultWorkspaceMember(ctx context.Context, userID string) (Workspace, error)
 	FirstUser(ctx context.Context) (User, error)

--- a/apps/web/src/ChatApp.svelte
+++ b/apps/web/src/ChatApp.svelte
@@ -48,6 +48,8 @@
   let profileDisplayName = "";
   let profileHandle = "";
   let profileAvatarURL = "";
+  let profilePushoverEnabled = false;
+  let profilePushoverUserKey = "";
   let profileStatus = "";
   let profileStatusError = false;
   let status = "loading";
@@ -115,6 +117,8 @@
     profileDisplayName = user.display_name;
     profileHandle = user.handle ? `@${user.handle}` : "";
     profileAvatarURL = user.avatar_url;
+    profilePushoverEnabled = user.notification_settings?.pushover_enabled ?? false;
+    profilePushoverUserKey = user.notification_settings?.pushover_user_key ?? "";
     profileStatus = "";
     profileStatusError = false;
     showProfileSettings = true;
@@ -130,6 +134,10 @@
           display_name: profileDisplayName,
           handle: profileHandle,
           avatar_url: profileAvatarURL,
+          notification_settings: {
+            pushover_enabled: profilePushoverEnabled,
+            pushover_user_key: profilePushoverUserKey,
+          },
         }),
       });
       user = data.user;
@@ -1165,11 +1173,15 @@
     displayName={profileDisplayName}
     handle={profileHandle}
     avatarURL={profileAvatarURL}
+    pushoverEnabled={profilePushoverEnabled}
+    pushoverUserKey={profilePushoverUserKey}
     status={profileStatus}
     statusError={profileStatusError}
     onDisplayName={(value) => (profileDisplayName = value)}
     onHandle={(value) => (profileHandle = value)}
     onAvatarURL={(value) => (profileAvatarURL = value)}
+    onPushoverEnabled={(value) => (profilePushoverEnabled = value)}
+    onPushoverUserKey={(value) => (profilePushoverUserKey = value)}
     onClose={closeModal}
     onSave={() => void saveProfile()}
   />

--- a/apps/web/src/components/profile/ProfileSettingsModal.svelte
+++ b/apps/web/src/components/profile/ProfileSettingsModal.svelte
@@ -7,11 +7,15 @@
     displayName: string;
     handle: string;
     avatarURL: string;
+    pushoverEnabled: boolean;
+    pushoverUserKey: string;
     status: string;
     statusError: boolean;
     onDisplayName: (value: string) => void;
     onHandle: (value: string) => void;
     onAvatarURL: (value: string) => void;
+    onPushoverEnabled: (value: boolean) => void;
+    onPushoverUserKey: (value: string) => void;
     onClose: () => void;
     onSave: () => void;
   };
@@ -21,11 +25,15 @@
     displayName,
     handle,
     avatarURL,
+    pushoverEnabled,
+    pushoverUserKey,
     status,
     statusError,
     onDisplayName,
     onHandle,
     onAvatarURL,
+    onPushoverEnabled,
+    onPushoverUserKey,
     onClose,
     onSave,
   }: Props = $props();
@@ -89,6 +97,24 @@
           placeholder="https://example.com/avatar.png"
           inputmode="url"
           oninput={(event) => onAvatarURL(event.currentTarget.value)}
+        />
+      </label>
+      <label class="field check-field">
+        <input
+          type="checkbox"
+          checked={pushoverEnabled}
+          onchange={(event) => onPushoverEnabled(event.currentTarget.checked)}
+        />
+        <span>Pushover notifications</span>
+      </label>
+      <label class="field">
+        <span>Pushover user key</span>
+        <input
+          value={pushoverUserKey}
+          aria-label="Pushover user key"
+          maxlength="30"
+          autocomplete="off"
+          oninput={(event) => onPushoverUserKey(event.currentTarget.value)}
         />
       </label>
       {#if status}<p class="profile-status" class:error={statusError}>{status}</p>{/if}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -4,6 +4,12 @@ export type User = {
   handle: string;
   avatar_url: string;
   created_at: string;
+  notification_settings?: NotificationSettings;
+};
+
+export type NotificationSettings = {
+  pushover_enabled: boolean;
+  pushover_user_key: string;
 };
 
 export type Workspace = {

--- a/apps/web/src/styles/modals.css
+++ b/apps/web/src/styles/modals.css
@@ -133,6 +133,18 @@
   box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
+.check-field {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.check-field input {
+  width: 16px;
+  height: 16px;
+  padding: 0;
+}
+
 .profile-status {
   color: var(--success);
   font-size: 12px;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ hook in `cmd/clickclack/main.go`.
 | —                     | `CLICKCLACK_GITHUB_CLIENT_ID`    | unset       | GitHub OAuth app client ID. |
 | —                     | `CLICKCLACK_GITHUB_CLIENT_SECRET`| unset       | GitHub OAuth app client secret. |
 | —                     | `CLICKCLACK_GITHUB_ALLOWED_ORG`  | unset       | Optional GitHub org login gate. Requires `read:org` scope. |
+| —                     | `CLICKCLACK_PUSHOVER_API_TOKEN`  | unset       | Pushover application API token. Users still opt in with their own Pushover user key in account settings. |
 
 ## Config file
 
@@ -42,7 +43,8 @@ hook in `cmd/clickclack/main.go`.
   "public_url": "https://chat.example.com",
   "github_client_id": "Iv1.xxxxxxxxxxxx",
   "github_client_secret": "...",
-  "github_allowed_org": "openclaw"
+  "github_allowed_org": "openclaw",
+  "pushover_api_token": "azGDORePK8gMaC0QOYAMyEEuzJnyUi"
 }
 ```
 

--- a/docs/features/profiles.md
+++ b/docs/features/profiles.md
@@ -5,7 +5,8 @@ read_when:
 
 # Profiles
 
-Each user has a display name, optional handle, and optional avatar URL.
+Each user has a display name, optional handle, optional avatar URL, and
+per-user notification settings.
 
 The handle is the human-friendly short name shown as `@name` in the app. The
 API accepts it with or without the leading `@`, normalizes it to lowercase, and
@@ -20,7 +21,11 @@ PATCH /api/me
 {
   "display_name": "Peter Steinberger",
   "handle": "@steipete",
-  "avatar_url": "https://example.com/avatar.png"
+  "avatar_url": "https://example.com/avatar.png",
+  "notification_settings": {
+    "pushover_enabled": true,
+    "pushover_user_key": "uQiRzpo4DXghDmr9QzzfQu27cmVRsG"
+  }
 }
 ```
 
@@ -28,11 +33,17 @@ PATCH /api/me
 must be 2-32 characters using letters, numbers, `_`, or `-`. Avatar URLs can be
 blank or an `http`/`https` URL.
 
+Pushover notifications require `CLICKCLACK_PUSHOVER_API_TOKEN` on the server.
+Each user opts in from account settings with their own 30-character Pushover
+user key. Message-created pushes are delivered to opted-in workspace members
+except the author; DMs are delivered only to opted-in conversation members
+except the author.
+
 ## App
 
 The current user's profile control sits at the bottom of the channel sidebar.
 Click or right-click it to open account settings and edit display name, handle,
-and avatar URL.
+avatar URL, and Pushover notification settings.
 
 Clicking a message avatar or author name opens a Slack-style profile pane in
 the right rail. The pane shows the user's avatar, display name, handle,

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -545,6 +545,8 @@ components:
         avatar_url:
           type: string
           format: uri
+        notification_settings:
+          $ref: "#/components/schemas/NotificationSettings"
     User:
       type: object
       required: [id, display_name, handle, avatar_url, created_at]
@@ -560,6 +562,18 @@ components:
         created_at:
           type: string
           format: date-time
+        notification_settings:
+          $ref: "#/components/schemas/NotificationSettings"
+    NotificationSettings:
+      type: object
+      required: [pushover_enabled, pushover_user_key]
+      properties:
+        pushover_enabled:
+          type: boolean
+        pushover_user_key:
+          type: string
+          description: Current user's Pushover user key. Must be set when Pushover notifications are enabled.
+          pattern: "^[A-Za-z0-9]{30}$"
     CreateChannelRequest:
       type: object
       required: [name]

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -474,6 +474,7 @@ export interface components {
       handle?: string;
       /** Format: uri */
       avatar_url?: string;
+      notification_settings?: components["schemas"]["NotificationSettings"];
     };
     User: {
       id: string;
@@ -482,6 +483,12 @@ export interface components {
       avatar_url: string;
       /** Format: date-time */
       created_at: string;
+      notification_settings?: components["schemas"]["NotificationSettings"];
+    };
+    NotificationSettings: {
+      pushover_enabled: boolean;
+      /** @description Current user's Pushover user key. Must be set when Pushover notifications are enabled. */
+      pushover_user_key: string;
     };
     CreateChannelRequest: {
       name: string;


### PR DESCRIPTION
Here's a good and quick way to get mobile notifications for this right now until such a time as mobile exists! (Also Pushover is fantastic for Codex notifications too :P)

## Summary
- add per-user notification settings backed by a new `user_notification_settings` table
- add Pushover as the first push notifier, configured with `CLICKCLACK_PUSHOVER_API_TOKEN`
- expose Pushover opt-in/user-key fields through `/api/me` and the account settings UI
- notify opted-in non-authors for channel messages, thread replies, webhook/slash posts, and DMs

## Verification
- `go test ./apps/api/internal/config ./apps/api/internal/store/sqlite ./apps/api/internal/httpapi ./apps/api/cmd/clickclack`
- `pnpm --filter @clickclack/web typecheck`
- `pnpm --filter @clickclack/sdk-ts typecheck`
- `pnpm exec oxfmt --check --threads=1 apps/web/src/ChatApp.svelte apps/web/src/components/profile/ProfileSettingsModal.svelte apps/web/src/lib/types.ts packages/sdk-ts/src/generated/openapi.d.ts`
- `pnpm docs:site`
- `git diff --check`
