### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Test
         run: go test ./...
 
+      - name: Deadcode
+        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+
       - name: Coverage gate
         run: bash scripts/check-go-coverage.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,13 @@ jobs:
         run: go test ./...
 
       - name: Deadcode
-        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+        run: |
+          output_file=$(mktemp)
+          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
 
       - name: Coverage gate
         run: bash scripts/check-go-coverage.sh

--- a/apps/api/internal/store/postgres/dms.go
+++ b/apps/api/internal/store/postgres/dms.go
@@ -234,11 +234,6 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	return msg, event, tx.Commit()
 }
 
-func (s *Store) requireDirectMembership(ctx context.Context, conversationID, userID string) error {
-	_, err := s.q.RequireDirectMembership(ctx, storedb.RequireDirectMembershipParams{ConversationID: conversationID, UserID: userID})
-	return err
-}
-
 func (s *Store) requireDirectAccess(ctx context.Context, conversationID, userID string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/apps/api/internal/store/postgres/moderation.go
+++ b/apps/api/internal/store/postgres/moderation.go
@@ -198,10 +198,6 @@ func requireCanSendDirectTx(ctx context.Context, tx *sql.Tx, workspaceID, userID
 	return nil
 }
 
-func (s *Store) postsRemaining(ctx context.Context, workspaceID, userID, role string) (int, int, error) {
-	return postsRemainingTx(ctx, s.db, workspaceID, userID, role)
-}
-
 func postsRemainingTx(ctx context.Context, q storedb.DBTX, workspaceID, userID, role string) (int, int, error) {
 	if role != store.WorkspaceRoleGuest {
 		return 0, 0, nil

--- a/apps/api/internal/store/postgres/sqlc_adapters.go
+++ b/apps/api/internal/store/postgres/sqlc_adapters.go
@@ -101,16 +101,6 @@ func storeMagicLinkFromDB(link storedb.AuthMagicLink) store.MagicLink {
 	}
 }
 
-func storeWorkspaceFromFirstWorkspace(row storedb.FirstWorkspaceRow) store.Workspace {
-	return store.Workspace{
-		ID:        row.ID,
-		RouteID:   row.RouteID,
-		Name:      row.Name,
-		Slug:      row.Slug,
-		CreatedAt: row.CreatedAt,
-	}
-}
-
 func storeWorkspaceFromListWorkspaces(row storedb.ListWorkspacesRow) store.Workspace {
 	return store.Workspace{
 		ID:        row.ID,

--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -234,11 +234,6 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	return msg, event, tx.Commit()
 }
 
-func (s *Store) requireDirectMembership(ctx context.Context, conversationID, userID string) error {
-	_, err := s.q.RequireDirectMembership(ctx, storedb.RequireDirectMembershipParams{ConversationID: conversationID, UserID: userID})
-	return err
-}
-
 func (s *Store) requireDirectAccess(ctx context.Context, conversationID, userID string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/apps/api/internal/store/sqlite/moderation.go
+++ b/apps/api/internal/store/sqlite/moderation.go
@@ -190,10 +190,6 @@ func requireCanSendDirectTx(ctx context.Context, tx *sql.Tx, workspaceID, userID
 	return nil
 }
 
-func (s *Store) postsRemaining(ctx context.Context, workspaceID, userID, role string) (int, int, error) {
-	return postsRemainingTx(ctx, s.db, workspaceID, userID, role)
-}
-
 func postsRemainingTx(ctx context.Context, q storedb.DBTX, workspaceID, userID, role string) (int, int, error) {
 	if role != store.WorkspaceRoleGuest {
 		return 0, 0, nil

--- a/apps/api/internal/store/sqlite/sqlc_adapters.go
+++ b/apps/api/internal/store/sqlite/sqlc_adapters.go
@@ -101,16 +101,6 @@ func storeMagicLinkFromDB(link storedb.AuthMagicLink) store.MagicLink {
 	}
 }
 
-func storeWorkspaceFromFirstWorkspace(row storedb.FirstWorkspaceRow) store.Workspace {
-	return store.Workspace{
-		ID:        row.ID,
-		RouteID:   row.RouteID,
-		Name:      row.Name,
-		Slug:      row.Slug,
-		CreatedAt: row.CreatedAt,
-	}
-}
-
 func storeWorkspaceFromListWorkspaces(row storedb.ListWorkspacesRow) store.Workspace {
 	return store.Workspace{
 		ID:        row.ID,


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable store helpers reported by deadcode\n- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `go test -count=1 ./...`
- `go test -count=1 ./...`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean
