### PR TITLE
test(web): close mobile drawer via mobile control

### DIFF
--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -273,30 +273,36 @@ test("mobile navigation behaves like a drawer", async ({ page }) => {
 
   const composer = page.locator('textarea[aria-label="Message body"]');
   const toggle = page.getByRole("button", { name: "Toggle navigation" });
+  const openMobileNavigation = async () => {
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  };
+
+  await expect(page.getByRole("heading", { name: "#general" })).toBeVisible();
+  await expect(composer).toBeVisible();
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-  await toggle.click();
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await openMobileNavigation();
   await expect(page.getByRole("button", { name: "Close navigation" })).toBeVisible();
 
-  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await page.getByRole("button", { name: "Close navigation" }).click();
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-  await toggle.click();
-  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await openMobileNavigation();
   await page.setViewportSize({ width: 1024, height: 844 });
   await expect(page.getByRole("button", { name: "Collapse sidebar" })).toBeVisible();
   await page.setViewportSize({ width: 390, height: 844 });
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-  await toggle.click();
+  await openMobileNavigation();
   await page.keyboard.type("hidden draft");
   await expect(composer).toHaveValue("");
 
   await page.keyboard.press("Escape");
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
 
-  await toggle.click();
+  await openMobileNavigation();
   await page.getByRole("button", { name: "Close navigation" }).click();
   await expect(toggle).toHaveAttribute("aria-expanded", "false");
 });


### PR DESCRIPTION
What Problem This Solves

The post-merge main CI run failed in Playwright because the mobile drawer test clicked the desktop sidebar collapse button while it was offscreen at mobile width.

Why This Change Was Made

The mobile drawer already exposes a visible Close navigation control. The test should exercise that mobile control instead of relying on the desktop collapse affordance.

User Impact

No production behavior changes. This keeps the mobile navigation regression test aligned with the UI and unblocks main CI.

Evidence

- pnpm fmt:ts:check
- pnpm test:e2e tests/e2e/chat.spec.ts --project=chromium --grep "mobile navigation behaves like a drawer" built and started the app locally, then stopped because the local Playwright Chromium binary is not installed. The hosted PR CI has the browser bundle and is the E2E proof lane.
