### PR TITLE
feat: preserve request correlation in durable events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserved validated request correlation IDs as optional metadata on durable message and thread-reply events across replay and realtime delivery, and added canary run/case evidence IDs without changing message storage or gateway traffic.
 - Added an isolated FakeCo small-VM deployment path with idempotent synthetic chat seed data, OpenClaw and ClawRouter SecretRef configuration, correlated health/readiness and metadata-only telemetry, a quoted-reply end-to-end canary, tests, and teardown guidance.
 
 ## 0.1.0 - 2026-07-06

--- a/apps/api/cmd/clickclack/fakeco_canary.go
+++ b/apps/api/cmd/clickclack/fakeco_canary.go
@@ -20,6 +20,7 @@ import (
 
 type canaryOptions struct {
 	CorrelationID    string
+	RunID            string
 	GatewayHealthURL string
 	Timeout          time.Duration
 	PollInterval     time.Duration
@@ -28,6 +29,8 @@ type canaryOptions struct {
 type canaryResult struct {
 	Status              string `json:"status"`
 	CorrelationID       string `json:"correlation_id"`
+	RunID               string `json:"run_id,omitempty"`
+	CaseID              string `json:"case_id"`
 	GatewayPreflight    bool   `json:"gateway_preflight"`
 	WorkspaceID         string `json:"workspace_id"`
 	ChannelID           string `json:"channel_id"`
@@ -41,6 +44,7 @@ func (c apiClient) canary(args []string) error {
 	flags := flag.NewFlagSet("canary", flag.ExitOnError)
 	addClientFlags(flags, &opts)
 	correlationID := flags.String("correlation-id", "", "optional safe correlation ID")
+	runID := flags.String("run-id", "", "optional safe external run ID for evidence")
 	gatewayHealthURL := flags.String("gateway-health-url", os.Getenv("OPENCLAW_GATEWAY_HEALTH_URL"), "optional OpenClaw health URL")
 	timeout := flags.Duration("timeout", 2*time.Minute, "overall canary timeout")
 	pollInterval := flags.Duration("poll-interval", time.Second, "reply polling interval")
@@ -50,6 +54,7 @@ func (c apiClient) canary(args []string) error {
 	c = c.withOptions(opts, true)
 	result, err := c.runCanary(context.Background(), canaryOptions{
 		CorrelationID:    *correlationID,
+		RunID:            *runID,
 		GatewayHealthURL: *gatewayHealthURL,
 		Timeout:          *timeout,
 		PollInterval:     *pollInterval,
@@ -73,6 +78,10 @@ func (c apiClient) runCanary(parent context.Context, options canaryOptions) (can
 	}
 	if !validCanaryCorrelationID(correlationID) {
 		return canaryResult{}, errors.New("correlation ID must be 1-80 letters, numbers, dots, underscores, colons, or hyphens")
+	}
+	runID := strings.TrimSpace(options.RunID)
+	if runID != "" && !validCanaryCorrelationID(runID) {
+		return canaryResult{}, errors.New("run ID must be at most 80 letters, numbers, dots, underscores, colons, or hyphens")
 	}
 	c.correlationID = correlationID
 	ctx, cancel := context.WithTimeout(parent, options.Timeout)
@@ -131,6 +140,8 @@ func (c apiClient) runCanary(parent context.Context, options canaryOptions) (can
 			return canaryResult{
 				Status:              "passed",
 				CorrelationID:       correlationID,
+				RunID:               runID,
+				CaseID:              created.Message.ID,
 				GatewayPreflight:    gatewayPreflight,
 				WorkspaceID:         channel.WorkspaceID,
 				ChannelID:           channel.ID,

--- a/apps/api/cmd/clickclack/fakeco_canary_test.go
+++ b/apps/api/cmd/clickclack/fakeco_canary_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 	const correlationID = "fakeco-test-001"
+	const runID = "fakeco-run-001"
 	quoted := "msg_request"
 	var mu sync.Mutex
 	var correlations []string
@@ -80,6 +81,7 @@ func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 	}
 	result, err := c.runCanary(context.Background(), canaryOptions{
 		CorrelationID:    correlationID,
+		RunID:            runID,
 		GatewayHealthURL: server.URL + "/gateway-healthz",
 		Timeout:          time.Second,
 		PollInterval:     time.Millisecond,
@@ -87,7 +89,7 @@ func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != "passed" || !result.GatewayPreflight || result.RequestMessageID != quoted || result.ResponseMessageID != "msg_reply" {
+	if result.Status != "passed" || !result.GatewayPreflight || result.RunID != runID || result.CaseID != quoted || result.RequestMessageID != quoted || result.ResponseMessageID != "msg_reply" {
 		t.Fatalf("unexpected canary result: %#v", result)
 	}
 	mu.Lock()
@@ -117,6 +119,10 @@ func TestRunCanaryRejectsBotSessionAndUnsafeInputs(t *testing.T) {
 	_, err := c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco bot", Timeout: time.Second, PollInterval: time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "correlation ID") {
 		t.Fatalf("expected invalid correlation error, got %v", err)
+	}
+	_, err = c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco-run", RunID: "unsafe run", Timeout: time.Second, PollInterval: time.Millisecond})
+	if err == nil || !strings.Contains(err.Error(), "run ID") {
+		t.Fatalf("expected invalid run ID error, got %v", err)
 	}
 	_, err = c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco-bot", Timeout: time.Second, PollInterval: time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "human session token") {

--- a/apps/api/internal/httpapi/correlation_events_test.go
+++ b/apps/api/internal/httpapi/correlation_events_test.go
@@ -1,0 +1,176 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestMessageEventCorrelationSurvivesResponseRealtimeAndRetrieval(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "correlation-api@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	channels, err := st.ListChannels(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	wsURL := strings.Replace(server.URL, "http://", "ws://", 1) + "/api/realtime/ws?workspace_id=" + url.QueryEscape(workspace.ID)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close(websocket.StatusNormalClosure, "done") })
+
+	messageResult, messageStatus, messageHeaders := postJSONWithCorrelation[struct {
+		Message store.Message `json:"message"`
+		Event   store.Event   `json:"event"`
+	}](t, server.URL+"/api/channels/"+channels[0].ID+"/messages", "corr-api-message", map[string]string{
+		"body": "message content stays out of event metadata",
+	})
+	if messageStatus != http.StatusCreated || messageHeaders.Get(correlationIDHeader) != "corr-api-message" {
+		t.Fatalf("unexpected message response: status=%d correlation=%q", messageStatus, messageHeaders.Get(correlationIDHeader))
+	}
+	assertAPIEventPayloadValue(t, messageResult.Event, "correlation_id", "corr-api-message")
+	assertAPIEventPayloadMissing(t, messageResult.Event, "body")
+	liveMessage := readEventType(t, conn, "message.created")
+	assertAPIEventPayloadValue(t, liveMessage, "correlation_id", "corr-api-message")
+
+	retrievedMessages := getJSON[struct {
+		Events []store.Event `json:"events"`
+	}](t, server.URL+"/api/realtime/events?workspace_id="+url.QueryEscape(workspace.ID))
+	assertAPIEventPayloadValue(t, eventByID(t, retrievedMessages.Events, messageResult.Event.ID), "correlation_id", "corr-api-message")
+
+	replyResult, replyStatus, replyHeaders := postJSONWithCorrelation[struct {
+		Message     store.Message     `json:"message"`
+		ThreadState store.ThreadState `json:"thread_state"`
+		Events      []store.Event     `json:"events"`
+	}](t, server.URL+"/api/messages/"+messageResult.Message.ID+"/thread/replies", "corr-api-reply", map[string]string{
+		"body": "reply content stays out of event metadata",
+	})
+	if replyStatus != http.StatusCreated || replyHeaders.Get(correlationIDHeader) != "corr-api-reply" {
+		t.Fatalf("unexpected reply response: status=%d correlation=%q", replyStatus, replyHeaders.Get(correlationIDHeader))
+	}
+	replyEvent := eventByType(t, replyResult.Events, "thread.reply_created")
+	stateEvent := eventByType(t, replyResult.Events, "thread.state_updated")
+	assertAPIEventPayloadValue(t, replyEvent, "correlation_id", "corr-api-reply")
+	assertAPIEventPayloadMissing(t, replyEvent, "body")
+	assertAPIEventPayloadMissing(t, stateEvent, "correlation_id")
+	liveReply := readEventType(t, conn, "thread.reply_created")
+	assertAPIEventPayloadValue(t, liveReply, "correlation_id", "corr-api-reply")
+
+	retrievedReplies := getJSON[struct {
+		Events []store.Event `json:"events"`
+	}](t, server.URL+"/api/realtime/events?workspace_id="+url.QueryEscape(workspace.ID)+"&after_cursor="+url.QueryEscape(messageResult.Event.Cursor))
+	assertAPIEventPayloadValue(t, eventByID(t, retrievedReplies.Events, replyEvent.ID), "correlation_id", "corr-api-reply")
+
+	invalidResult, invalidStatus, invalidHeaders := postJSONWithCorrelation[struct {
+		Event store.Event `json:"event"`
+	}](t, server.URL+"/api/channels/"+channels[0].ID+"/messages", "unsafe correlation", map[string]string{
+		"body": "invalid caller correlation gets replaced",
+	})
+	generated := invalidHeaders.Get(correlationIDHeader)
+	if invalidStatus != http.StatusCreated || generated == "unsafe correlation" || !validCorrelationID(generated) {
+		t.Fatalf("invalid correlation was not safely replaced: status=%d correlation=%q", invalidStatus, generated)
+	}
+	assertAPIEventPayloadValue(t, invalidResult.Event, "correlation_id", generated)
+}
+
+func postJSONWithCorrelation[T any](t *testing.T, endpoint, correlationID string, body any) (T, int, http.Header) {
+	t.Helper()
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(correlationIDHeader, correlationID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST %s: %s %s", endpoint, resp.Status, body)
+	}
+	var out T
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out, resp.StatusCode, resp.Header.Clone()
+}
+
+func assertAPIEventPayloadValue(t *testing.T, event store.Event, key, want string) {
+	t.Helper()
+	payload, ok := event.Payload.(map[string]any)
+	if !ok || payload[key] != want {
+		t.Fatalf("event %s payload[%q] = %#v; want %q", event.ID, key, payload[key], want)
+	}
+}
+
+func assertAPIEventPayloadMissing(t *testing.T, event store.Event, key string) {
+	t.Helper()
+	payload, ok := event.Payload.(map[string]any)
+	if !ok {
+		t.Fatalf("event %s payload type = %T", event.ID, event.Payload)
+	}
+	if value, exists := payload[key]; exists {
+		t.Fatalf("event %s unexpectedly has payload[%q] = %#v", event.ID, key, value)
+	}
+}
+
+func eventByID(t *testing.T, events []store.Event, id string) store.Event {
+	t.Helper()
+	for _, event := range events {
+		if event.ID == id {
+			return event
+		}
+	}
+	t.Fatalf("event %s not found in %#v", id, events)
+	return store.Event{}
+}
+
+func eventByType(t *testing.T, events []store.Event, eventType string) store.Event {
+	t.Helper()
+	for _, event := range events {
+		if event.Type == eventType {
+			return event
+		}
+	}
+	t.Fatalf("event type %s not found in %#v", eventType, events)
+	return store.Event{}
+}

--- a/apps/api/internal/httpapi/observability.go
+++ b/apps/api/internal/httpapi/observability.go
@@ -14,11 +14,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
 )
 
 const correlationIDHeader = "X-Correlation-ID"
-
-type correlationIDContextKey struct{}
 
 func correlationIDMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -27,22 +26,13 @@ func correlationIDMiddleware(next http.Handler) http.Handler {
 			correlationID = newCorrelationID()
 		}
 		w.Header().Set(correlationIDHeader, correlationID)
-		ctx := context.WithValue(r.Context(), correlationIDContextKey{}, correlationID)
+		ctx := requestmeta.WithCorrelationID(r.Context(), correlationID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
 func validCorrelationID(value string) bool {
-	if value == "" || len(value) > 128 {
-		return false
-	}
-	for _, r := range value {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("._:-", r) {
-			continue
-		}
-		return false
-	}
-	return true
+	return requestmeta.ValidCorrelationID(value)
 }
 
 func newCorrelationID() string {
@@ -54,8 +44,7 @@ func newCorrelationID() string {
 }
 
 func correlationIDFromContext(ctx context.Context) string {
-	value, _ := ctx.Value(correlationIDContextKey{}).(string)
-	return value
+	return requestmeta.CorrelationID(ctx)
 }
 
 type buildMetadata struct {

--- a/apps/api/internal/requestmeta/correlation.go
+++ b/apps/api/internal/requestmeta/correlation.go
@@ -1,0 +1,36 @@
+package requestmeta
+
+import (
+	"context"
+	"strings"
+)
+
+type correlationIDContextKey struct{}
+
+func ValidCorrelationID(value string) bool {
+	if value == "" || len(value) > 128 {
+		return false
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || strings.ContainsRune("._:-", r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func WithCorrelationID(ctx context.Context, value string) context.Context {
+	if !ValidCorrelationID(value) {
+		return ctx
+	}
+	return context.WithValue(ctx, correlationIDContextKey{}, value)
+}
+
+func CorrelationID(ctx context.Context) string {
+	value, _ := ctx.Value(correlationIDContextKey{}).(string)
+	if !ValidCorrelationID(value) {
+		return ""
+	}
+	return value
+}

--- a/apps/api/internal/requestmeta/correlation_test.go
+++ b/apps/api/internal/requestmeta/correlation_test.go
@@ -1,0 +1,23 @@
+package requestmeta
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCorrelationIDContextAcceptsOnlyBoundedSafeValues(t *testing.T) {
+	t.Parallel()
+	valid := strings.Repeat("a", 128)
+	if got := CorrelationID(WithCorrelationID(context.Background(), valid)); got != valid {
+		t.Fatalf("correlation ID = %q, want %q", got, valid)
+	}
+	for _, invalid := range []string{"", "unsafe correlation", strings.Repeat("a", 129)} {
+		if ValidCorrelationID(invalid) {
+			t.Fatalf("expected invalid correlation ID %q", invalid)
+		}
+		if got := CorrelationID(WithCorrelationID(context.Background(), invalid)); got != "" {
+			t.Fatalf("invalid correlation ID persisted as %q", got)
+		}
+	}
+}

--- a/apps/api/internal/store/postgres/dms.go
+++ b/apps/api/internal/store/postgres/dms.go
@@ -335,7 +335,7 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	if input.TurnID != "" {
 		dmEventFields["turn_id"] = input.TurnID
 	}
-	event, err := insertEventWithRecipients(ctx, tx, workspaceID, "", "message.created", &seq, eventPayload(dmEventFields, nonce), recipients)
+	event, err := insertEventWithRecipients(ctx, tx, workspaceID, "", "message.created", &seq, eventPayload(ctx, dmEventFields, nonce), recipients)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/postgres/storedb"
 )
@@ -276,18 +277,23 @@ func insertEventWithRecipients(ctx context.Context, tx *sql.Tx, workspaceID, cha
 	return event, nil
 }
 
-// eventPayload returns the base payload with a "nonce" key only if non-empty.
-// Used so optimistic clients can correlate WS message.created with their pending
-// placeholder.
-func eventPayload(base map[string]string, nonce string) map[string]string {
-	if nonce == "" {
+// eventPayload adds optional client and request correlation metadata to durable
+// message creation events without copying message content.
+func eventPayload(ctx context.Context, base map[string]string, nonce string) map[string]string {
+	correlationID := requestmeta.CorrelationID(ctx)
+	if nonce == "" && correlationID == "" {
 		return base
 	}
-	out := make(map[string]string, len(base)+1)
+	out := make(map[string]string, len(base)+2)
 	for k, v := range base {
 		out[k] = v
 	}
-	out["nonce"] = nonce
+	if nonce != "" {
+		out["nonce"] = nonce
+	}
+	if correlationID != "" {
+		out["correlation_id"] = correlationID
+	}
 	return out
 }
 

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -582,7 +582,7 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 	if input.TurnID != "" {
 		eventFields["turn_id"] = input.TurnID
 	}
-	event, err := insertEvent(ctx, tx, workspaceID, input.ChannelID, "message.created", &seq, eventPayload(eventFields, nonce))
+	event, err := insertEvent(ctx, tx, workspaceID, input.ChannelID, "message.created", &seq, eventPayload(ctx, eventFields, nonce))
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}
@@ -744,7 +744,7 @@ func (s *Store) CreateThreadReply(ctx context.Context, input store.CreateThreadR
 	if err != nil {
 		return store.Message{}, store.ThreadState{}, nil, err
 	}
-	replyPayload := eventPayload(map[string]string{"message_id": id, "root_message_id": root.ID}, nonce)
+	replyPayload := eventPayload(ctx, map[string]string{"message_id": id, "root_message_id": root.ID}, nonce)
 	statePayload := map[string]string{"root_message_id": root.ID}
 	var recipients []string
 	if root.DirectConversationID != "" {

--- a/apps/api/internal/store/postgres/postgres_test.go
+++ b/apps/api/internal/store/postgres/postgres_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 )
 
@@ -38,13 +39,16 @@ func TestPostgresStoreSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	created, event, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channel.ID, AuthorID: owner.ID, Body: "hello postgres"})
+	messageCtx := requestmeta.WithCorrelationID(ctx, "corr-postgres-message")
+	created, event, err := st.CreateMessage(messageCtx, store.CreateMessageInput{ChannelID: channel.ID, AuthorID: owner.ID, Body: "hello postgres"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if event.ID == "" || event.Seq == nil || *event.Seq != 1 {
 		t.Fatalf("unexpected event: %#v", event)
 	}
+	assertPostgresEventPayloadValue(t, event, "correlation_id", "corr-postgres-message")
+	assertPostgresEventPayloadMissing(t, event, "body")
 	page, err := st.ListMessages(ctx, channel.ID, owner.ID, store.MessagePageRequest{Limit: 10})
 	if err != nil {
 		t.Fatal(err)
@@ -52,9 +56,26 @@ func TestPostgresStoreSmoke(t *testing.T) {
 	if len(page.Messages) != 1 || page.Messages[0].ID != created.ID {
 		t.Fatalf("unexpected messages: %#v", page.Messages)
 	}
-	if _, state, _, err := st.CreateThreadReply(ctx, store.CreateThreadReplyInput{RootMessageID: created.ID, AuthorID: owner.ID, Body: "postgres thread reply"}); err != nil || state.ReplyCount != 1 {
+	replyCtx := requestmeta.WithCorrelationID(ctx, "corr-postgres-reply")
+	_, state, replyEvents, err := st.CreateThreadReply(replyCtx, store.CreateThreadReplyInput{RootMessageID: created.ID, AuthorID: owner.ID, Body: "postgres thread reply"})
+	if err != nil || state.ReplyCount != 1 {
 		t.Fatalf("unexpected thread reply result: %#v err=%v", state, err)
 	}
+	if len(replyEvents) != 2 || replyEvents[0].Type != "thread.reply_created" {
+		t.Fatalf("unexpected thread reply events: %#v", replyEvents)
+	}
+	assertPostgresEventPayloadValue(t, replyEvents[0], "correlation_id", "corr-postgres-reply")
+	assertPostgresEventPayloadMissing(t, replyEvents[1], "correlation_id")
+	persisted, err := st.ListEventsAfter(ctx, workspace.ID, owner.ID, "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	persistedByID := make(map[string]store.Event, len(persisted))
+	for _, persistedEvent := range persisted {
+		persistedByID[persistedEvent.ID] = persistedEvent
+	}
+	assertPostgresEventPayloadValue(t, persistedByID[event.ID], "correlation_id", "corr-postgres-message")
+	assertPostgresEventPayloadValue(t, persistedByID[replyEvents[0].ID], "correlation_id", "corr-postgres-reply")
 	threadPage, err := st.ListMessages(ctx, channel.ID, owner.ID, store.MessagePageRequest{Limit: 10})
 	if err != nil {
 		t.Fatal(err)
@@ -66,8 +87,43 @@ func TestPostgresStoreSmoke(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].Message.ID != created.ID {
+	foundCreated := false
+	for _, result := range results {
+		if result.Message.ID == created.ID {
+			foundCreated = true
+			break
+		}
+	}
+	if !foundCreated {
 		t.Fatalf("unexpected search results: %#v", results)
+	}
+}
+
+func assertPostgresEventPayloadValue(t *testing.T, event store.Event, key, want string) {
+	t.Helper()
+	got, ok := postgresEventPayloadValue(event, key)
+	if !ok || got != want {
+		t.Fatalf("event %s payload[%q] = %q, %v; want %q", event.ID, key, got, ok, want)
+	}
+}
+
+func assertPostgresEventPayloadMissing(t *testing.T, event store.Event, key string) {
+	t.Helper()
+	if got, ok := postgresEventPayloadValue(event, key); ok {
+		t.Fatalf("event %s unexpectedly has payload[%q] = %q", event.ID, key, got)
+	}
+}
+
+func postgresEventPayloadValue(event store.Event, key string) (string, bool) {
+	switch payload := event.Payload.(type) {
+	case map[string]string:
+		value, ok := payload[key]
+		return value, ok
+	case map[string]any:
+		value, ok := payload[key].(string)
+		return value, ok
+	default:
+		return "", false
 	}
 }
 

--- a/apps/api/internal/store/sqlite/correlation_events_test.go
+++ b/apps/api/internal/store/sqlite/correlation_events_test.go
@@ -1,0 +1,134 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestDurableMessageEventsPreserveOptionalCorrelationMetadata(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "correlation-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	channels, err := st.ListChannels(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	messageCtx := requestmeta.WithCorrelationID(ctx, "corr-sqlite-message")
+	root, messageEvent, err := st.CreateMessage(messageCtx, store.CreateMessageInput{
+		ChannelID: channels[0].ID,
+		AuthorID:  owner.ID,
+		Body:      "message content stays in the message row",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEventPayloadValue(t, messageEvent, "correlation_id", "corr-sqlite-message")
+	assertEventPayloadMissing(t, messageEvent, "body")
+
+	replyCtx := requestmeta.WithCorrelationID(ctx, "corr-sqlite-reply")
+	_, _, replyEvents, err := st.CreateThreadReply(replyCtx, store.CreateThreadReplyInput{
+		RootMessageID: root.ID,
+		AuthorID:      owner.ID,
+		Body:          "reply content stays in the message row",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(replyEvents) != 2 || replyEvents[0].Type != "thread.reply_created" || replyEvents[1].Type != "thread.state_updated" {
+		t.Fatalf("unexpected reply events: %#v", replyEvents)
+	}
+	assertEventPayloadValue(t, replyEvents[0], "correlation_id", "corr-sqlite-reply")
+	assertEventPayloadMissing(t, replyEvents[0], "body")
+	assertEventPayloadMissing(t, replyEvents[1], "correlation_id")
+
+	second, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Second", Email: "correlation-second@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, second.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	dm, err := st.CreateDirectConversation(ctx, store.CreateDirectConversationInput{
+		WorkspaceID: workspace.ID,
+		UserID:      owner.ID,
+		MemberIDs:   []string{second.ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dmCtx := requestmeta.WithCorrelationID(ctx, "corr-sqlite-dm")
+	_, dmEvent, err := st.CreateDirectMessage(dmCtx, store.CreateDirectMessageInput{
+		ConversationID: dm.ID,
+		AuthorID:       owner.ID,
+		Body:           "private content stays in the message row",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEventPayloadValue(t, dmEvent, "correlation_id", "corr-sqlite-dm")
+	assertEventPayloadMissing(t, dmEvent, "body")
+
+	_, uncorrelatedEvent, err := st.CreateMessage(ctx, store.CreateMessageInput{
+		ChannelID: channels[0].ID,
+		AuthorID:  owner.ID,
+		Body:      "backward-compatible event",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEventPayloadMissing(t, uncorrelatedEvent, "correlation_id")
+
+	persisted, err := st.ListEventsAfter(ctx, workspace.ID, owner.ID, "", 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := make(map[string]store.Event, len(persisted))
+	for _, event := range persisted {
+		byID[event.ID] = event
+	}
+	assertEventPayloadValue(t, byID[messageEvent.ID], "correlation_id", "corr-sqlite-message")
+	assertEventPayloadValue(t, byID[replyEvents[0].ID], "correlation_id", "corr-sqlite-reply")
+	assertEventPayloadValue(t, byID[dmEvent.ID], "correlation_id", "corr-sqlite-dm")
+	assertEventPayloadMissing(t, byID[uncorrelatedEvent.ID], "correlation_id")
+}
+
+func assertEventPayloadValue(t *testing.T, event store.Event, key, want string) {
+	t.Helper()
+	got, ok := eventPayloadValue(event, key)
+	if !ok || got != want {
+		t.Fatalf("event %s payload[%q] = %q, %v; want %q", event.ID, key, got, ok, want)
+	}
+}
+
+func assertEventPayloadMissing(t *testing.T, event store.Event, key string) {
+	t.Helper()
+	if got, ok := eventPayloadValue(event, key); ok {
+		t.Fatalf("event %s unexpectedly has payload[%q] = %q", event.ID, key, got)
+	}
+}
+
+func eventPayloadValue(event store.Event, key string) (string, bool) {
+	switch payload := event.Payload.(type) {
+	case map[string]string:
+		value, ok := payload[key]
+		return value, ok
+	case map[string]any:
+		value, ok := payload[key].(string)
+		return value, ok
+	default:
+		return "", false
+	}
+}

--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -335,7 +335,7 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	if input.TurnID != "" {
 		dmEventFields["turn_id"] = input.TurnID
 	}
-	event, err := insertEventWithRecipients(ctx, tx, workspaceID, "", "message.created", &seq, eventPayload(dmEventFields, nonce), recipients)
+	event, err := insertEventWithRecipients(ctx, tx, workspaceID, "", "message.created", &seq, eventPayload(ctx, dmEventFields, nonce), recipients)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
+	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
 )
@@ -271,18 +272,23 @@ func insertEventWithRecipients(ctx context.Context, tx *sql.Tx, workspaceID, cha
 	return event, nil
 }
 
-// eventPayload returns the base payload with a "nonce" key only if non-empty.
-// Used so optimistic clients can correlate WS message.created with their pending
-// placeholder.
-func eventPayload(base map[string]string, nonce string) map[string]string {
-	if nonce == "" {
+// eventPayload adds optional client and request correlation metadata to durable
+// message creation events without copying message content.
+func eventPayload(ctx context.Context, base map[string]string, nonce string) map[string]string {
+	correlationID := requestmeta.CorrelationID(ctx)
+	if nonce == "" && correlationID == "" {
 		return base
 	}
-	out := make(map[string]string, len(base)+1)
+	out := make(map[string]string, len(base)+2)
 	for k, v := range base {
 		out[k] = v
 	}
-	out["nonce"] = nonce
+	if nonce != "" {
+		out["nonce"] = nonce
+	}
+	if correlationID != "" {
+		out["correlation_id"] = correlationID
+	}
 	return out
 }
 

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -581,7 +581,7 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 	if input.TurnID != "" {
 		eventFields["turn_id"] = input.TurnID
 	}
-	event, err := insertEvent(ctx, tx, workspaceID, input.ChannelID, "message.created", &seq, eventPayload(eventFields, nonce))
+	event, err := insertEvent(ctx, tx, workspaceID, input.ChannelID, "message.created", &seq, eventPayload(ctx, eventFields, nonce))
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}
@@ -743,7 +743,7 @@ func (s *Store) CreateThreadReply(ctx context.Context, input store.CreateThreadR
 	if err != nil {
 		return store.Message{}, store.ThreadState{}, nil, err
 	}
-	replyPayload := eventPayload(map[string]string{"message_id": id, "root_message_id": root.ID}, nonce)
+	replyPayload := eventPayload(ctx, map[string]string{"message_id": id, "root_message_id": root.ID}, nonce)
 	statePayload := map[string]string{"root_message_id": root.ID}
 	var recipients []string
 	if root.DirectConversationID != "" {

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -19,12 +19,15 @@ The server resolves callers in this order (see
 2. `cc_session` cookie.
 3. `X-ClickClack-User: usr_...` header (local/dev impersonation for tests).
 4. Dev fallback to the first user in the DB (only with
-   `--dev-bootstrap=true`).
+`--dev-bootstrap=true`).
 
 `/healthz`, `/readyz`, and the opt-in `/metrics` operator endpoint do not use
 chat authentication. Keep metrics private. Every HTTP response carries
 `X-Correlation-ID`; a caller-supplied value is accepted only when it uses the
-safe bounded character set.
+safe bounded character set. Durable `message.created` and
+`thread.reply_created` events copy that validated value to optional
+`payload.correlation_id` metadata for HTTP recovery and WebSocket consumers.
+The value is not stored on message rows or exported as a metrics label.
 
 ## Endpoint groups
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -262,8 +262,9 @@ clickclack canary --workspace fakeco --channel e2e-canary --json
 Requires a human session token. It optionally preflights the OpenClaw health
 URL, posts a unique correlated prompt, and waits for a bot reply quoting the
 request and carrying the same marker. `--timeout`, `--poll-interval`, and
-`--correlation-id` are available for controlled tests. Never pass credentials
-inside the health URL.
+`--correlation-id` are available for controlled tests. Optional `--run-id`
+appears in JSON evidence without changing the request; `case_id` is the request
+message ID. Never pass credentials inside the health URL.
 
 ## Exit codes
 

--- a/docs/fakeco.md
+++ b/docs/fakeco.md
@@ -147,7 +147,7 @@ CLICKCLACK_SERVER=https://chat.fakeco.example \
 CLICKCLACK_WORKSPACE=fakeco \
 CLICKCLACK_CHANNEL=e2e-canary \
 OPENCLAW_GATEWAY_HEALTH_URL=http://openclaw.fakeco.internal:18789/healthz \
-clickclack canary --json
+clickclack canary --run-id fakeco-smoke-20260709 --json
 ```
 
 The command first checks the configured Gateway health URL, then posts a unique
@@ -155,7 +155,10 @@ human message and polls for an ordinary bot reply that quotes that exact
 message and equals `fakeco-canary-ok <correlation-id>`. It exits non-zero on
 gateway failure, wrong credentials, a missing workspace/channel, a bot caller,
 or timeout. The correlation ID is also sent on every HTTP request as
-`X-Correlation-ID` and returned by ClickClack in the response header.
+`X-Correlation-ID`, returned by ClickClack in the response header, and retained
+as optional metadata on the durable creation event. `--run-id` adds an external
+run identifier to JSON evidence only; `case_id` always equals the canary request
+message ID. Neither value adds a new outbound gateway call.
 
 ## Health, logs, and telemetry
 

--- a/docs/features/realtime.md
+++ b/docs/features/realtime.md
@@ -75,7 +75,11 @@ conversation members.
 
 `message.created` carries the message sequence in top-level `seq` and includes
 `message_id`, `author_id`, optional `direct_conversation_id`, and optional
-`nonce` in `payload`. Read receipt events carry the updated read pointer in
+`nonce` in `payload`. `message.created` and `thread.reply_created` also include
+the request's validated `correlation_id` when one is available. This metadata
+survives both cursor replay and live WebSocket delivery; it is omitted for
+events created outside a correlated request and never contains message bodies.
+Read receipt events carry the updated read pointer in
 top-level `seq` and include `user_id` plus the channel or DM conversation ID in
 `payload`; they are delivered only to that user.
 Moderation events carry the target `user_id` and current `role`; they are

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -234,6 +234,11 @@ export type RouteTarget = {
   canonical_path: string;
 };
 
+export type RealtimeEventPayload = {
+  correlation_id?: string;
+  [key: string]: unknown;
+};
+
 export type RealtimeEvent = {
   id: string;
   cursor: string;
@@ -242,7 +247,7 @@ export type RealtimeEvent = {
   channel_id?: string;
   seq?: number;
   created_at: string;
-  payload: unknown;
+  payload: RealtimeEventPayload;
 };
 
 export type ClickClackClientOptions = {


### PR DESCRIPTION
## Summary

- preserve the validated request ID as optional `event.payload.correlation_id` on durable `message.created` and `thread.reply_created` events, including channel and direct-message flows
- retain that payload field through SQLite/Postgres persistence, mutation responses, HTTP cursor replay, WebSocket delivery, and event-subscription serialization
- expose the optional field in the TypeScript SDK and document the canonical payload location
- add optional canary `run_id` evidence plus `case_id` equal to the request message ID, without changing gateway traffic

## Why

FakeCo and other operators need one bounded identifier that connects safe request logs to durable chat events and end-to-end canary evidence. Keeping it in the existing type-specific event payload avoids a new envelope and remains compatible with historical events.

## Safety contract

- no top-level `event.metadata` or `event.correlation_id`
- no message-table migration, body duplication, generated sqlc change, or Prometheus label
- invalid caller IDs are replaced through the existing 128-character safe correlation validator before persistence
- events created outside a correlated request continue to omit the optional field
- canary run/case fields are evidence formatting only; no outbound gateway behavior was added

## Validation

- `pnpm check`
- exact CI dead-code command
- `pnpm coverage` — 86.7% total
- `pnpm docs:site`
- focused request-metadata, SQLite durability, API response/replay/WebSocket, and canary tests
- Postgres integration smoke against a disposable local Postgres 17 instance
- source-blind behavior validation: all response, live delivery, replay, invalid-input, and canary evidence clauses passed
- structured autoreview: clean, no actionable findings