### PR TITLE
feat: expose realtime event tail cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added an opt-in realtime tail cursor so fresh clients can skip retained history without racing new events, and applied read-receipt visibility before event pagination. Thanks @shakkernerd.
 - Preserved validated request correlation IDs as optional metadata on durable message and thread-reply events across replay and realtime delivery, and added canary run/case evidence IDs without changing message storage or gateway traffic.
 - Added an isolated FakeCo small-VM deployment path with idempotent synthetic chat seed data, OpenClaw and ClawRouter SecretRef configuration, correlated health/readiness and metadata-only telemetry, a quoted-reply end-to-end canary, tests, and teardown guidance.
 

--- a/apps/api/internal/httpapi/realtime_tail_test.go
+++ b/apps/api/internal/httpapi/realtime_tail_test.go
@@ -1,0 +1,83 @@
+package httpapi
+
+import (
+	"context"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestEventTailCursorUsesVisibleEventWindow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "realtime-tail-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{
+		DisplayName: "Member",
+		Email:       "realtime-tail-member@example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	first := postJSONAsUser[struct {
+		Message store.Message `json:"message"`
+		Event   store.Event   `json:"event"`
+	}](t, owner.ID, server.URL+"/api/channels/"+channels[0].ID+"/messages", map[string]string{
+		"body": "first",
+	})
+	postJSONAsUser[struct {
+		Receipt store.ReadReceipt `json:"receipt"`
+	}](t, owner.ID, server.URL+"/api/channels/"+channels[0].ID+"/read", map[string]int64{
+		"seq": *first.Message.ChannelSeq,
+	})
+	second := postJSONAsUser[struct {
+		Message store.Message `json:"message"`
+		Event   store.Event   `json:"event"`
+	}](t, owner.ID, server.URL+"/api/channels/"+channels[0].ID+"/messages", map[string]string{
+		"body": "second",
+	})
+
+	result := getJSONAsUser[struct {
+		Events     []store.Event `json:"events"`
+		TailCursor string        `json:"tail_cursor"`
+	}](t, member.ID, server.URL+"/api/realtime/events?workspace_id="+
+		url.QueryEscape(workspace.ID)+"&after_cursor="+url.QueryEscape(first.Event.Cursor)+
+		"&limit=1&include_tail=true")
+
+	if len(result.Events) != 1 || result.Events[0].ID != second.Event.ID {
+		t.Fatalf("hidden read receipt consumed the visible page: %#v", result.Events)
+	}
+	if result.TailCursor != second.Event.Cursor {
+		t.Fatalf("tail cursor = %q, want %q", result.TailCursor, second.Event.Cursor)
+	}
+}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -829,11 +829,21 @@ func (s *Server) listEvents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
+	result := map[string]any{}
+	if r.URL.Query().Get("include_tail") == "true" {
+		tailCursor, err := s.store.LatestEventCursor(r.Context(), workspaceID, act.user.ID)
+		if err != nil {
+			writeResult(w, nil, err)
+			return
+		}
+		result["tail_cursor"] = tailCursor
+	}
 	events, err := s.store.ListEventsAfter(r.Context(), workspaceID, act.user.ID, r.URL.Query().Get("after_cursor"), queryInt(r, "limit", 200))
 	if err == nil {
 		events = filterEventsForUser(events, act.user.ID)
+		result["events"] = events
 	}
-	writeResult(w, map[string]any{"events": events}, err)
+	writeResult(w, result, err)
 }
 
 func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -812,6 +812,20 @@ func (s *Store) ListEventsAfter(ctx context.Context, workspaceID, userID, cursor
 	return out, nil
 }
 
+func (s *Store) LatestEventCursor(ctx context.Context, workspaceID, userID string) (string, error) {
+	if err := s.requireMembership(ctx, workspaceID, userID); err != nil {
+		return "", err
+	}
+	cursor, err := s.q.LatestEventCursor(ctx, storedb.LatestEventCursorParams{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return cursor, err
+}
+
 func directConversationIDFromEvent(event store.Event) string {
 	payload, ok := event.Payload.(map[string]any)
 	if !ok {

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -700,6 +700,10 @@ WHERE e.workspace_id = sqlc.arg(workspace_id)
     OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = sqlc.arg(user_id))
   )
   AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(e.payload_json::jsonb ->> 'user_id', '') = sqlc.arg(user_id)
+  )
+  AND (
     e.channel_id IS NULL
     OR viewer.role <> 'guest'
     OR event_channel.name = 'guest'
@@ -749,6 +753,71 @@ WHERE e.workspace_id = sqlc.arg(workspace_id)
   )
 ORDER BY e.cursor
 LIMIT sqlc.arg(limit_count);
+
+-- name: LatestEventCursor :one
+SELECT e.cursor
+FROM events e
+JOIN workspace_members viewer ON viewer.workspace_id = e.workspace_id AND viewer.user_id = sqlc.arg(user_id)
+LEFT JOIN channels event_channel ON event_channel.id = e.channel_id AND event_channel.workspace_id = e.workspace_id
+WHERE e.workspace_id = sqlc.arg(workspace_id)
+  AND (
+    e.is_private = 0
+    OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = sqlc.arg(user_id))
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(e.payload_json::jsonb ->> 'user_id', '') = sqlc.arg(user_id)
+  )
+  AND (
+    e.channel_id IS NULL
+    OR viewer.role <> 'guest'
+    OR event_channel.name = 'guest'
+  )
+  AND (
+    COALESCE(
+      e.payload_json::jsonb ->> 'direct_conversation_id',
+      (
+        SELECT m.direct_conversation_id
+        FROM messages m
+        WHERE m.workspace_id = e.workspace_id
+          AND m.id IN (
+            COALESCE(e.payload_json::jsonb ->> 'message_id', ''),
+            COALESCE(e.payload_json::jsonb ->> 'root_message_id', '')
+          )
+          AND m.direct_conversation_id IS NOT NULL
+          AND m.direct_conversation_id <> ''
+        LIMIT 1
+      ),
+      ''
+    ) = ''
+    OR (
+      viewer.role <> 'guest'
+      AND EXISTS (
+        SELECT 1
+        FROM direct_conversation_members dcm
+        JOIN direct_conversations dc ON dc.id = dcm.conversation_id
+        WHERE dc.workspace_id = e.workspace_id
+          AND dcm.conversation_id = COALESCE(
+            e.payload_json::jsonb ->> 'direct_conversation_id',
+            (
+              SELECT m.direct_conversation_id
+              FROM messages m
+              WHERE m.workspace_id = e.workspace_id
+                AND m.id IN (
+                  COALESCE(e.payload_json::jsonb ->> 'message_id', ''),
+                  COALESCE(e.payload_json::jsonb ->> 'root_message_id', '')
+                )
+                AND m.direct_conversation_id IS NOT NULL
+                AND m.direct_conversation_id <> ''
+              LIMIT 1
+            )
+          )
+          AND dcm.user_id = sqlc.arg(user_id)
+      )
+    )
+  )
+ORDER BY e.cursor DESC
+LIMIT 1;
 
 -- name: InsertEvent :exec
 INSERT INTO events (id, cursor, workspace_id, channel_id, type, seq, payload_json, created_at, is_private)

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1781,6 +1781,84 @@ func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspace
 	return err
 }
 
+const latestEventCursor = `-- name: LatestEventCursor :one
+SELECT e.cursor
+FROM events e
+JOIN workspace_members viewer ON viewer.workspace_id = e.workspace_id AND viewer.user_id = $1
+LEFT JOIN channels event_channel ON event_channel.id = e.channel_id AND event_channel.workspace_id = e.workspace_id
+WHERE e.workspace_id = $2
+  AND (
+    e.is_private = 0
+    OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = $1)
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(e.payload_json::jsonb ->> 'user_id', '') = $1
+  )
+  AND (
+    e.channel_id IS NULL
+    OR viewer.role <> 'guest'
+    OR event_channel.name = 'guest'
+  )
+  AND (
+    COALESCE(
+      e.payload_json::jsonb ->> 'direct_conversation_id',
+      (
+        SELECT m.direct_conversation_id
+        FROM messages m
+        WHERE m.workspace_id = e.workspace_id
+          AND m.id IN (
+            COALESCE(e.payload_json::jsonb ->> 'message_id', ''),
+            COALESCE(e.payload_json::jsonb ->> 'root_message_id', '')
+          )
+          AND m.direct_conversation_id IS NOT NULL
+          AND m.direct_conversation_id <> ''
+        LIMIT 1
+      ),
+      ''
+    ) = ''
+    OR (
+      viewer.role <> 'guest'
+      AND EXISTS (
+        SELECT 1
+        FROM direct_conversation_members dcm
+        JOIN direct_conversations dc ON dc.id = dcm.conversation_id
+        WHERE dc.workspace_id = e.workspace_id
+          AND dcm.conversation_id = COALESCE(
+            e.payload_json::jsonb ->> 'direct_conversation_id',
+            (
+              SELECT m.direct_conversation_id
+              FROM messages m
+              WHERE m.workspace_id = e.workspace_id
+                AND m.id IN (
+                  COALESCE(e.payload_json::jsonb ->> 'message_id', ''),
+                  COALESCE(e.payload_json::jsonb ->> 'root_message_id', '')
+                )
+                AND m.direct_conversation_id IS NOT NULL
+                AND m.direct_conversation_id <> ''
+              LIMIT 1
+            )
+          )
+          AND dcm.user_id = $1
+      )
+    )
+  )
+ORDER BY e.cursor DESC
+LIMIT 1
+`
+
+type LatestEventCursorParams struct {
+	UserID      string `json:"user_id"`
+	WorkspaceID string `json:"workspace_id"`
+}
+
+func (q *Queries) LatestEventCursor(ctx context.Context, arg LatestEventCursorParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, latestEventCursor, arg.UserID, arg.WorkspaceID)
+	var cursor string
+	err := row.Scan(&cursor)
+	return cursor, err
+}
+
 const listChannels = `-- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS BIGINT) AS last_seq,
@@ -1981,6 +2059,10 @@ WHERE e.workspace_id = $2
   AND (
     e.is_private = 0
     OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = $1)
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(e.payload_json::jsonb ->> 'user_id', '') = $1
   )
   AND (
     e.channel_id IS NULL

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -688,6 +688,10 @@ WHERE e.workspace_id = sqlc.arg(workspace_id)
     OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = sqlc.arg(user_id))
   )
   AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(json_extract(e.payload_json, '$.user_id'), '') = sqlc.arg(user_id)
+  )
+  AND (
     e.channel_id IS NULL
     OR viewer.role <> 'guest'
     OR event_channel.name = 'guest'
@@ -737,6 +741,71 @@ WHERE e.workspace_id = sqlc.arg(workspace_id)
   )
 ORDER BY e.cursor
 LIMIT sqlc.arg(limit_count);
+
+-- name: LatestEventCursor :one
+SELECT e.cursor
+FROM events e
+JOIN workspace_members viewer ON viewer.workspace_id = e.workspace_id AND viewer.user_id = sqlc.arg(user_id)
+LEFT JOIN channels event_channel ON event_channel.id = e.channel_id AND event_channel.workspace_id = e.workspace_id
+WHERE e.workspace_id = sqlc.arg(workspace_id)
+  AND (
+    e.is_private = 0
+    OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = sqlc.arg(user_id))
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(json_extract(e.payload_json, '$.user_id'), '') = sqlc.arg(user_id)
+  )
+  AND (
+    e.channel_id IS NULL
+    OR viewer.role <> 'guest'
+    OR event_channel.name = 'guest'
+  )
+  AND (
+    COALESCE(
+      json_extract(e.payload_json, '$.direct_conversation_id'),
+      (
+        SELECT m.direct_conversation_id
+        FROM messages m
+        WHERE m.workspace_id = e.workspace_id
+          AND m.id IN (
+            COALESCE(json_extract(e.payload_json, '$.message_id'), ''),
+            COALESCE(json_extract(e.payload_json, '$.root_message_id'), '')
+          )
+          AND m.direct_conversation_id IS NOT NULL
+          AND m.direct_conversation_id <> ''
+        LIMIT 1
+      ),
+      ''
+    ) = ''
+    OR (
+      viewer.role <> 'guest'
+      AND EXISTS (
+        SELECT 1
+        FROM direct_conversation_members dcm
+        JOIN direct_conversations dc ON dc.id = dcm.conversation_id
+        WHERE dc.workspace_id = e.workspace_id
+          AND dcm.conversation_id = COALESCE(
+            json_extract(e.payload_json, '$.direct_conversation_id'),
+            (
+              SELECT m.direct_conversation_id
+              FROM messages m
+              WHERE m.workspace_id = e.workspace_id
+                AND m.id IN (
+                  COALESCE(json_extract(e.payload_json, '$.message_id'), ''),
+                  COALESCE(json_extract(e.payload_json, '$.root_message_id'), '')
+                )
+                AND m.direct_conversation_id IS NOT NULL
+                AND m.direct_conversation_id <> ''
+              LIMIT 1
+            )
+          )
+          AND dcm.user_id = sqlc.arg(user_id)
+      )
+    )
+  )
+ORDER BY e.cursor DESC
+LIMIT 1;
 
 -- name: InsertEvent :exec
 INSERT INTO events (id, cursor, workspace_id, channel_id, type, seq, payload_json, created_at, is_private)

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -811,6 +811,20 @@ func (s *Store) ListEventsAfter(ctx context.Context, workspaceID, userID, cursor
 	return out, nil
 }
 
+func (s *Store) LatestEventCursor(ctx context.Context, workspaceID, userID string) (string, error) {
+	if err := s.requireMembership(ctx, workspaceID, userID); err != nil {
+		return "", err
+	}
+	cursor, err := s.q.LatestEventCursor(ctx, storedb.LatestEventCursorParams{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return cursor, err
+}
+
 func directConversationIDFromEvent(event store.Event) string {
 	payload, ok := event.Payload.(map[string]any)
 	if !ok {

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1776,6 +1776,84 @@ func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspace
 	return err
 }
 
+const latestEventCursor = `-- name: LatestEventCursor :one
+SELECT e.cursor
+FROM events e
+JOIN workspace_members viewer ON viewer.workspace_id = e.workspace_id AND viewer.user_id = ?1
+LEFT JOIN channels event_channel ON event_channel.id = e.channel_id AND event_channel.workspace_id = e.workspace_id
+WHERE e.workspace_id = ?2
+  AND (
+    e.is_private = 0
+    OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = ?1)
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(json_extract(e.payload_json, '$.user_id'), '') = ?1
+  )
+  AND (
+    e.channel_id IS NULL
+    OR viewer.role <> 'guest'
+    OR event_channel.name = 'guest'
+  )
+  AND (
+    COALESCE(
+      json_extract(e.payload_json, '$.direct_conversation_id'),
+      (
+        SELECT m.direct_conversation_id
+        FROM messages m
+        WHERE m.workspace_id = e.workspace_id
+          AND m.id IN (
+            COALESCE(json_extract(e.payload_json, '$.message_id'), ''),
+            COALESCE(json_extract(e.payload_json, '$.root_message_id'), '')
+          )
+          AND m.direct_conversation_id IS NOT NULL
+          AND m.direct_conversation_id <> ''
+        LIMIT 1
+      ),
+      ''
+    ) = ''
+    OR (
+      viewer.role <> 'guest'
+      AND EXISTS (
+        SELECT 1
+        FROM direct_conversation_members dcm
+        JOIN direct_conversations dc ON dc.id = dcm.conversation_id
+        WHERE dc.workspace_id = e.workspace_id
+          AND dcm.conversation_id = COALESCE(
+            json_extract(e.payload_json, '$.direct_conversation_id'),
+            (
+              SELECT m.direct_conversation_id
+              FROM messages m
+              WHERE m.workspace_id = e.workspace_id
+                AND m.id IN (
+                  COALESCE(json_extract(e.payload_json, '$.message_id'), ''),
+                  COALESCE(json_extract(e.payload_json, '$.root_message_id'), '')
+                )
+                AND m.direct_conversation_id IS NOT NULL
+                AND m.direct_conversation_id <> ''
+              LIMIT 1
+            )
+          )
+          AND dcm.user_id = ?1
+      )
+    )
+  )
+ORDER BY e.cursor DESC
+LIMIT 1
+`
+
+type LatestEventCursorParams struct {
+	UserID      string `json:"user_id"`
+	WorkspaceID string `json:"workspace_id"`
+}
+
+func (q *Queries) LatestEventCursor(ctx context.Context, arg LatestEventCursorParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, latestEventCursor, arg.UserID, arg.WorkspaceID)
+	var cursor string
+	err := row.Scan(&cursor)
+	return cursor, err
+}
+
 const listChannels = `-- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS INTEGER) AS last_seq,
@@ -1976,6 +2054,10 @@ WHERE e.workspace_id = ?2
   AND (
     e.is_private = 0
     OR EXISTS (SELECT 1 FROM event_recipients er WHERE er.event_id = e.id AND er.user_id = ?1)
+  )
+  AND (
+    e.type NOT IN ('channel.read', 'dm.read')
+    OR COALESCE(json_extract(e.payload_json, '$.user_id'), '') = ?1
   )
   AND (
     e.channel_id IS NULL

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -757,6 +757,7 @@ type Store interface {
 	CreateThreadReply(ctx context.Context, input CreateThreadReplyInput) (Message, ThreadState, []Event, error)
 	AddReaction(ctx context.Context, input CreateReactionInput) (Event, error)
 	RemoveReaction(ctx context.Context, input CreateReactionInput) (Event, error)
+	LatestEventCursor(ctx context.Context, workspaceID, userID string) (string, error)
 	ListEventsAfter(ctx context.Context, workspaceID, userID, cursor string, limit int) ([]Event, error)
 	CreateUpload(ctx context.Context, input CreateUploadInput) (Upload, error)
 	GetUpload(ctx context.Context, uploadID, userID string) (Upload, error)

--- a/docs/features/realtime.md
+++ b/docs/features/realtime.md
@@ -27,7 +27,7 @@ to drop events.
 
 ```http
 GET  /api/realtime/ws?workspace_id=&after_cursor=
-GET  /api/realtime/events?workspace_id=&after_cursor=&limit=
+GET  /api/realtime/events?workspace_id=&after_cursor=&limit=&include_tail=
 POST /api/realtime/ephemeral
 ```
 
@@ -37,7 +37,10 @@ POST /api/realtime/ephemeral
 - `GET /events` is the same backfill in pull form. Use it after a long offline
   period instead of relying on the connect-time backfill. User-private durable
   events, such as read receipts, are filtered the same way as the WebSocket
-  stream.
+  stream. Pass `include_tail=true` when a fresh client needs to skip retained
+  history: the response adds `tail_cursor`, captured before the page query, and
+  the client can open `/ws` from that cursor without racing events created
+  during startup. Servers that predate this option omit the field.
 - `POST /ephemeral` publishes a non-durable typing, presence, or agent progress
   event into the hub. Channel events are scoped by `channel_id`; DM events must
   send `direct_conversation_id` and are delivered only to that conversation's

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -711,6 +711,11 @@ paths:
           in: query
           schema:
             type: integer
+        - name: include_tail
+          in: query
+          description: Include the latest durable cursor visible at request start.
+          schema:
+            type: boolean
       responses:
         "200":
           description: Durable events after cursor

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -2564,6 +2564,8 @@ export interface operations {
         workspace_id: string;
         after_cursor?: string;
         limit?: number;
+        /** @description Include the latest durable cursor visible at request start. */
+        include_tail?: boolean;
       };
       header?: never;
       path?: never;


### PR DESCRIPTION
## What Problem This Solves

Fresh realtime clients cannot atomically distinguish retained history from events created during startup. Fetching history before subscribing can drop events created during the fetch, while subscribing from an old cursor can replay the retained backlog. Hidden read-receipt events could also consume SQL page slots before response filtering.

## Why This Change Was Made

- Add an opt-in `include_tail=true` query that returns the latest cursor visible when the request begins.
- Calculate the tail with the same private-event, guest-channel, direct-message, and read-receipt visibility rules as event backfill.
- Apply read-receipt visibility before pagination in both SQLite and PostgreSQL.
- Keep the API additive so existing clients and servers remain compatible.

## User Impact

Clients can skip retained startup history without losing events created during startup. Existing callers that do not request the tail cursor are unchanged. This is the server-side contract consumed by openclaw/openclaw#102486.

## Evidence

- AWS Crabbox (`aws`) run `run_a2ff8460a932`: `go test ./apps/api/internal/httpapi ./apps/api/internal/store/sqlite ./apps/api/internal/store/postgres`
- `pnpm --filter @clickclack/sdk-ts typecheck`
- `pnpm fmt:check`
- Final autoreview: no accepted or actionable findings
- Published tree: `8431a8a80bf3c110f48917141797f5c0d70369b8`
