### PR TITLE
test(e2e): wait for app readiness before interactions

### DIFF
--- a/tests/e2e/app-ready.ts
+++ b/tests/e2e/app-ready.ts
@@ -1,0 +1,7 @@
+import { expect, type Page } from "@playwright/test";
+
+export async function waitForAppReady(page: Page) {
+  // SSR exposes controls before Svelte binds their handlers. Realtime only
+  // connects after the client has mounted and started the selected workspace.
+  await expect(page.locator('.shell[data-connected="true"]')).toBeVisible();
+}

--- a/tests/e2e/appearance.spec.ts
+++ b/tests/e2e/appearance.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./app-ready";
 
 // Appearance prefs are device-local: the settings modal writes localStorage
 // and data attributes on <html>; base.css maps those to color-scheme and
@@ -7,9 +8,19 @@ import { expect, test } from "@playwright/test";
 
 async function openAppearanceSettings(page: import("@playwright/test").Page) {
   await page.goto("/app");
-  await page.getByRole("button", { name: /account settings/i }).click();
-  await page.getByRole("button", { name: "Appearance" }).click();
-  await expect(page.getByRole("heading", { name: "Appearance" })).toBeVisible();
+  await waitForAppReady(page);
+  const accountSettings = page.getByRole("button", { name: /account settings/i });
+  const modal = page.getByRole("dialog", { name: "Account settings" });
+  const appearanceHeading = modal.getByRole("heading", { name: "Appearance" });
+  await expect(async () => {
+    if (await appearanceHeading.isVisible()) return;
+    if (!(await modal.isVisible())) await accountSettings.click();
+    await expect(modal.getByRole("heading", { name: "Profile settings" })).toBeVisible({
+      timeout: 750,
+    });
+    await modal.getByRole("button", { name: "Appearance" }).click();
+    await expect(appearanceHeading).toBeVisible({ timeout: 750 });
+  }).toPass({ timeout: 5_000 });
 }
 
 test("forced color mode applies instantly and survives reload", async ({ page }) => {

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -11,6 +11,7 @@ import {
   openClawWorkspaceIdentifier,
 } from "../../apps/web/src/lib/bots";
 import { productAppURLForHost } from "../../apps/web/src/productLinks";
+import { waitForAppReady } from "./app-ready";
 
 const serverURL = "http://127.0.0.1:18082";
 const execFileAsync = promisify(execFile);
@@ -259,6 +260,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   }
 
   await page.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(page);
   const channelNames = (targetPage: Page) =>
     targetPage
       .locator("#sidebar-channels-list")
@@ -269,6 +271,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
 
   const peer = await page.context().newPage();
   await peer.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(peer);
   await expect.poll(() => channelNames(peer)).toEqual(names);
 
   const source = page.getByRole("button", { name: `Move #${names[2]}` });
@@ -279,6 +282,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   await expect.poll(() => channelNames(peer)).toEqual([names[2], names[0], names[1]]);
 
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([names[2], names[0], names[1]]);
 
   await page.getByRole("button", { name: "Channels", exact: true }).click();
@@ -290,6 +294,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   await expect(page.getByRole("button", { name: `Move #${names[0]}` })).toHaveCount(0);
   await expect(page.getByRole("link", { name: `# ${names[0]}` })).toHaveCSS("flex-grow", "1");
   await page.reload();
+  await waitForAppReady(page);
   await expect(page.getByRole("button", { name: "Channels", exact: true })).toHaveAttribute(
     "aria-expanded",
     "false",
@@ -310,6 +315,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   });
   expect(addedResponse.ok()).toBe(true);
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([names[0], names[2], names[1], addedName]);
 
   const secondWorkspaceResponse = await page.request.post("/api/workspaces", {
@@ -326,8 +332,10 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
     expect(response.ok()).toBe(true);
   }
   await page.goto(`/app/${secondWorkspace.route_id}`);
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([`aa-other-${suffix}`, `zz-other-${suffix}`]);
   await page.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([names[0], names[2], names[1], addedName]);
 
   const storageKey = await page.evaluate(() =>
@@ -336,6 +344,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   expect(storageKey).toBeTruthy();
   await page.evaluate((key) => localStorage.setItem(key, "not-json"), storageKey!);
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([names[0], addedName, names[1], names[2]]);
 
   await page.evaluate(({ key, value }) => localStorage.setItem(key, value), {
@@ -343,6 +352,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
     value: "x".repeat(1_000_001),
   });
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => channelNames(page)).toEqual([names[0], addedName, names[1], names[2]]);
 
   await page.addInitScript(() => {
@@ -359,6 +369,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
     };
   });
   await page.reload();
+  await waitForAppReady(page);
   await page.getByRole("button", { name: `Move #${names[2]}` }).focus();
   await page.keyboard.press("ArrowUp");
   await expect.poll(() => channelNames(page)).toEqual([names[0], addedName, names[2], names[1]]);
@@ -373,6 +384,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   });
   const mobilePage = await mobileContext.newPage();
   await mobilePage.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(mobilePage);
   await mobilePage.getByRole("button", { name: "Toggle navigation" }).click();
   await mobilePage.getByRole("button", { name: `Move #${names[1]}` }).click();
   await mobilePage
@@ -383,6 +395,7 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
     .poll(() => channelNames(mobilePage))
     .toEqual([names[0], names[1], addedName, names[2]]);
   await mobilePage.reload();
+  await waitForAppReady(mobilePage);
   await mobilePage.getByRole("button", { name: "Toggle navigation" }).click();
   await expect
     .poll(() => channelNames(mobilePage))
@@ -965,6 +978,7 @@ test("sends messages, searches, uploads, opens a thread, and creates a DM", asyn
   ).trim();
 
   await page.goto("/app");
+  await waitForAppReady(page);
   await expect(page).toHaveURL(/\/app\/[^/]+\/[^/]+$/);
 
   await page
@@ -1144,6 +1158,7 @@ test("closes direct messages without deleting history", async ({ page }) => {
   };
 
   await page.goto("/app");
+  await waitForAppReady(page);
   const dmSection = page.locator(".nav-section", { hasText: "Direct messages" });
   const dmLink = dmSection.getByRole("link", { name: new RegExp(name) });
   const closeDirectMessage = async () => {
@@ -1164,6 +1179,7 @@ test("closes direct messages without deleting history", async ({ page }) => {
   const hiddenGet = await page.request.get(`/api/dms/${conversation.id}`);
   expect(hiddenGet.ok()).toBe(true);
   await page.goto(`/app/${workspace.route_id}/${conversation.route_id}`);
+  await waitForAppReady(page);
   await expect(page.getByRole("heading", { name: new RegExp(name) })).toBeVisible();
 
   await closeDirectMessage();
@@ -1175,6 +1191,7 @@ test("closes direct messages without deleting history", async ({ page }) => {
   const reopenedBody = (await reopened.json()) as { conversation: { id: string } };
   expect(reopenedBody.conversation.id).toBe(conversation.id);
   await page.reload();
+  await waitForAppReady(page);
   await expect(dmLink).toBeVisible();
 
   await closeDirectMessage();

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1135,7 +1135,7 @@ test("closes direct messages without deleting history", async ({ page }) => {
     workspaces: { id: string; route_id: string }[];
   };
   const workspace = workspaces.workspaces[0];
-  const name = `Close User ${Date.now()}`;
+  const name = `Close User ${randomUUID().replaceAll("-", "").slice(0, 12)}`;
   const otherUserId = clickclack([
     "admin",
     "user",
@@ -1160,12 +1160,12 @@ test("closes direct messages without deleting history", async ({ page }) => {
   await page.goto("/app");
   await waitForAppReady(page);
   const dmSection = page.locator(".nav-section", { hasText: "Direct messages" });
-  const dmLink = dmSection.getByRole("link", { name: new RegExp(name) });
+  const dmRow = dmSection.locator(".dm-row").filter({ hasText: name });
+  const dmLink = dmRow.getByRole("link", { name: new RegExp(name) });
   const closeDirectMessage = async () => {
-    await dmSection
-      .getByRole("button", { name: `Direct message actions for ${name}` })
-      .click({ force: true });
-    await dmSection.getByRole("menuitem", { name: "Close direct message" }).click();
+    await dmRow.hover();
+    await dmRow.getByRole("button", { name: `Direct message actions for ${name}` }).click();
+    await dmRow.getByRole("menuitem", { name: "Close direct message" }).click();
   };
   await expect(dmLink).toBeVisible();
   await closeDirectMessage();


### PR DESCRIPTION
## Summary

- wait for the mounted app's existing `data-connected` readiness signal before post-navigation interactions
- use that readiness boundary across channel-ordering and direct-message reload/navigation paths
- make Appearance setup retry only its idempotent modal-open/section-select actions while asserting real modal headings
- reveal the scoped direct-message action through hover and click it normally instead of forcing a hidden control
- use collision-resistant identities for repeated direct-message test runs

## Diagnosis

The named failures are hydration/readiness races, not Go server contention. SSR exposes the sidebar controls before Svelte binds their handlers, so an early settings or mobile-navigation click can be lost; the failing runs still showed fast API responses. The settings modal also refreshes its user state on mount, which can detach the rail once before it settles.

This keeps Playwright's normal timeouts and worker parallelism. It does not add suite retries, forced clicks, sleeps, or worker serialization.

## Proof

- `pnpm check`
- `pnpm test:e2e` — 69 passed
- Appearance stress: 40 passed, 20 repeats, 16 workers
- Channel-order stress: 10 passed, 10 repeats, 10 workers
- Direct-message stress: 20 passed, 20 repeats
- Full-suite follow-up: 69 passed, 10 workers
- Autoreview: clean, no actionable findings (full branch and follow-up diff)
