### PR TITLE
ci(release): publish desktop apps for three platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -24,6 +24,8 @@ jobs:
     name: GoReleaser
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - name: Check out
         uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
@@ -66,3 +68,126 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  desktop:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS Desktop
+            os: macos-latest
+            platform: mac
+            builder_args: --mac dmg zip --x64 --arm64
+            files: |
+              apps/desktop/release/*.dmg
+              apps/desktop/release/*.zip
+          - name: Windows Desktop
+            os: windows-latest
+            platform: win
+            builder_args: --win nsis zip --x64
+            files: |
+              apps/desktop/release/*.exe
+              apps/desktop/release/*.zip
+          - name: Linux Desktop
+            os: ubuntu-latest
+            platform: linux
+            builder_args: --linux AppImage deb --x64
+            files: |
+              apps/desktop/release/*.AppImage
+              apps/desktop/release/*.deb
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: "false"
+    steps:
+      - name: Check out
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Resolve release version
+        id: release
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          if [[ ! "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Release tag must be semantic version vMAJOR.MINOR.PATCH: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test desktop contract
+        run: pnpm test:desktop
+
+      - name: Typecheck desktop
+        run: pnpm --filter @clickclack/desktop typecheck
+
+      - name: Build desktop app
+        run: pnpm --filter @clickclack/desktop build
+
+      - name: Package desktop installers
+        run: pnpm --filter @clickclack/desktop exec electron-builder ${{ matrix.builder_args }} --config.extraMetadata.version=${{ steps.release.outputs.version }} --publish never
+
+      - name: Write desktop checksums
+        run: node apps/desktop/scripts/release-artifacts.mjs ${{ matrix.platform }} ${{ steps.release.outputs.version }} apps/desktop/release
+
+      - name: Upload desktop release candidates
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ClickClack-desktop-${{ matrix.platform }}
+          path: |
+            ${{ matrix.files }}
+            apps/desktop/release/ClickClack-*-SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  publish-desktop:
+    name: Publish desktop apps
+    needs:
+      - release
+      - desktop
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Download desktop release candidates
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: ClickClack-desktop-*
+          path: desktop-release
+          merge-multiple: true
+
+      - name: Verify desktop checksums
+        working-directory: desktop-release
+        run: sha256sum --check ClickClack-*-SHA256SUMS.txt
+
+      - name: Attach desktop apps to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
+        run: gh release upload "$RELEASE_TAG" desktop-release/* --clobber --repo "$GITHUB_REPOSITORY"
+
+      - name: Publish verified GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag_name || github.ref_name }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --repo "$GITHUB_REPOSITORY"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -66,6 +66,12 @@ changelog:
       - "^Merge pull request"
       - "^Merge branch"
 
+release:
+  draft: true
+  use_existing_draft: true
+  replace_existing_artifacts: true
+  mode: replace
+
 nfpms:
   - id: linux-packages
     ids:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Published automated macOS, Windows, and Linux desktop installers with verified SHA-256 manifests alongside every tagged GitHub Release.
 - Integrated the desktop sidebar toggle and message search into native macOS, Windows, and Linux title bars while preserving the browser app header.
 - Added secure ClickClack desktop apps for macOS, Windows, and Linux with native notifications, unread badges, tray lifecycle, quick compose, deep links, downloads, spellcheck, and self-hosted server selection.
 - Opened desktop GitHub sign-in in the system browser, then returned securely through a short-lived, verifier-bound `clickclack://` callback so existing browser sessions, passkeys, and two-factor authentication work without exposing tokens in URLs.

--- a/apps/desktop/scripts/release-artifacts.mjs
+++ b/apps/desktop/scripts/release-artifacts.mjs
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const releaseTargets = Object.freeze({
+  linux: Object.freeze(["linux-amd64.deb", "linux-x86_64.AppImage"]),
+  mac: Object.freeze(["mac-arm64.dmg", "mac-arm64.zip", "mac-x64.dmg", "mac-x64.zip"]),
+  win: Object.freeze(["win-x64.exe", "win-x64.zip"]),
+});
+
+export function normalizeReleaseVersion(tag) {
+  const match =
+    /^v?((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$/.exec(
+      tag,
+    );
+  if (!match) {
+    throw new Error(`Release version must be semantic version vMAJOR.MINOR.PATCH: ${tag}`);
+  }
+  return match[1];
+}
+
+export function expectedDesktopArtifactNames(platform, tag) {
+  const target = releaseTargets[platform];
+  if (!target) {
+    throw new Error(`Unsupported desktop release platform: ${platform}`);
+  }
+  const version = normalizeReleaseVersion(tag);
+  return target.map((suffix) => `ClickClack-${version}-${suffix}`);
+}
+
+export function writeDesktopChecksums(directory, platform, tag) {
+  const version = normalizeReleaseVersion(tag);
+  const artifacts = expectedDesktopArtifactNames(platform, version).sort();
+  const lines = artifacts.map((name) => {
+    const file = path.join(directory, name);
+    if (!existsSync(file) || !statSync(file).isFile()) {
+      throw new Error(`Desktop release artifact is not a file: ${file}`);
+    }
+    return `${createHash("sha256").update(readFileSync(file)).digest("hex")}  ${name}`;
+  });
+  const output = path.join(directory, `ClickClack-${version}-${platform}-SHA256SUMS.txt`);
+  writeFileSync(output, `${lines.join("\n")}\n`);
+  return output;
+}
+
+const isMain =
+  process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (isMain) {
+  const [platform, tag, directory = path.resolve("apps/desktop/release")] = process.argv.slice(2);
+  if (!platform || !tag) {
+    throw new Error(
+      "Usage: node apps/desktop/scripts/release-artifacts.mjs <mac|win|linux> <version> [release-directory]",
+    );
+  }
+  console.log(writeDesktopChecksums(path.resolve(directory), platform, tag));
+}

--- a/apps/desktop/scripts/release-artifacts.test.mjs
+++ b/apps/desktop/scripts/release-artifacts.test.mjs
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  expectedDesktopArtifactNames,
+  normalizeReleaseVersion,
+  writeDesktopChecksums,
+} from "./release-artifacts.mjs";
+
+test("normalizes semantic release tags", () => {
+  assert.equal(normalizeReleaseVersion("v1.2.3"), "1.2.3");
+  assert.equal(normalizeReleaseVersion("1.2.3-beta.1"), "1.2.3-beta.1");
+  assert.throws(() => normalizeReleaseVersion("v1.2"), /semantic version/);
+  assert.throws(() => normalizeReleaseVersion("v01.2.3"), /semantic version/);
+});
+
+test("describes every expected native installer", () => {
+  assert.deepEqual(expectedDesktopArtifactNames("mac", "v1.2.3"), [
+    "ClickClack-1.2.3-mac-arm64.dmg",
+    "ClickClack-1.2.3-mac-arm64.zip",
+    "ClickClack-1.2.3-mac-x64.dmg",
+    "ClickClack-1.2.3-mac-x64.zip",
+  ]);
+  assert.deepEqual(expectedDesktopArtifactNames("win", "1.2.3"), [
+    "ClickClack-1.2.3-win-x64.exe",
+    "ClickClack-1.2.3-win-x64.zip",
+  ]);
+  assert.deepEqual(expectedDesktopArtifactNames("linux", "1.2.3"), [
+    "ClickClack-1.2.3-linux-amd64.deb",
+    "ClickClack-1.2.3-linux-x86_64.AppImage",
+  ]);
+});
+
+test("writes a sorted SHA-256 manifest and rejects missing installers", (context) => {
+  const directory = mkdtempSync(path.join(tmpdir(), "clickclack-desktop-release-"));
+  context.after(() => rmSync(directory, { force: true, recursive: true }));
+  const names = expectedDesktopArtifactNames("win", "1.2.3");
+  for (const name of names) writeFileSync(path.join(directory, name), name);
+
+  const output = writeDesktopChecksums(directory, "win", "1.2.3");
+  const expected = [...names]
+    .sort()
+    .map((name) => `${createHash("sha256").update(name).digest("hex")}  ${name}`)
+    .join("\n");
+  assert.equal(readFileSync(output, "utf8"), `${expected}\n`);
+
+  assert.throws(() => writeDesktopChecksums(directory, "mac", "1.2.3"), /Desktop release artifact/);
+});

--- a/apps/desktop/scripts/test.mjs
+++ b/apps/desktop/scripts/test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const outfile = path.join(root, ".test", "contract.test.cjs");
+const releaseArtifactsTest = path.join(root, "scripts", "release-artifacts.test.mjs");
 
 await build({
   absWorkingDir: root,
@@ -17,5 +18,7 @@ await build({
   target: "node22",
 });
 
-const result = spawnSync(process.execPath, ["--test", outfile], { stdio: "inherit" });
+const result = spawnSync(process.execPath, ["--test", outfile, releaseArtifactsTest], {
+  stdio: "inherit",
+});
 process.exit(result.status ?? 1);

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -104,9 +104,11 @@ pnpm --filter @clickclack/desktop run dist:linux
 ```
 
 Pull requests run a three-platform desktop workflow and attach unsigned preview
-installers for seven days. Production distribution still needs the normal
-platform signing/notarization credentials; preview artifacts are for review and
-testing only.
+installers for seven days. Version tags run the release workflow on native
+macOS, Windows, and Linux runners, verify per-platform SHA-256 manifests, and
+attach the installers before publishing the matching draft GitHub Release.
+These builds are currently unsigned, so operating-system trust prompts are
+expected until platform signing and notarization credentials are configured.
 
 ## Icon system
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -57,6 +57,12 @@ docker run --rm -v clickclack-data:/app/data clickclack \
 GitHub releases publish `clickclack` archives for Linux, macOS, Windows, and
 FreeBSD on `amd64` and `arm64`, plus Linux `.deb` and `.rpm` packages.
 
+The same release also includes ClickClack desktop apps: macOS `.dmg` and `.zip`
+files for Intel and Apple silicon, a Windows x64 installer and `.zip`, and Linux
+x64 `.AppImage` and `.deb` files. Match the installer name to your operating
+system and architecture. Platform-specific `ClickClack-*-SHA256SUMS.txt` files
+cover every desktop download.
+
 ```sh
 # macOS/Linux tarball shape
 tar -xzf clickclack_<version>_<os>_<arch>.tar.gz

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -31,6 +31,20 @@ The snapshot build runs `pnpm build`, then cross-compiles `clickclack` for:
 
 It also emits Linux `.deb` and `.rpm` packages and `sha256sums.txt`.
 
+The same workflow builds native desktop installers on their matching GitHub
+runner. The desktop app version comes from the release tag, and each runner
+emits a platform checksum manifest:
+
+- macOS: x64 and arm64 `.dmg` and `.zip`
+- Windows: x64 NSIS `.exe` and `.zip`
+- Linux: x64 `.AppImage` and `.deb`
+
+GoReleaser leaves the GitHub Release as a draft after uploading the server
+artifacts. The publish job downloads all three runner outputs, verifies every
+SHA-256 manifest, attaches the installers and manifests to that draft, and only
+then publishes it. A failed native build, upload, or checksum leaves a private
+draft instead of exposing an incomplete release.
+
 ## Publish
 
 Push a semver tag:
@@ -42,7 +56,12 @@ git push origin v0.1.0
 
 The release workflow checks out the tag, installs Go and pnpm, runs
 `pnpm check`, sets `CLICKCLACK_WEB_VERSION` to the checked-out commit, then
-runs `goreleaser release --clean` with `GITHUB_TOKEN`.
+runs `goreleaser release --clean` with `GITHUB_TOKEN`. In parallel, native
+runners build the desktop apps. Once GoReleaser and all native builds succeed,
+the verified desktop files are uploaded and the draft is published.
 
 Manual release dispatch is available for an existing tag through the
-`release` workflow's `tag_name` input.
+`release` workflow's `tag_name` input. GoReleaser reuses an existing draft and
+replaces matching server assets, while the desktop uploader replaces matching
+desktop assets. This makes a failed draft release safe to retry without making
+published releases mutable.


### PR DESCRIPTION
## Summary

- build ClickClack desktop apps natively for macOS, Windows, and Linux on every release
- derive application versions and artifact names from the release tag
- publish platform checksum manifests alongside DMG, ZIP, EXE, AppImage, and DEB downloads
- stage all artifacts in a draft release and publish only after every platform succeeds
- document release behavior, local validation, retries, and the current unsigned-app trust prompts

## Release assets

| Platform | Architectures | Formats |
| --- | --- | --- |
| macOS | Apple Silicon, Intel | DMG, ZIP |
| Windows | x64 | NSIS EXE, ZIP |
| Linux | x64 | AppImage, DEB |

## Safety and retry behavior

GoReleaser creates or reuses a draft release. Each native runner uploads its files only after its own build and checksum checks pass. A final job verifies all expected files and publishes the draft, keeping partially successful runs private and making reruns safe.

Desktop artifacts are currently unsigned. Installation docs explain the expected OS trust prompts until signing credentials are configured.

## Validation

- `pnpm check`
- `pnpm docs:site`
- desktop release helper tests: 13 passing
- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `goreleaser check`
- real Linux and Windows CI artifact names verified
- synthetic `9.8.7` macOS arm64/x64 builds verified, including bundle versions and SHA-256 checksums
- final autoreview: no actionable findings
