### PR TITLE
fix(protocol): allow clearing pushover user keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allowed disabled Pushover notification settings to clear the stored user key through the public API contract.
 - Unified the desktop shell chrome like Slack: title bar, workspace rail, and sidebar share one continuous plate with the conversation floating on it as a rounded card, the sidebar workspace header and the in-card channel header are gone on desktop — the workspace name (click for workspace settings) and the current channel or DM title live in the title bar — and the always-on "Connected" labels are gone everywhere (app settings stay on the native menu and Cmd/Ctrl+,; a pulsing "Connecting…" note appears only while the realtime link is down). The browser app keeps its sidebar workspace header and channel header unchanged.
 - Fixed live agent-activity bursts so same-turn preambles grow in place without dropping realtime rows or pulling a bottom-pinned timeline away from the live edge.
 - Softened message bubbles: hairline accent-tint borders replace the heavier outlines, gentler keycap under-edges, and roomier padding.

--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -118,6 +118,18 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	if updatedMe.User.NotificationSettings == nil || !updatedMe.User.NotificationSettings.PushoverEnabled || updatedMe.User.NotificationSettings.PushoverUserKey == "" {
 		t.Fatalf("expected profile notification settings, got %#v", updatedMe.User)
 	}
+	clearedNotifications := patchJSON[struct {
+		User store.User `json:"user"`
+	}](t, server.URL+"/api/me", map[string]any{
+		"display_name": "Owner",
+		"notification_settings": map[string]any{
+			"pushover_enabled":  false,
+			"pushover_user_key": "",
+		},
+	})
+	if clearedNotifications.User.NotificationSettings == nil || clearedNotifications.User.NotificationSettings.PushoverEnabled || clearedNotifications.User.NotificationSettings.PushoverUserKey != "" {
+		t.Fatalf("expected cleared profile notification settings, got %#v", clearedNotifications.User)
+	}
 	beforeFailedProfile, err := st.GetUser(ctx, owner.ID)
 	if err != nil {
 		t.Fatal(err)

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -1638,7 +1638,7 @@ components:
         pushover_user_key:
           type: string
           description: Current user's Pushover user key. Must be set when Pushover notifications are enabled.
-          pattern: "^[A-Za-z0-9]{30}$"
+          pattern: "^$|^[A-Za-z0-9]{30}$"
     CreateChannelRequest:
       type: object
       required: [name]


### PR DESCRIPTION
## Summary

- allow an empty Pushover user key when notifications are disabled
- cover clearing an existing key through `PATCH /api/me`
- document the contract correction in the changelog

## Scope

3 files, 14 additions, 1 deletion. The earlier broad audit PR was closed and is not part of this change.

## Validation

- `go test ./apps/api/internal/httpapi`
- OpenAPI parsed successfully with `openapi-typescript` on direct AWS Crabbox
