### PR TITLE
feat: harden multi-instance authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY packages packages
 COPY scripts scripts
 RUN pnpm build
 
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS api
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS api
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.cloudflare
+++ b/Dockerfile.cloudflare
@@ -13,7 +13,7 @@ COPY packages packages
 COPY scripts scripts
 RUN pnpm build
 
-FROM golang:1.26-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS api
+FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS api
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/README.md
+++ b/README.md
@@ -136,13 +136,16 @@ Create bot tokens with `clickclack admin bot create`. See
 
 ## Auth
 
-ClickClack accepts, in order: an `Authorization: Bearer` session or bot token, the
-`cc_session` cookie, an `X-ClickClack-User` header, or a dev fallback to the
-first user in the DB. Magic-link tokens are mintable from the CLI today; the
-HTTP endpoint also exists. GitHub OAuth is opt-in via:
+ClickClack accepts, in order: an `Authorization: Bearer` session or bot token,
+the configured session cookie (`cc_session` by default), an
+`X-ClickClack-User` header, or a dev fallback to the first user in the DB.
+Magic-link tokens are mintable from the CLI today; the HTTP endpoint also
+exists. GitHub OAuth is opt-in via:
 
 ```sh
 CLICKCLACK_PUBLIC_URL=https://chat.example.com
+# Optional for multiple trusted instances on one hostname:
+# CLICKCLACK_COOKIE_NAMESPACE=production
 CLICKCLACK_GITHUB_CLIENT_ID=...
 CLICKCLACK_GITHUB_CLIENT_SECRET=...
 # Optional org gate:

--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
 	"github.com/openclaw/clickclack/apps/api/internal/config"
 	"github.com/openclaw/clickclack/apps/api/internal/fakeco"
 	"github.com/openclaw/clickclack/apps/api/internal/httpapi"
@@ -94,6 +95,13 @@ func serve(args []string) error {
 		return err
 	}
 	applyFlagOverrides(flags, &cfg)
+	if err := cfg.ValidateServe(); err != nil {
+		return err
+	}
+	cookieNames, err := authpolicy.NewCookieNames(cfg.CookieNamespace, cfg.PublicURL)
+	if err != nil {
+		return err
+	}
 	url := resolveDB(cfg.Data, cfg.DB)
 	if err := ensureDirs(cfg.Data); err != nil {
 		return err
@@ -127,6 +135,7 @@ func serve(args []string) error {
 	server := httpapi.New(st, realtime.NewHub(), httpapi.Options{
 		UploadStorage:  uploads,
 		DisableDevAuth: !cfg.DevBootstrap,
+		CookieNames:    cookieNames,
 		GitHubOAuth: httpapi.GitHubOAuthConfig{
 			ClientID:     cfg.GitHubClientID,
 			ClientSecret: cfg.GitHubClientSecret,

--- a/apps/api/internal/authpolicy/policy.go
+++ b/apps/api/internal/authpolicy/policy.go
@@ -1,0 +1,127 @@
+package authpolicy
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+const MaxCookieNamespaceLength = 32
+
+type CookieNames struct {
+	Session      string
+	OAuthBinding string
+}
+
+func DefaultCookieNames() CookieNames {
+	return CookieNames{
+		Session:      "cc_session",
+		OAuthBinding: "cc_oauth_binding",
+	}
+}
+
+func ParseCookieNamespace(input string) (string, error) {
+	namespace := strings.TrimSpace(input)
+	if namespace == "" {
+		return "", nil
+	}
+	if len(namespace) > MaxCookieNamespaceLength {
+		return "", fmt.Errorf("cookie namespace must be at most %d characters", MaxCookieNamespaceLength)
+	}
+	for index, character := range namespace {
+		if character >= 'a' && character <= 'z' || character >= '0' && character <= '9' {
+			continue
+		}
+		if character == '-' && index > 0 && index < len(namespace)-1 {
+			continue
+		}
+		return "", errors.New("cookie namespace must contain only lowercase letters, digits, and interior hyphens")
+	}
+	return namespace, nil
+}
+
+func NewCookieNames(namespace, publicURL string) (CookieNames, error) {
+	namespace, err := ParseCookieNamespace(namespace)
+	if err != nil {
+		return CookieNames{}, err
+	}
+	if namespace == "" {
+		return DefaultCookieNames(), nil
+	}
+	canonicalURL, err := CanonicalPublicURL(publicURL)
+	if err != nil {
+		return CookieNames{}, fmt.Errorf("namespaced cookies require a valid public URL: %w", err)
+	}
+	if canonicalURL == "" {
+		return CookieNames{}, errors.New("namespaced cookies require CLICKCLACK_PUBLIC_URL")
+	}
+	prefix := "cc-" + namespace + "-"
+	if strings.HasPrefix(canonicalURL, "https://") {
+		prefix = "__Host-" + prefix
+	}
+	return CookieNames{
+		Session:      prefix + "session",
+		OAuthBinding: prefix + "oauth-binding",
+	}, nil
+}
+
+func CanonicalPublicURL(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", nil
+	}
+	value, err := url.Parse(input)
+	if err != nil {
+		return "", fmt.Errorf("parse public URL: %w", err)
+	}
+	if value.Scheme != "http" && value.Scheme != "https" {
+		return "", errors.New("public URL must use http or https")
+	}
+	if value.Host == "" {
+		return "", errors.New("public URL must include a host")
+	}
+	if value.User != nil {
+		return "", errors.New("public URL must not include credentials")
+	}
+	if value.RawQuery != "" || value.Fragment != "" {
+		return "", errors.New("public URL must not include a query or fragment")
+	}
+	if value.EscapedPath() != "" && value.EscapedPath() != "/" {
+		return "", errors.New("public URL must be an origin without a path")
+	}
+	hostname := strings.ToLower(value.Hostname())
+	if hostname == "" || strings.HasSuffix(hostname, ".") {
+		return "", errors.New("public URL has an invalid host")
+	}
+	if value.Scheme == "http" && !isLoopbackHost(hostname) {
+		return "", errors.New("non-loopback public URLs must use https")
+	}
+	port := value.Port()
+	if port == defaultPort(value.Scheme) {
+		port = ""
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	return value.Scheme + "://" + host, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	address := net.ParseIP(host)
+	return address != nil && address.IsLoopback()
+}
+
+func defaultPort(scheme string) string {
+	if scheme == "http" {
+		return "80"
+	}
+	return "443"
+}

--- a/apps/api/internal/authpolicy/policy.go
+++ b/apps/api/internal/authpolicy/policy.go
@@ -14,6 +14,7 @@ const MaxCookieNamespaceLength = 32
 type CookieNames struct {
 	Session      string
 	OAuthBinding string
+	Namespaced   bool
 }
 
 func DefaultCookieNames() CookieNames {
@@ -65,6 +66,7 @@ func NewCookieNames(namespace, publicURL string) (CookieNames, error) {
 	return CookieNames{
 		Session:      prefix + "session",
 		OAuthBinding: prefix + "oauth-binding",
+		Namespaced:   true,
 	}, nil
 }
 

--- a/apps/api/internal/authpolicy/policy.go
+++ b/apps/api/internal/authpolicy/policy.go
@@ -107,6 +107,7 @@ func CanonicalPublicURL(input string) (string, error) {
 		if err != nil || number < 1 || number > 65535 {
 			return "", errors.New("public URL has an invalid port")
 		}
+		port = strconv.Itoa(number)
 	}
 	if port == defaultPort(value.Scheme) {
 		port = ""

--- a/apps/api/internal/authpolicy/policy.go
+++ b/apps/api/internal/authpolicy/policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -99,6 +100,12 @@ func CanonicalPublicURL(input string) (string, error) {
 		return "", errors.New("non-loopback public URLs must use https")
 	}
 	port := value.Port()
+	if port != "" {
+		number, err := strconv.Atoi(port)
+		if err != nil || number < 1 || number > 65535 {
+			return "", errors.New("public URL has an invalid port")
+		}
+	}
 	if port == defaultPort(value.Scheme) {
 		port = ""
 	}

--- a/apps/api/internal/authpolicy/policy_test.go
+++ b/apps/api/internal/authpolicy/policy_test.go
@@ -1,0 +1,76 @@
+package authpolicy
+
+import "testing"
+
+func TestParseCookieNamespace(t *testing.T) {
+	t.Parallel()
+	for _, value := range []string{"", "a", "prod", "prod-2", "a1-b2", "abcdefghijklmnopqrstuvwxyz123456"} {
+		if _, err := ParseCookieNamespace(value); err != nil {
+			t.Fatalf("expected %q to be valid: %v", value, err)
+		}
+	}
+	for _, value := range []string{"Prod", "-prod", "prod-", "prod_name", "prod.name", "prod/name", "abcdefghijklmnopqrstuvwxyz1234567"} {
+		if _, err := ParseCookieNamespace(value); err == nil {
+			t.Fatalf("expected %q to be invalid", value)
+		}
+	}
+}
+
+func TestCanonicalPublicURL(t *testing.T) {
+	t.Parallel()
+	for input, expected := range map[string]string{
+		"":                              "",
+		"https://Chat.Example.com":      "https://chat.example.com",
+		"https://chat.example.com:443/": "https://chat.example.com",
+		"https://chat.example.com:8443": "https://chat.example.com:8443",
+		"http://localhost:8080/":        "http://localhost:8080",
+		"http://127.0.0.1:8080":         "http://127.0.0.1:8080",
+		"http://[::1]:8080":             "http://[::1]:8080",
+	} {
+		got, err := CanonicalPublicURL(input)
+		if err != nil {
+			t.Fatalf("canonicalize %q: %v", input, err)
+		}
+		if got != expected {
+			t.Fatalf("canonicalize %q: got %q, want %q", input, got, expected)
+		}
+	}
+	for _, value := range []string{
+		"ftp://chat.example.com",
+		"https://",
+		"https://user:secret@chat.example.com",
+		"https://chat.example.com/app",
+		"https://chat.example.com?x=1",
+		"https://chat.example.com#fragment",
+		"http://chat.example.com",
+		"https://chat.example.com.",
+	} {
+		if _, err := CanonicalPublicURL(value); err == nil {
+			t.Fatalf("expected %q to be invalid", value)
+		}
+	}
+}
+
+func TestNewCookieNames(t *testing.T) {
+	t.Parallel()
+	if got, err := NewCookieNames("", ""); err != nil || got != DefaultCookieNames() {
+		t.Fatalf("unexpected default cookie names: %#v %v", got, err)
+	}
+	secure, err := NewCookieNames("prod-2", "https://chat.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if secure.Session != "__Host-cc-prod-2-session" || secure.OAuthBinding != "__Host-cc-prod-2-oauth-binding" {
+		t.Fatalf("unexpected secure names: %#v", secure)
+	}
+	loopback, err := NewCookieNames("dev", "http://localhost:8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loopback.Session != "cc-dev-session" || loopback.OAuthBinding != "cc-dev-oauth-binding" {
+		t.Fatalf("unexpected loopback names: %#v", loopback)
+	}
+	if _, err := NewCookieNames("prod", ""); err == nil {
+		t.Fatal("expected namespaced cookies without a public URL to fail")
+	}
+}

--- a/apps/api/internal/authpolicy/policy_test.go
+++ b/apps/api/internal/authpolicy/policy_test.go
@@ -19,13 +19,15 @@ func TestParseCookieNamespace(t *testing.T) {
 func TestCanonicalPublicURL(t *testing.T) {
 	t.Parallel()
 	for input, expected := range map[string]string{
-		"":                              "",
-		"https://Chat.Example.com":      "https://chat.example.com",
-		"https://chat.example.com:443/": "https://chat.example.com",
-		"https://chat.example.com:8443": "https://chat.example.com:8443",
-		"http://localhost:8080/":        "http://localhost:8080",
-		"http://127.0.0.1:8080":         "http://127.0.0.1:8080",
-		"http://[::1]:8080":             "http://[::1]:8080",
+		"":                               "",
+		"https://Chat.Example.com":       "https://chat.example.com",
+		"https://chat.example.com:443/":  "https://chat.example.com",
+		"https://chat.example.com:0443/": "https://chat.example.com",
+		"https://chat.example.com:8443":  "https://chat.example.com:8443",
+		"https://chat.example.com:08443": "https://chat.example.com:8443",
+		"http://localhost:8080/":         "http://localhost:8080",
+		"http://127.0.0.1:8080":          "http://127.0.0.1:8080",
+		"http://[::1]:8080":              "http://[::1]:8080",
 	} {
 		got, err := CanonicalPublicURL(input)
 		if err != nil {

--- a/apps/api/internal/authpolicy/policy_test.go
+++ b/apps/api/internal/authpolicy/policy_test.go
@@ -44,6 +44,8 @@ func TestCanonicalPublicURL(t *testing.T) {
 		"https://chat.example.com#fragment",
 		"http://chat.example.com",
 		"https://chat.example.com.",
+		"https://chat.example.com:0",
+		"https://chat.example.com:65536",
 	} {
 		if _, err := CanonicalPublicURL(value); err == nil {
 			t.Fatalf("expected %q to be invalid", value)

--- a/apps/api/internal/authpolicy/policy_test.go
+++ b/apps/api/internal/authpolicy/policy_test.go
@@ -62,14 +62,14 @@ func TestNewCookieNames(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if secure.Session != "__Host-cc-prod-2-session" || secure.OAuthBinding != "__Host-cc-prod-2-oauth-binding" {
+	if secure.Session != "__Host-cc-prod-2-session" || secure.OAuthBinding != "__Host-cc-prod-2-oauth-binding" || !secure.Namespaced {
 		t.Fatalf("unexpected secure names: %#v", secure)
 	}
 	loopback, err := NewCookieNames("dev", "http://localhost:8080")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loopback.Session != "cc-dev-session" || loopback.OAuthBinding != "cc-dev-oauth-binding" {
+	if loopback.Session != "cc-dev-session" || loopback.OAuthBinding != "cc-dev-oauth-binding" || !loopback.Namespaced {
 		t.Fatalf("unexpected loopback names: %#v", loopback)
 	}
 	if _, err := NewCookieNames("prod", ""); err == nil {

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -2,8 +2,13 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"strconv"
+	"strings"
+
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
 )
 
 type Config struct {
@@ -14,6 +19,7 @@ type Config struct {
 	Environment        string `json:"environment"`
 	MetricsEnabled     bool   `json:"metrics_enabled"`
 	PublicURL          string `json:"public_url"`
+	CookieNamespace    string `json:"cookie_namespace"`
 	DevBootstrap       bool   `json:"dev_bootstrap"`
 	GitHubClientID     string `json:"github_client_id"`
 	GitHubClientSecret string `json:"github_client_secret"`
@@ -72,6 +78,9 @@ func Load(path string) (Config, error) {
 	if env := os.Getenv("CLICKCLACK_PUBLIC_URL"); env != "" {
 		cfg.PublicURL = env
 	}
+	if env := os.Getenv("CLICKCLACK_COOKIE_NAMESPACE"); env != "" {
+		cfg.CookieNamespace = env
+	}
 	if env := os.Getenv("CLICKCLACK_DEV_BOOTSTRAP"); env != "" && !fileHasDevBootstrap {
 		value, err := strconv.ParseBool(env)
 		if err != nil {
@@ -113,4 +122,32 @@ func Load(path string) (Config, error) {
 		cfg.Data = "./data"
 	}
 	return cfg, nil
+}
+
+func (c *Config) ValidateServe() error {
+	namespace, err := authpolicy.ParseCookieNamespace(c.CookieNamespace)
+	if err != nil {
+		return fmt.Errorf("CLICKCLACK_COOKIE_NAMESPACE: %w", err)
+	}
+	publicURL, err := authpolicy.CanonicalPublicURL(c.PublicURL)
+	if err != nil {
+		return fmt.Errorf("CLICKCLACK_PUBLIC_URL: %w", err)
+	}
+	hasClientID := strings.TrimSpace(c.GitHubClientID) != ""
+	hasClientSecret := strings.TrimSpace(c.GitHubClientSecret) != ""
+	if hasClientID != hasClientSecret {
+		return errors.New("CLICKCLACK_GITHUB_CLIENT_ID and CLICKCLACK_GITHUB_CLIENT_SECRET must be configured together")
+	}
+	if hasClientID && publicURL == "" {
+		return errors.New("GitHub OAuth requires CLICKCLACK_PUBLIC_URL")
+	}
+	if (strings.TrimSpace(c.GitHubAllowedOrg) != "" || strings.TrimSpace(c.GitHubModeratorOrg) != "") && !hasClientID {
+		return errors.New("GitHub organization settings require GitHub OAuth credentials")
+	}
+	if _, err := authpolicy.NewCookieNames(namespace, publicURL); err != nil {
+		return fmt.Errorf("cookie policy: %w", err)
+	}
+	c.CookieNamespace = namespace
+	c.PublicURL = publicURL
+	return nil
 }

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -133,15 +133,19 @@ func (c *Config) ValidateServe() error {
 	if err != nil {
 		return fmt.Errorf("CLICKCLACK_PUBLIC_URL: %w", err)
 	}
-	hasClientID := strings.TrimSpace(c.GitHubClientID) != ""
-	hasClientSecret := strings.TrimSpace(c.GitHubClientSecret) != ""
+	clientID := strings.TrimSpace(c.GitHubClientID)
+	clientSecret := strings.TrimSpace(c.GitHubClientSecret)
+	allowedOrg := strings.TrimSpace(c.GitHubAllowedOrg)
+	moderatorOrg := strings.TrimSpace(c.GitHubModeratorOrg)
+	hasClientID := clientID != ""
+	hasClientSecret := clientSecret != ""
 	if hasClientID != hasClientSecret {
 		return errors.New("CLICKCLACK_GITHUB_CLIENT_ID and CLICKCLACK_GITHUB_CLIENT_SECRET must be configured together")
 	}
 	if hasClientID && publicURL == "" {
 		return errors.New("GitHub OAuth requires CLICKCLACK_PUBLIC_URL")
 	}
-	if (strings.TrimSpace(c.GitHubAllowedOrg) != "" || strings.TrimSpace(c.GitHubModeratorOrg) != "") && !hasClientID {
+	if (allowedOrg != "" || moderatorOrg != "") && !hasClientID {
 		return errors.New("GitHub organization settings require GitHub OAuth credentials")
 	}
 	if _, err := authpolicy.NewCookieNames(namespace, publicURL); err != nil {
@@ -149,5 +153,9 @@ func (c *Config) ValidateServe() error {
 	}
 	c.CookieNamespace = namespace
 	c.PublicURL = publicURL
+	c.GitHubClientID = clientID
+	c.GitHubClientSecret = clientSecret
+	c.GitHubAllowedOrg = allowedOrg
+	c.GitHubModeratorOrg = moderatorOrg
 	return nil
 }

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	t.Setenv("CLICKCLACK_ENVIRONMENT", "fakeco")
 	t.Setenv("CLICKCLACK_METRICS_ENABLED", "true")
 	t.Setenv("CLICKCLACK_PUBLIC_URL", "https://clickclack.test")
+	t.Setenv("CLICKCLACK_COOKIE_NAMESPACE", "prod-2")
 	t.Setenv("CLICKCLACK_DEV_BOOTSTRAP", "false")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_ID", "client")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_SECRET", "secret")
@@ -28,7 +29,7 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Addr != ":9000" || cfg.Data != "/tmp/clickclack" || cfg.DB != "sqlite:///tmp/clickclack.db" || cfg.Uploads != "r2://clickclack-uploads/prod" || cfg.Environment != "fakeco" || !cfg.MetricsEnabled || cfg.PublicURL != "https://clickclack.test" || cfg.DevBootstrap || cfg.GitHubClientID != "client" || cfg.GitHubClientSecret != "secret" || cfg.GitHubAllowedOrg != "openclaw" || cfg.GitHubModeratorOrg != "openclaw" || cfg.PushoverAPIToken != "app-token" || cfg.R2AccountID != "account" || cfg.R2AccessKeyID != "access" || cfg.R2SecretAccessKey != "secret-access" || cfg.R2Endpoint != "https://r2.example.com" {
+	if cfg.Addr != ":9000" || cfg.Data != "/tmp/clickclack" || cfg.DB != "sqlite:///tmp/clickclack.db" || cfg.Uploads != "r2://clickclack-uploads/prod" || cfg.Environment != "fakeco" || !cfg.MetricsEnabled || cfg.PublicURL != "https://clickclack.test" || cfg.CookieNamespace != "prod-2" || cfg.DevBootstrap || cfg.GitHubClientID != "client" || cfg.GitHubClientSecret != "secret" || cfg.GitHubAllowedOrg != "openclaw" || cfg.GitHubModeratorOrg != "openclaw" || cfg.PushoverAPIToken != "app-token" || cfg.R2AccountID != "account" || cfg.R2AccessKeyID != "access" || cfg.R2SecretAccessKey != "secret-access" || cfg.R2Endpoint != "https://r2.example.com" {
 		t.Fatalf("unexpected env config: %#v", cfg)
 	}
 
@@ -51,6 +52,7 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	t.Setenv("CLICKCLACK_ENVIRONMENT", "")
 	t.Setenv("CLICKCLACK_METRICS_ENABLED", "")
 	t.Setenv("CLICKCLACK_PUBLIC_URL", "")
+	t.Setenv("CLICKCLACK_COOKIE_NAMESPACE", "")
 	t.Setenv("CLICKCLACK_DEV_BOOTSTRAP", "")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_ID", "")
 	t.Setenv("CLICKCLACK_GITHUB_CLIENT_SECRET", "")
@@ -102,5 +104,40 @@ func TestLoadDefaultsEnvAndFile(t *testing.T) {
 	}
 	if _, err := Load(badPath); err == nil {
 		t.Fatal("expected bad json error")
+	}
+}
+
+func TestValidateServe(t *testing.T) {
+	t.Parallel()
+	cfg := Config{
+		PublicURL:          "https://Chat.Example.com:443/",
+		CookieNamespace:    " prod-2 ",
+		GitHubClientID:     "client",
+		GitHubClientSecret: "secret",
+	}
+	if err := cfg.ValidateServe(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.PublicURL != "https://chat.example.com" || cfg.CookieNamespace != "prod-2" {
+		t.Fatalf("unexpected validated config: %#v", cfg)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		{"invalid namespace", Config{CookieNamespace: "__Host-session", PublicURL: "https://chat.example.com"}},
+		{"namespace without public url", Config{CookieNamespace: "prod"}},
+		{"non-https remote url", Config{PublicURL: "http://chat.example.com"}},
+		{"public url path", Config{PublicURL: "https://chat.example.com/app"}},
+		{"missing client secret", Config{PublicURL: "https://chat.example.com", GitHubClientID: "client"}},
+		{"oauth without public url", Config{GitHubClientID: "client", GitHubClientSecret: "secret"}},
+		{"org without oauth", Config{GitHubAllowedOrg: "openclaw"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.ValidateServe(); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
 	}
 }

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -112,14 +112,23 @@ func TestValidateServe(t *testing.T) {
 	cfg := Config{
 		PublicURL:          "https://Chat.Example.com:443/",
 		CookieNamespace:    " prod-2 ",
-		GitHubClientID:     "client",
-		GitHubClientSecret: "secret",
+		GitHubClientID:     " client ",
+		GitHubClientSecret: " secret ",
+		GitHubAllowedOrg:   " openclaw ",
 	}
 	if err := cfg.ValidateServe(); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.PublicURL != "https://chat.example.com" || cfg.CookieNamespace != "prod-2" {
+	if cfg.PublicURL != "https://chat.example.com" || cfg.CookieNamespace != "prod-2" || cfg.GitHubClientID != "client" || cfg.GitHubClientSecret != "secret" || cfg.GitHubAllowedOrg != "openclaw" {
 		t.Fatalf("unexpected validated config: %#v", cfg)
+	}
+
+	disabled := Config{GitHubClientID: " ", GitHubClientSecret: "\t"}
+	if err := disabled.ValidateServe(); err != nil {
+		t.Fatal(err)
+	}
+	if disabled.GitHubClientID != "" || disabled.GitHubClientSecret != "" {
+		t.Fatalf("expected whitespace credentials to normalize as disabled: %#v", disabled)
 	}
 
 	for _, tc := range []struct {

--- a/apps/api/internal/httpapi/auth.go
+++ b/apps/api/internal/httpapi/auth.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -120,6 +121,13 @@ func canonicalOrigin(value *url.URL) (string, bool) {
 		return "", false
 	}
 	port := value.Port()
+	if port != "" {
+		number, err := strconv.Atoi(port)
+		if err != nil || number < 1 || number > 65535 {
+			return "", false
+		}
+		port = strconv.Itoa(number)
+	}
 	if port == defaultPort(scheme) {
 		port = ""
 	}

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -11,6 +11,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -482,6 +483,33 @@ func TestCookieSessionMutationsRequireCSRF(t *testing.T) {
 	handler.ServeHTTP(recorder, req)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("expected bearer mutation to bypass cookie csrf, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func TestCanonicalOriginNormalizesAndValidatesPorts(t *testing.T) {
+	t.Parallel()
+	for input, expected := range map[string]string{
+		"https://chat.example.com:0443":  "https://chat.example.com",
+		"https://chat.example.com:08443": "https://chat.example.com:8443",
+		"http://127.0.0.1:080":           "http://127.0.0.1",
+	} {
+		value, err := url.Parse(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, ok := canonicalOrigin(value)
+		if !ok || got != expected {
+			t.Fatalf("canonical origin %q: got %q, %v; want %q", input, got, ok, expected)
+		}
+	}
+	for _, input := range []string{"https://chat.example.com:0", "https://chat.example.com:65536"} {
+		value, err := url.Parse(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, ok := canonicalOrigin(value); ok {
+			t.Fatalf("expected invalid origin %q to fail, got %q", input, got)
+		}
 	}
 }
 

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -64,6 +64,11 @@ const (
 )
 
 func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
+	c.ClientID = strings.TrimSpace(c.ClientID)
+	c.ClientSecret = strings.TrimSpace(c.ClientSecret)
+	c.PublicURL = strings.TrimSpace(c.PublicURL)
+	c.AllowedOrg = strings.TrimSpace(c.AllowedOrg)
+	c.ModeratorOrg = strings.TrimSpace(c.ModeratorOrg)
 	if c.AuthURL == "" {
 		c.AuthURL = "https://github.com/login/oauth/authorize"
 	}

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -511,7 +511,7 @@ func (s *Server) githubRedirectURL(r *http.Request) string {
 
 func (s *Server) setSessionCookie(w http.ResponseWriter, r *http.Request, session store.Session) {
 	expires, _ := time.Parse(time.RFC3339Nano, session.ExpiresAt)
-	http.SetCookie(w, &http.Cookie{Name: "cc_session", Value: session.Token, Path: "/", Expires: expires, HttpOnly: true, Secure: s.secureCookies(r), SameSite: http.SameSiteLaxMode})
+	http.SetCookie(w, &http.Cookie{Name: s.cookies.Session, Value: session.Token, Path: "/", Expires: expires, HttpOnly: true, Secure: s.secureCookies(r), SameSite: http.SameSiteLaxMode})
 }
 
 func (s *Server) secureCookies(r *http.Request) bool {

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -213,13 +213,13 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 	token, err := s.exchangeGitHubCode(r.Context(), code, transaction.PKCEVerifier, redirectURL)
 	if err != nil {
 		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
-		writeError(w, http.StatusBadGateway, err)
+		s.writeGitHubOAuthProviderError(w, r, "token exchange", err)
 		return
 	}
 	profile, err := s.fetchGitHubProfile(r.Context(), token)
 	if err != nil {
 		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
-		writeError(w, http.StatusBadGateway, err)
+		s.writeGitHubOAuthProviderError(w, r, "profile fetch", err)
 		return
 	}
 	if err := s.ensureGitHubAllowedOrgMembership(r.Context(), token); err != nil {
@@ -229,7 +229,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
-		writeError(w, http.StatusBadGateway, err)
+		s.writeGitHubOAuthProviderError(w, r, "organization check", err)
 		return
 	}
 	user, err := s.store.UpsertIdentityUser(r.Context(), store.UpsertIdentityUserInput{
@@ -345,6 +345,11 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 func (s *Server) writeGitHubOAuthServerError(w http.ResponseWriter, r *http.Request, phase string, err error) {
 	log.Printf("github oauth %s failed correlation_id=%q error_type=%T", phase, correlationIDFromContext(r.Context()), err)
 	writeError(w, http.StatusInternalServerError, errors.New("github oauth request failed"))
+}
+
+func (s *Server) writeGitHubOAuthProviderError(w http.ResponseWriter, r *http.Request, phase string, err error) {
+	log.Printf("github oauth provider %s failed correlation_id=%q error_type=%T", phase, correlationIDFromContext(r.Context()), err)
+	writeError(w, http.StatusBadGateway, errors.New("github authentication provider request failed"))
 }
 
 func desktopCodeChallenge(verifier string) string {

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -38,12 +38,13 @@ var errGitHubOrgDenied = errors.New("github account is not a member of the allow
 const defaultGitHubHTTPTimeout = 30 * time.Second
 
 const (
-	desktopOAuthCallbackURL  = "clickclack://auth/callback"
-	oauthTransactionTTL      = 10 * time.Minute
-	oauthBrowserBindingTTL   = 30 * time.Minute
-	desktopOAuthGrantTTL     = 5 * time.Minute
-	oauthSecretBytes         = 32
-	oauthEncodedSecretLength = 43
+	desktopOAuthLegacyCallbackURL = "clickclack://auth/callback"
+	desktopOAuthCallbackURL       = "chat.clickclack.desktop:/auth/callback"
+	oauthTransactionTTL           = 10 * time.Minute
+	oauthBrowserBindingTTL        = 30 * time.Minute
+	desktopOAuthGrantTTL          = 5 * time.Minute
+	oauthSecretBytes              = 32
+	oauthEncodedSecretLength      = 43
 )
 
 func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
@@ -69,7 +70,7 @@ func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
 }
 
 func (s *Server) githubStart(w http.ResponseWriter, r *http.Request) {
-	s.startGitHubOAuth(w, r, "")
+	s.startGitHubOAuth(w, r, "", 0)
 }
 
 func (s *Server) githubDesktopStart(w http.ResponseWriter, r *http.Request) {
@@ -78,10 +79,19 @@ func (s *Server) githubDesktopStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("valid desktop oauth code challenge is required"))
 		return
 	}
-	s.startGitHubOAuth(w, r, challenge)
+	protocol, err := desktopProtocolVersion(r.URL.Query().Get("desktop_protocol"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if s.cookies.Session != "cc_session" && protocol < 2 {
+		writeDesktopUpgradeRequired(w)
+		return
+	}
+	s.startGitHubOAuth(w, r, challenge, protocol)
 }
 
-func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, desktopChallenge string) {
+func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, desktopChallenge string, desktopProtocol int64) {
 	if s.githubOAuth.ClientID == "" || s.githubOAuth.ClientSecret == "" {
 		writeError(w, http.StatusNotImplemented, errors.New("github oauth is not configured"))
 		return
@@ -121,6 +131,7 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 		Mode:               mode,
 		PKCEVerifier:       pkceVerifier,
 		DesktopChallenge:   desktopChallenge,
+		DesktopProtocol:    desktopProtocol,
 		CreatedAt:          now,
 		ExpiresAt:          now.Add(oauthTransactionTTL),
 	}); err != nil {
@@ -211,7 +222,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid desktop oauth transaction"))
 		return
 	}
-	grantCode, err := randomOAuthSecret()
+	grantCode, err := newDesktopOAuthGrantCode(transaction.DesktopProtocol)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
@@ -231,11 +242,28 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	callback, _ := url.Parse(desktopOAuthCallbackURL)
-	query := callback.Query()
-	query.Set("code", grantCode)
-	callback.RawQuery = query.Encode()
-	http.Redirect(w, r, callback.String(), http.StatusFound)
+	http.Redirect(w, r, desktopOAuthCallback(transaction.DesktopProtocol, grantCode), http.StatusFound)
+}
+
+func desktopProtocolVersion(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 1, nil
+	}
+	protocol, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || protocol < 1 || protocol > 2 {
+		return 0, errors.New("unsupported desktop oauth protocol")
+	}
+	return protocol, nil
+}
+
+func writeDesktopUpgradeRequired(w http.ResponseWriter) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; base-uri 'none'")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusUpgradeRequired)
+	_, _ = w.Write([]byte("<!doctype html><meta charset=utf-8><title>ClickClack update required</title><h1>Update ClickClack to sign in</h1><p>This server requires a newer ClickClack desktop app.</p>"))
 }
 
 func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
@@ -250,7 +278,7 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	if !validDesktopCode(body.Code, oauthEncodedSecretLength, oauthEncodedSecretLength) || !validDesktopCode(body.Verifier, 43, 128) {
+	if !validOAuthGrantCode(body.Code) || !validDesktopCode(body.Verifier, 43, 128) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid desktop oauth grant"))
 		return
 	}
@@ -516,6 +544,48 @@ func randomOAuthSecret() (string, error) {
 		return "", err
 	}
 	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func randomLegacyOAuthGrant() (string, error) {
+	var data [16]byte
+	if _, err := rand.Read(data[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(data[:]), nil
+}
+
+func newDesktopOAuthGrantCode(protocol int64) (string, error) {
+	if protocol == 1 {
+		return randomLegacyOAuthGrant()
+	}
+	return randomOAuthSecret()
+}
+
+func desktopOAuthCallback(protocol int64, grantCode string) string {
+	callbackURL := desktopOAuthLegacyCallbackURL
+	if protocol >= 2 {
+		callbackURL = desktopOAuthCallbackURL
+	}
+	callback, _ := url.Parse(callbackURL)
+	query := callback.Query()
+	query.Set("code", grantCode)
+	callback.RawQuery = query.Encode()
+	return callback.String()
+}
+
+func validOAuthGrantCode(value string) bool {
+	if validDesktopCode(value, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		return true
+	}
+	if len(value) != 32 {
+		return false
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' && (character < 'a' || character > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func secretHash(value string) string {

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -104,7 +104,7 @@ func (s *Server) githubDesktopStart(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	if s.cookies.Session != "cc_session" && protocol < 2 {
+	if s.cookies.Namespaced && protocol < 2 {
 		s.recordGitHubOAuthEvent(githubOAuthEventDesktopUpgradeRequired)
 		writeDesktopUpgradeRequired(w)
 		return

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/subtle"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -14,10 +13,10 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"golang.org/x/oauth2"
 )
 
 type GitHubOAuthConfig struct {
@@ -39,28 +38,13 @@ var errGitHubOrgDenied = errors.New("github account is not a member of the allow
 const defaultGitHubHTTPTimeout = 30 * time.Second
 
 const (
-	desktopOAuthCallbackURL = "clickclack://auth/callback"
-	desktopOAuthStateTTL    = 10 * time.Minute
-	desktopOAuthGrantTTL    = 5 * time.Minute
-	desktopOAuthMaxGrants   = 4096
+	desktopOAuthCallbackURL  = "clickclack://auth/callback"
+	oauthTransactionTTL      = 10 * time.Minute
+	oauthBrowserBindingTTL   = 30 * time.Minute
+	desktopOAuthGrantTTL     = 5 * time.Minute
+	oauthSecretBytes         = 32
+	oauthEncodedSecretLength = 43
 )
-
-type desktopOAuthGrant struct {
-	challenge string
-	expiresAt time.Time
-	session   store.Session
-}
-
-type desktopOAuthBroker struct {
-	mu     sync.Mutex
-	grants map[string]desktopOAuthGrant
-}
-
-func newDesktopOAuthBroker() *desktopOAuthBroker {
-	return &desktopOAuthBroker{
-		grants: make(map[string]desktopOAuthGrant),
-	}
-}
 
 func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
 	if c.AuthURL == "" {
@@ -102,55 +86,85 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 		writeError(w, http.StatusNotImplemented, errors.New("github oauth is not configured"))
 		return
 	}
-	state, err := randomToken()
+	redirectURL, err := s.githubRedirectURL(r)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, err)
+		return
+	}
+	browserBinding, err := s.oauthBrowserBinding(w, r)
+	if err != nil {
+		if errors.Is(err, errAmbiguousCookie) {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	state, err := randomOAuthSecret()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	pkceVerifier, err := randomOAuthSecret()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	mode := store.OAuthModeBrowser
 	if desktopChallenge != "" {
-		maxAge := int(desktopOAuthStateTTL / time.Second)
-		http.SetCookie(w, &http.Cookie{Name: "cc_github_desktop_state", Value: state, Path: "/", MaxAge: maxAge, HttpOnly: true, Secure: s.secureCookies(r), SameSite: http.SameSiteLaxMode})
-		http.SetCookie(w, &http.Cookie{Name: "cc_github_desktop_challenge", Value: desktopChallenge, Path: "/", MaxAge: maxAge, HttpOnly: true, Secure: s.secureCookies(r), SameSite: http.SameSiteLaxMode})
-	} else {
-		s.clearGitHubDesktopStateCookie(w, r)
-		s.clearGitHubDesktopChallengeCookie(w, r)
+		mode = store.OAuthModeDesktop
 	}
-	http.SetCookie(w, &http.Cookie{Name: "cc_github_state", Value: state, Path: "/", MaxAge: 600, HttpOnly: true, Secure: s.secureCookies(r), SameSite: http.SameSiteLaxMode})
-	values := url.Values{
-		"client_id":    {s.githubOAuth.ClientID},
-		"redirect_uri": {s.githubRedirectURL(r)},
-		"scope":        {s.githubScope()},
-		"state":        {state},
+	now := time.Now().UTC()
+	if err := s.store.CreateOAuthTransaction(r.Context(), store.OAuthTransaction{
+		StateHash:          secretHash(state),
+		BrowserBindingHash: secretHash(browserBinding),
+		Mode:               mode,
+		PKCEVerifier:       pkceVerifier,
+		DesktopChallenge:   desktopChallenge,
+		CreatedAt:          now,
+		ExpiresAt:          now.Add(oauthTransactionTTL),
+	}); err != nil {
+		if errors.Is(err, store.ErrOAuthCapacityExceeded) {
+			writeError(w, http.StatusServiceUnavailable, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
+		return
 	}
-	http.Redirect(w, r, s.githubOAuth.AuthURL+"?"+values.Encode(), http.StatusFound)
+	http.Redirect(w, r, s.oauth2Config(redirectURL).AuthCodeURL(state, oauth2.S256ChallengeOption(pkceVerifier)), http.StatusFound)
 }
 
 func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
-	state, err := r.Cookie("cc_github_state")
-	if err != nil || state.Value == "" || state.Value != r.URL.Query().Get("state") {
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	if !validDesktopCode(state, oauthEncodedSecretLength, oauthEncodedSecretLength) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 		return
 	}
-	s.clearGitHubStateCookie(w, r)
-	desktopStateCookie, desktopCookieErr := r.Cookie("cc_github_desktop_state")
-	isDesktop := desktopCookieErr == nil && desktopStateCookie.Value == state.Value
-	s.clearGitHubDesktopStateCookie(w, r)
-	desktopChallengeCookie, desktopChallengeErr := r.Cookie("cc_github_desktop_challenge")
-	s.clearGitHubDesktopChallengeCookie(w, r)
-	var desktopChallenge string
-	if isDesktop {
-		if desktopChallengeErr != nil || !validDesktopCode(desktopChallengeCookie.Value, 43, 43) {
-			writeError(w, http.StatusBadRequest, errors.New("desktop oauth request expired"))
+	bindingCookie, err := requestCookie(r, s.cookies.OAuthBinding)
+	if err != nil || !validDesktopCode(bindingCookie.Value, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
+		return
+	}
+	transaction, err := s.store.ConsumeOAuthTransaction(r.Context(), secretHash(state), secretHash(bindingCookie.Value), time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, store.ErrOAuthTransactionInvalid) {
+			writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 			return
 		}
-		desktopChallenge = desktopChallengeCookie.Value
+		writeError(w, http.StatusInternalServerError, err)
+		return
 	}
 	code := strings.TrimSpace(r.URL.Query().Get("code"))
 	if code == "" {
 		writeError(w, http.StatusBadRequest, errors.New("github oauth code is required"))
 		return
 	}
-	token, err := s.exchangeGitHubCode(r.Context(), r, code)
+	redirectURL, err := s.githubRedirectURL(r)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, err)
+		return
+	}
+	token, err := s.exchangeGitHubCode(r.Context(), code, transaction.PKCEVerifier, redirectURL)
 	if err != nil {
 		writeError(w, http.StatusBadGateway, err)
 		return
@@ -183,23 +197,38 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	session, err := s.store.CreateSession(r.Context(), user.ID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err)
-		return
-	}
-	if !isDesktop {
+	if transaction.Mode == store.OAuthModeBrowser {
+		session, err := s.store.CreateSession(r.Context(), user.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err)
+			return
+		}
 		s.setSessionCookie(w, r, session)
 		http.Redirect(w, r, "/", http.StatusFound)
 		return
 	}
-	grantCode, err := randomToken()
+	if transaction.Mode != store.OAuthModeDesktop || !validDesktopCode(transaction.DesktopChallenge, 43, 43) {
+		writeError(w, http.StatusBadRequest, errors.New("invalid desktop oauth transaction"))
+		return
+	}
+	grantCode, err := randomOAuthSecret()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
-	if !s.desktopOAuth.putGrant(grantCode, desktopChallenge, session, time.Now().Add(desktopOAuthGrantTTL)) {
-		writeError(w, http.StatusServiceUnavailable, errors.New("too many pending desktop oauth grants"))
+	now := time.Now().UTC()
+	if err := s.store.CreateDesktopOAuthGrant(r.Context(), store.DesktopOAuthGrant{
+		GrantHash:        secretHash(grantCode),
+		UserID:           user.ID,
+		DesktopChallenge: transaction.DesktopChallenge,
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(desktopOAuthGrantTTL),
+	}); err != nil {
+		if errors.Is(err, store.ErrOAuthCapacityExceeded) {
+			writeError(w, http.StatusServiceUnavailable, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 	callback, _ := url.Parse(desktopOAuthCallbackURL)
@@ -221,87 +250,21 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	if !validDesktopCode(body.Code, 32, 32) || !validDesktopCode(body.Verifier, 43, 128) {
+	if !validDesktopCode(body.Code, oauthEncodedSecretLength, oauthEncodedSecretLength) || !validDesktopCode(body.Verifier, 43, 128) {
 		writeError(w, http.StatusBadRequest, errors.New("invalid desktop oauth grant"))
 		return
 	}
-	session, ok := s.desktopOAuth.consumeGrant(body.Code, desktopCodeChallenge(body.Verifier), time.Now())
-	if !ok {
-		writeError(w, http.StatusBadRequest, errors.New("invalid or expired desktop oauth grant"))
+	session, err := s.store.ConsumeDesktopOAuthGrant(r.Context(), secretHash(body.Code), desktopCodeChallenge(body.Verifier), time.Now().UTC())
+	if err != nil {
+		if errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 	s.setSessionCookie(w, r, session)
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
-}
-
-func (s *Server) clearGitHubStateCookie(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     "cc_github_state",
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		Expires:  time.Unix(0, 0),
-		HttpOnly: true,
-		Secure:   s.secureCookies(r),
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
-func (s *Server) clearGitHubDesktopStateCookie(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     "cc_github_desktop_state",
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		Expires:  time.Unix(0, 0),
-		HttpOnly: true,
-		Secure:   s.secureCookies(r),
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
-func (s *Server) clearGitHubDesktopChallengeCookie(w http.ResponseWriter, r *http.Request) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     "cc_github_desktop_challenge",
-		Value:    "",
-		Path:     "/",
-		MaxAge:   -1,
-		Expires:  time.Unix(0, 0),
-		HttpOnly: true,
-		Secure:   s.secureCookies(r),
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
-func (b *desktopOAuthBroker) putGrant(code, challenge string, session store.Session, expiresAt time.Time) bool {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.pruneLocked(time.Now())
-	if len(b.grants) >= desktopOAuthMaxGrants {
-		return false
-	}
-	b.grants[code] = desktopOAuthGrant{challenge: challenge, expiresAt: expiresAt, session: session}
-	return true
-}
-
-func (b *desktopOAuthBroker) consumeGrant(code, challenge string, now time.Time) (store.Session, bool) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.pruneLocked(now)
-	grant, ok := b.grants[code]
-	if !ok || subtle.ConstantTimeCompare([]byte(grant.challenge), []byte(challenge)) != 1 {
-		return store.Session{}, false
-	}
-	delete(b.grants, code)
-	return grant.session, true
-}
-
-func (b *desktopOAuthBroker) pruneLocked(now time.Time) {
-	for key, grant := range b.grants {
-		if !now.Before(grant.expiresAt) {
-			delete(b.grants, key)
-		}
-	}
 }
 
 func desktopCodeChallenge(verifier string) string {
@@ -347,41 +310,30 @@ func (s *Server) ensureGitHubWorkspace(ctx context.Context, token, userID string
 	return s.store.EnsureDefaultGuestWorkspaceMember(ctx, userID, role)
 }
 
-func (s *Server) exchangeGitHubCode(ctx context.Context, r *http.Request, code string) (string, error) {
-	body := url.Values{
-		"client_id":     {s.githubOAuth.ClientID},
-		"client_secret": {s.githubOAuth.ClientSecret},
-		"code":          {code},
-		"redirect_uri":  {s.githubRedirectURL(r)},
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.githubOAuth.TokenURL, strings.NewReader(body.Encode()))
+func (s *Server) exchangeGitHubCode(ctx context.Context, code, verifier, redirectURL string) (string, error) {
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, s.githubOAuth.HTTPClient)
+	token, err := s.oauth2Config(redirectURL).Exchange(ctx, code, oauth2.VerifierOption(verifier))
 	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := s.githubOAuth.HTTPClient.Do(req)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode >= 300 {
 		return "", errors.New("github token exchange failed")
 	}
-	var out struct {
-		AccessToken string `json:"access_token"`
-		Error       string `json:"error"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		return "", err
-	}
-	if out.Error != "" {
-		return "", errors.New(out.Error)
-	}
-	if out.AccessToken == "" {
+	if token.AccessToken == "" {
 		return "", errors.New("github access token missing")
 	}
-	return out.AccessToken, nil
+	return token.AccessToken, nil
+}
+
+func (s *Server) oauth2Config(redirectURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     s.githubOAuth.ClientID,
+		ClientSecret: s.githubOAuth.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   s.githubOAuth.AuthURL,
+			TokenURL:  s.githubOAuth.TokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		RedirectURL: redirectURL,
+		Scopes:      strings.Fields(s.githubScope()),
+	}
 }
 
 type githubProfile struct {
@@ -497,16 +449,19 @@ func (s *Server) githubScope() string {
 	return scope
 }
 
-func (s *Server) githubRedirectURL(r *http.Request) string {
+func (s *Server) githubRedirectURL(r *http.Request) (string, error) {
 	base := strings.TrimRight(s.githubOAuth.PublicURL, "/")
 	if base == "" {
+		if s.disableDevAuth || !isLocalHostPort(r.Host) || !isLocalHostPort(r.RemoteAddr) {
+			return "", errors.New("github oauth requires a configured public URL")
+		}
 		scheme := "http"
 		if r.TLS != nil {
 			scheme = "https"
 		}
 		base = scheme + "://" + r.Host
 	}
-	return base + "/api/auth/github/callback"
+	return base + "/api/auth/github/callback", nil
 }
 
 func (s *Server) setSessionCookie(w http.ResponseWriter, r *http.Request, session store.Session) {
@@ -531,12 +486,41 @@ func (s *Server) secureCookies(r *http.Request) bool {
 	return !(!s.disableDevAuth && isLocalHostPort(r.RemoteAddr) && isLocalHostPort(r.Host))
 }
 
-func randomToken() (string, error) {
-	var data [16]byte
-	if _, err := rand.Read(data[:]); err != nil {
+func (s *Server) oauthBrowserBinding(w http.ResponseWriter, r *http.Request) (string, error) {
+	if cookie, err := requestCookie(r, s.cookies.OAuthBinding); err == nil && validDesktopCode(cookie.Value, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		return cookie.Value, nil
+	} else if errors.Is(err, errAmbiguousCookie) {
 		return "", err
 	}
-	return hex.EncodeToString(data[:]), nil
+	binding, err := randomOAuthSecret()
+	if err != nil {
+		return "", err
+	}
+	maxAge := int(oauthBrowserBindingTTL / time.Second)
+	http.SetCookie(w, &http.Cookie{
+		Name:     s.cookies.OAuthBinding,
+		Value:    binding,
+		Path:     "/",
+		MaxAge:   maxAge,
+		Expires:  time.Now().UTC().Add(oauthBrowserBindingTTL),
+		HttpOnly: true,
+		Secure:   s.secureCookies(r),
+		SameSite: http.SameSiteLaxMode,
+	})
+	return binding, nil
+}
+
+func randomOAuthSecret() (string, error) {
+	data := make([]byte, oauthSecretBytes)
+	if _, err := rand.Read(data); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func secretHash(value string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(value)))
+	return hex.EncodeToString(sum[:])
 }
 
 func firstNonEmpty(values ...string) string {

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -136,17 +137,17 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "browser binding", err)
 		return
 	}
 	state, err := randomOAuthSecret()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "state generation", err)
 		return
 	}
 	pkceVerifier, err := randomOAuthSecret()
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "PKCE generation", err)
 		return
 	}
 	mode := store.OAuthModeBrowser
@@ -170,7 +171,7 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 			return
 		}
 		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "transaction creation", err)
 		return
 	}
 	http.Redirect(w, r, s.oauth2Config(redirectURL).AuthCodeURL(state, oauth2.S256ChallengeOption(pkceVerifier)), http.StatusFound)
@@ -196,7 +197,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "transaction consumption", err)
 		return
 	}
 	code := strings.TrimSpace(r.URL.Query().Get("code"))
@@ -239,17 +240,17 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 		AvatarURL:       profile.AvatarURL,
 	})
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err)
+		s.writeGitHubOAuthServerError(w, r, "identity provisioning", err)
 		return
 	}
 	if _, err := s.ensureGitHubWorkspace(r.Context(), token, user.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "workspace provisioning", err)
 		return
 	}
 	if transaction.Mode == store.OAuthModeBrowser {
 		session, err := s.store.CreateSession(r.Context(), user.ID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err)
+			s.writeGitHubOAuthServerError(w, r, "browser session creation", err)
 			return
 		}
 		s.setSessionCookie(w, r, session)
@@ -263,7 +264,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	grantCode, err := newDesktopOAuthGrantCode(transaction.DesktopProtocol)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "desktop grant generation", err)
 		return
 	}
 	now := time.Now().UTC()
@@ -279,7 +280,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusServiceUnavailable, err)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "desktop grant creation", err)
 		return
 	}
 	s.recordGitHubOAuthEvent(githubOAuthEventDesktopGrantCreated)
@@ -333,12 +334,17 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
-		writeError(w, http.StatusInternalServerError, err)
+		s.writeGitHubOAuthServerError(w, r, "desktop grant consumption", err)
 		return
 	}
 	s.setSessionCookie(w, r, session)
 	s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeSucceeded)
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+func (s *Server) writeGitHubOAuthServerError(w http.ResponseWriter, r *http.Request, phase string, err error) {
+	log.Printf("github oauth %s failed correlation_id=%q error_type=%T", phase, correlationIDFromContext(r.Context()), err)
+	writeError(w, http.StatusInternalServerError, errors.New("github oauth request failed"))
 }
 
 func desktopCodeChallenge(verifier string) string {

--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -47,6 +47,22 @@ const (
 	oauthEncodedSecretLength      = 43
 )
 
+const (
+	githubOAuthEventBrowserStart            = "browser_start"
+	githubOAuthEventDesktopStart            = "desktop_start"
+	githubOAuthEventStartRejected           = "start_rejected"
+	githubOAuthEventCapacityRejected        = "capacity_rejected"
+	githubOAuthEventStateRejected           = "state_rejected"
+	githubOAuthEventProviderFailed          = "provider_failed"
+	githubOAuthEventOrgDenied               = "org_denied"
+	githubOAuthEventBrowserSucceeded        = "browser_succeeded"
+	githubOAuthEventDesktopGrantCreated     = "desktop_grant_created"
+	githubOAuthEventDesktopProtocolRejected = "desktop_protocol_rejected"
+	githubOAuthEventDesktopUpgradeRequired  = "desktop_upgrade_required"
+	githubOAuthEventDesktopConsumeRejected  = "desktop_consume_rejected"
+	githubOAuthEventDesktopConsumeSucceeded = "desktop_consume_succeeded"
+)
+
 func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
 	if c.AuthURL == "" {
 		c.AuthURL = "https://github.com/login/oauth/authorize"
@@ -70,21 +86,26 @@ func (c GitHubOAuthConfig) withDefaults() GitHubOAuthConfig {
 }
 
 func (s *Server) githubStart(w http.ResponseWriter, r *http.Request) {
+	s.recordGitHubOAuthEvent(githubOAuthEventBrowserStart)
 	s.startGitHubOAuth(w, r, "", 0)
 }
 
 func (s *Server) githubDesktopStart(w http.ResponseWriter, r *http.Request) {
+	s.recordGitHubOAuthEvent(githubOAuthEventDesktopStart)
 	challenge := strings.TrimSpace(r.URL.Query().Get("code_challenge"))
 	if !validDesktopCode(challenge, 43, 43) {
+		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
 		writeError(w, http.StatusBadRequest, errors.New("valid desktop oauth code challenge is required"))
 		return
 	}
 	protocol, err := desktopProtocolVersion(r.URL.Query().Get("desktop_protocol"))
 	if err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventDesktopProtocolRejected)
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
 	if s.cookies.Session != "cc_session" && protocol < 2 {
+		s.recordGitHubOAuthEvent(githubOAuthEventDesktopUpgradeRequired)
 		writeDesktopUpgradeRequired(w)
 		return
 	}
@@ -93,16 +114,19 @@ func (s *Server) githubDesktopStart(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, desktopChallenge string, desktopProtocol int64) {
 	if s.githubOAuth.ClientID == "" || s.githubOAuth.ClientSecret == "" {
+		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
 		writeError(w, http.StatusNotImplemented, errors.New("github oauth is not configured"))
 		return
 	}
 	redirectURL, err := s.githubRedirectURL(r)
 	if err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
 		writeError(w, http.StatusServiceUnavailable, err)
 		return
 	}
 	browserBinding, err := s.oauthBrowserBinding(w, r)
 	if err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
 		if errors.Is(err, errAmbiguousCookie) {
 			writeError(w, http.StatusBadRequest, err)
 			return
@@ -136,9 +160,11 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 		ExpiresAt:          now.Add(oauthTransactionTTL),
 	}); err != nil {
 		if errors.Is(err, store.ErrOAuthCapacityExceeded) {
+			s.recordGitHubOAuthEvent(githubOAuthEventCapacityRejected)
 			writeError(w, http.StatusServiceUnavailable, err)
 			return
 		}
+		s.recordGitHubOAuthEvent(githubOAuthEventStartRejected)
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
@@ -148,17 +174,20 @@ func (s *Server) startGitHubOAuth(w http.ResponseWriter, r *http.Request, deskto
 func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 	state := strings.TrimSpace(r.URL.Query().Get("state"))
 	if !validDesktopCode(state, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		s.recordGitHubOAuthEvent(githubOAuthEventStateRejected)
 		writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 		return
 	}
 	bindingCookie, err := requestCookie(r, s.cookies.OAuthBinding)
 	if err != nil || !validDesktopCode(bindingCookie.Value, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		s.recordGitHubOAuthEvent(githubOAuthEventStateRejected)
 		writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 		return
 	}
 	transaction, err := s.store.ConsumeOAuthTransaction(r.Context(), secretHash(state), secretHash(bindingCookie.Value), time.Now().UTC())
 	if err != nil {
 		if errors.Is(err, store.ErrOAuthTransactionInvalid) {
+			s.recordGitHubOAuthEvent(githubOAuthEventStateRejected)
 			writeError(w, http.StatusBadRequest, errors.New("invalid github oauth state"))
 			return
 		}
@@ -177,19 +206,23 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	token, err := s.exchangeGitHubCode(r.Context(), code, transaction.PKCEVerifier, redirectURL)
 	if err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
 		writeError(w, http.StatusBadGateway, err)
 		return
 	}
 	profile, err := s.fetchGitHubProfile(r.Context(), token)
 	if err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
 		writeError(w, http.StatusBadGateway, err)
 		return
 	}
 	if err := s.ensureGitHubAllowedOrgMembership(r.Context(), token); err != nil {
 		if errors.Is(err, errGitHubOrgDenied) {
+			s.recordGitHubOAuthEvent(githubOAuthEventOrgDenied)
 			writeError(w, http.StatusForbidden, err)
 			return
 		}
+		s.recordGitHubOAuthEvent(githubOAuthEventProviderFailed)
 		writeError(w, http.StatusBadGateway, err)
 		return
 	}
@@ -215,6 +248,7 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.setSessionCookie(w, r, session)
+		s.recordGitHubOAuthEvent(githubOAuthEventBrowserSucceeded)
 		http.Redirect(w, r, "/", http.StatusFound)
 		return
 	}
@@ -236,12 +270,14 @@ func (s *Server) githubCallback(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt:        now.Add(desktopOAuthGrantTTL),
 	}); err != nil {
 		if errors.Is(err, store.ErrOAuthCapacityExceeded) {
+			s.recordGitHubOAuthEvent(githubOAuthEventCapacityRejected)
 			writeError(w, http.StatusServiceUnavailable, err)
 			return
 		}
 		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	s.recordGitHubOAuthEvent(githubOAuthEventDesktopGrantCreated)
 	http.Redirect(w, r, desktopOAuthCallback(transaction.DesktopProtocol, grantCode), http.StatusFound)
 }
 
@@ -268,6 +304,7 @@ func writeDesktopUpgradeRequired(w http.ResponseWriter) {
 
 func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 	if !s.requireSameOriginJSON(w, r) {
+		s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeRejected)
 		return
 	}
 	var body struct {
@@ -275,16 +312,19 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 		Verifier string `json:"code_verifier"`
 	}
 	if err := readJSON(w, r, &body); err != nil {
+		s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeRejected)
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
 	if !validOAuthGrantCode(body.Code) || !validDesktopCode(body.Verifier, 43, 128) {
+		s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeRejected)
 		writeError(w, http.StatusBadRequest, errors.New("invalid desktop oauth grant"))
 		return
 	}
 	session, err := s.store.ConsumeDesktopOAuthGrant(r.Context(), secretHash(body.Code), desktopCodeChallenge(body.Verifier), time.Now().UTC())
 	if err != nil {
 		if errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+			s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeRejected)
 			writeError(w, http.StatusBadRequest, err)
 			return
 		}
@@ -292,6 +332,7 @@ func (s *Server) githubDesktopConsume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.setSessionCookie(w, r, session)
+	s.recordGitHubOAuthEvent(githubOAuthEventDesktopConsumeSucceeded)
 	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -1184,6 +1184,17 @@ func TestGitHubOAuthDoesNotExposeInternalStoreErrors(t *testing.T) {
 	if !strings.Contains(body, "github oauth request failed") {
 		t.Fatalf("unexpected public OAuth error: %s", body)
 	}
+
+	providerRecorder := httptest.NewRecorder()
+	api := New(base, realtime.NewHub(), Options{})
+	api.writeGitHubOAuthProviderError(providerRecorder, request, "profile fetch", errors.New("dial database.internal with token=secret"))
+	providerBody := providerRecorder.Body.String()
+	if providerRecorder.Code != http.StatusBadGateway || strings.Contains(providerBody, "database.internal") || strings.Contains(providerBody, "secret") {
+		t.Fatalf("provider OAuth error leaked to client: %d %s", providerRecorder.Code, providerBody)
+	}
+	if !strings.Contains(providerBody, "github authentication provider request failed") {
+		t.Fatalf("unexpected public provider error: %s", providerBody)
+	}
 }
 
 type failingOAuthTransactionStore struct {

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -172,6 +172,80 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestLegacyDesktopOAuthFlow(t *testing.T) {
+	t.Parallel()
+	st := newEmptyHTTPStore(t)
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "legacy-token"})
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 78, "login": "legacy", "email": "legacy@example.com"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(provider.Close)
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{
+		ClientID:     "client",
+		ClientSecret: "secret",
+		AuthURL:      provider.URL + "/authorize",
+		TokenURL:     provider.URL + "/token",
+		UserURL:      provider.URL + "/user",
+		EmailsURL:    provider.URL + "/emails",
+	}}).Handler())
+	t.Cleanup(server.Close)
+	client := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }}
+
+	verifier := strings.Repeat("l", 43)
+	challenge := desktopCodeChallenge(verifier)
+	resp, err := client.Get(server.URL + "/api/auth/github/desktop/start?code_challenge=" + challenge)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, bindingCookie, _ := oauthStartResponse(t, resp)
+	resp.Body.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(bindingCookie)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callback, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grantCode := callback.Query().Get("code")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound || callback.Scheme != "clickclack" || callback.Host != "auth" || callback.Path != "/callback" || len(grantCode) != 32 || !validOAuthGrantCode(grantCode) {
+		t.Fatalf("unexpected legacy desktop callback: %s %s", resp.Status, callback.String())
+	}
+
+	body, err := json.Marshal(map[string]string{"code": grantCode, "code_verifier": verifier})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err = http.NewRequest(http.MethodPost, server.URL+"/api/auth/github/desktop/consume", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionCookie := findCookie(resp.Cookies(), "cc_session")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || sessionCookie == nil || sessionCookie.Value == "" {
+		t.Fatalf("legacy desktop consume did not create a session: %s %#v", resp.Status, sessionCookie)
+	}
+}
+
 func TestDesktopOAuthProtocolCompatibility(t *testing.T) {
 	t.Parallel()
 	st := newEmptyHTTPStore(t)

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -83,7 +83,7 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 
 	verifier := strings.Repeat("v", 43)
 	challenge := desktopCodeChallenge(verifier)
-	resp, err := client.Get(server.URL + "/api/auth/github/desktop/start?code_challenge=" + challenge)
+	resp, err := client.Get(server.URL + "/api/auth/github/desktop/start?code_challenge=" + challenge + "&desktop_protocol=2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	grantCode := callback.Query().Get("code")
-	if resp.StatusCode != http.StatusFound || callback.Scheme != "clickclack" || callback.Host != "auth" || callback.Path != "/callback" || !validDesktopCode(grantCode, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+	if resp.StatusCode != http.StatusFound || callback.Scheme != "chat.clickclack.desktop" || callback.Host != "" || callback.Path != "/auth/callback" || !validDesktopCode(grantCode, oauthEncodedSecretLength, oauthEncodedSecretLength) {
 		t.Fatalf("unexpected desktop callback: %s %s", resp.Status, callback.String())
 	}
 	if cookie := findCookie(resp.Cookies(), "cc_session"); cookie != nil {
@@ -170,6 +170,76 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		t.Fatalf("expected one-time grant rejection, got %s", resp.Status)
 	}
 	resp.Body.Close()
+}
+
+func TestDesktopOAuthProtocolCompatibility(t *testing.T) {
+	t.Parallel()
+	st := newEmptyHTTPStore(t)
+	challenge := strings.Repeat("a", 43)
+	defaultServer := New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{
+		ClientID:     "client",
+		ClientSecret: "secret",
+		AuthURL:      "https://github.example/authorize",
+	}}).Handler()
+	legacyRequest := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/auth/github/desktop/start?code_challenge="+challenge, nil)
+	legacyRequest.RemoteAddr = "127.0.0.1:12345"
+	legacyRecorder := httptest.NewRecorder()
+	defaultServer.ServeHTTP(legacyRecorder, legacyRequest)
+	if legacyRecorder.Code != http.StatusFound {
+		t.Fatalf("expected legacy desktop protocol on the default cookie server, got %d", legacyRecorder.Code)
+	}
+
+	names, err := authpolicy.NewCookieNames("prod", "https://chat.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	namespacedServer := New(st, realtime.NewHub(), Options{
+		CookieNames: names,
+		GitHubOAuth: GitHubOAuthConfig{
+			ClientID:     "client",
+			ClientSecret: "secret",
+			PublicURL:    "https://chat.example.com",
+			AuthURL:      "https://github.example/authorize",
+		},
+	}).Handler()
+	oldRequest := httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/auth/github/desktop/start?code_challenge="+challenge, nil)
+	oldRecorder := httptest.NewRecorder()
+	namespacedServer.ServeHTTP(oldRecorder, oldRequest)
+	if oldRecorder.Code != http.StatusUpgradeRequired || oldRecorder.Header().Get("Cache-Control") != "no-store" || !strings.Contains(oldRecorder.Body.String(), "Update ClickClack") {
+		t.Fatalf("expected early desktop upgrade response, got %d %q", oldRecorder.Code, oldRecorder.Body.String())
+	}
+	if oldRecorder.Header().Get("Location") != "" {
+		t.Fatalf("old desktop client was redirected to GitHub: %q", oldRecorder.Header().Get("Location"))
+	}
+
+	newRequest := httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/auth/github/desktop/start?code_challenge="+challenge+"&desktop_protocol=2", nil)
+	newRecorder := httptest.NewRecorder()
+	namespacedServer.ServeHTTP(newRecorder, newRequest)
+	if newRecorder.Code != http.StatusFound {
+		t.Fatalf("expected protocol 2 namespaced start, got %d %s", newRecorder.Code, newRecorder.Body.String())
+	}
+
+	invalidRequest := httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/auth/github/desktop/start?code_challenge="+challenge+"&desktop_protocol=3", nil)
+	invalidRecorder := httptest.NewRecorder()
+	namespacedServer.ServeHTTP(invalidRecorder, invalidRequest)
+	if invalidRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected unsupported protocol rejection, got %d", invalidRecorder.Code)
+	}
+
+	legacyGrant, err := newDesktopOAuthGrantCode(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validOAuthGrantCode(legacyGrant) || len(legacyGrant) != 32 {
+		t.Fatalf("invalid legacy desktop grant %q", legacyGrant)
+	}
+	legacyCallback, err := url.Parse(desktopOAuthCallback(1, legacyGrant))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacyCallback.Scheme != "clickclack" || legacyCallback.Host != "auth" || legacyCallback.Path != "/callback" || legacyCallback.Query().Get("code") != legacyGrant {
+		t.Fatalf("unexpected legacy desktop callback %s", legacyCallback)
+	}
 }
 
 func TestGitHubOAuthFlow(t *testing.T) {

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -1085,6 +1085,42 @@ func TestGitHubOAuthErrors(t *testing.T) {
 	}
 }
 
+func TestGitHubOAuthDoesNotExposeInternalStoreErrors(t *testing.T) {
+	t.Parallel()
+	base := newEmptyHTTPStore(t)
+	handler := New(failingOAuthTransactionStore{
+		Store: base,
+		err:   errors.New(`postgres://admin:secret@database.internal:5432/clickclack`),
+	}, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{
+		ClientID:     "client",
+		ClientSecret: "secret",
+		AuthURL:      "https://github.example/authorize",
+	}}).Handler()
+	request := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/auth/github/start", nil)
+	request.RemoteAddr = "127.0.0.1:12345"
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("expected internal error, got %d", recorder.Code)
+	}
+	body := recorder.Body.String()
+	if strings.Contains(body, "admin") || strings.Contains(body, "secret") || strings.Contains(body, "database.internal") {
+		t.Fatalf("internal OAuth error leaked to client: %s", body)
+	}
+	if !strings.Contains(body, "github oauth request failed") {
+		t.Fatalf("unexpected public OAuth error: %s", body)
+	}
+}
+
+type failingOAuthTransactionStore struct {
+	store.Store
+	err error
+}
+
+func (s failingOAuthTransactionStore) CreateOAuthTransaction(context.Context, store.OAuthTransaction) error {
+	return s.err
+}
+
 func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
 	for _, cookie := range cookies {
 		if cookie.Name == name {

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -193,7 +193,7 @@ func TestDesktopOAuthProtocolCompatibility(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	namespacedServer := New(st, realtime.NewHub(), Options{
+	namespacedAPI := New(st, realtime.NewHub(), Options{
 		CookieNames: names,
 		GitHubOAuth: GitHubOAuthConfig{
 			ClientID:     "client",
@@ -201,7 +201,9 @@ func TestDesktopOAuthProtocolCompatibility(t *testing.T) {
 			PublicURL:    "https://chat.example.com",
 			AuthURL:      "https://github.example/authorize",
 		},
-	}).Handler()
+		MetricsEnabled: true,
+	})
+	namespacedServer := namespacedAPI.Handler()
 	oldRequest := httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/auth/github/desktop/start?code_challenge="+challenge, nil)
 	oldRecorder := httptest.NewRecorder()
 	namespacedServer.ServeHTTP(oldRecorder, oldRequest)
@@ -224,6 +226,16 @@ func TestDesktopOAuthProtocolCompatibility(t *testing.T) {
 	namespacedServer.ServeHTTP(invalidRecorder, invalidRequest)
 	if invalidRecorder.Code != http.StatusBadRequest {
 		t.Fatalf("expected unsupported protocol rejection, got %d", invalidRecorder.Code)
+	}
+	metrics := namespacedAPI.metrics.render(buildMetadata{})
+	for _, expected := range []string{
+		`clickclack_github_oauth_events_total{event="desktop_start"} 3`,
+		`clickclack_github_oauth_events_total{event="desktop_upgrade_required"} 1`,
+		`clickclack_github_oauth_events_total{event="desktop_protocol_rejected"} 1`,
+	} {
+		if !strings.Contains(metrics, expected) {
+			t.Fatalf("OAuth metrics missing %q:\n%s", expected, metrics)
+		}
 	}
 
 	legacyGrant, err := newDesktopOAuthGrantCode(1)

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"log"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
 	"github.com/openclaw/clickclack/apps/api/internal/realtime"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
@@ -46,9 +48,19 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tokenRequests := make(chan oauthTokenRequest, 4)
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/token":
+			if err := r.ParseForm(); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			tokenRequests <- oauthTokenRequest{
+				RedirectURL: r.FormValue("redirect_uri"),
+				Verifier:    r.FormValue("code_verifier"),
+			}
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "d-token"})
 		case "/user":
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": 77, "login": "desktop", "email": "desktop@example.com"})
@@ -78,21 +90,17 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 	if resp.StatusCode != http.StatusFound || !strings.HasPrefix(resp.Header.Get("Location"), provider.URL+"/authorize?") {
 		t.Fatalf("unexpected desktop start response: %s %s", resp.Status, resp.Header.Get("Location"))
 	}
-	stateCookie := findCookie(resp.Cookies(), "cc_github_state")
-	desktopCookie := findCookie(resp.Cookies(), "cc_github_desktop_state")
-	challengeCookie := findCookie(resp.Cookies(), "cc_github_desktop_challenge")
+	state, bindingCookie, authorizationURL := oauthStartResponse(t, resp)
 	resp.Body.Close()
-	if stateCookie == nil || desktopCookie == nil || desktopCookie.Value != stateCookie.Value || challengeCookie == nil || challengeCookie.Value != challenge {
-		t.Fatalf("expected matching desktop state and challenge cookies, got %#v %#v %#v", stateCookie, desktopCookie, challengeCookie)
+	if authorizationURL.Query().Get("code_challenge_method") != "S256" || authorizationURL.Query().Get("code_challenge") == "" {
+		t.Fatalf("expected GitHub PKCE challenge, got %s", authorizationURL.String())
 	}
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+stateCookie.Value, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.AddCookie(stateCookie)
-	req.AddCookie(desktopCookie)
-	req.AddCookie(challengeCookie)
+	req.AddCookie(bindingCookie)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -102,16 +110,23 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	grantCode := callback.Query().Get("code")
-	if resp.StatusCode != http.StatusFound || callback.Scheme != "clickclack" || callback.Host != "auth" || callback.Path != "/callback" || !validDesktopCode(grantCode, 32, 32) {
+	if resp.StatusCode != http.StatusFound || callback.Scheme != "clickclack" || callback.Host != "auth" || callback.Path != "/callback" || !validDesktopCode(grantCode, oauthEncodedSecretLength, oauthEncodedSecretLength) {
 		t.Fatalf("unexpected desktop callback: %s %s", resp.Status, callback.String())
 	}
 	if cookie := findCookie(resp.Cookies(), "cc_session"); cookie != nil {
 		t.Fatalf("desktop callback leaked a browser session cookie: %#v", cookie)
 	}
-	if cookie := findCookie(resp.Cookies(), "cc_github_desktop_challenge"); cookie == nil || cookie.MaxAge >= 0 {
-		t.Fatalf("expected desktop challenge cookie to be cleared, got %#v", cookie)
-	}
 	resp.Body.Close()
+	tokenRequest := <-tokenRequests
+	if tokenRequest.RedirectURL != server.URL+"/api/auth/github/callback" {
+		t.Fatalf("unexpected token redirect URI %q", tokenRequest.RedirectURL)
+	}
+	if desktopCodeChallenge(tokenRequest.Verifier) != authorizationURL.Query().Get("code_challenge") {
+		t.Fatal("token exchange verifier did not match the authorization PKCE challenge")
+	}
+
+	consumeServer := httptest.NewServer(New(st, realtime.NewHub(), Options{}).Handler())
+	t.Cleanup(consumeServer.Close)
 
 	consume := func(origin, candidateVerifier string) *http.Response {
 		t.Helper()
@@ -119,7 +134,7 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		req, err := http.NewRequest(http.MethodPost, server.URL+"/api/auth/github/desktop/consume", bytes.NewReader(body))
+		req, err := http.NewRequest(http.MethodPost, consumeServer.URL+"/api/auth/github/desktop/consume", bytes.NewReader(body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,18 +154,18 @@ func TestGitHubDesktopOAuthFlow(t *testing.T) {
 		t.Fatalf("expected cross-site consume rejection, got %s", resp.Status)
 	}
 	resp.Body.Close()
-	resp = consume(server.URL, strings.Repeat("x", 43))
+	resp = consume(consumeServer.URL, strings.Repeat("x", 43))
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected wrong verifier rejection, got %s", resp.Status)
 	}
 	resp.Body.Close()
-	resp = consume(server.URL, verifier)
+	resp = consume(consumeServer.URL, verifier)
 	sessionCookie := findCookie(resp.Cookies(), "cc_session")
 	if resp.StatusCode != http.StatusOK || sessionCookie == nil || sessionCookie.Value == "" {
 		t.Fatalf("expected desktop session cookie, got %s %#v", resp.Status, sessionCookie)
 	}
 	resp.Body.Close()
-	resp = consume(server.URL, verifier)
+	resp = consume(consumeServer.URL, verifier)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected one-time grant rejection, got %s", resp.Status)
 	}
@@ -170,11 +185,17 @@ func TestGitHubOAuthFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tokenRequests := make(chan oauthTokenRequest, 16)
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/token":
+			w.Header().Set("Content-Type", "application/json")
 			if err := r.ParseForm(); err != nil {
 				t.Fatal(err)
+			}
+			tokenRequests <- oauthTokenRequest{
+				RedirectURL: r.FormValue("redirect_uri"),
+				Verifier:    r.FormValue("code_verifier"),
 			}
 			switch r.FormValue("code") {
 			case "ok":
@@ -223,22 +244,31 @@ func TestGitHubOAuthFlow(t *testing.T) {
 	if resp.StatusCode != http.StatusFound || !strings.HasPrefix(resp.Header.Get("Location"), provider.URL+"/authorize?") {
 		t.Fatalf("unexpected start response: %s %s", resp.Status, resp.Header.Get("Location"))
 	}
-	var stateCookie *http.Cookie
-	for _, cookie := range resp.Cookies() {
-		if cookie.Name == "cc_github_state" {
-			stateCookie = cookie
-		}
-	}
+	state, bindingCookie, authorizationURL := oauthStartResponse(t, resp)
 	resp.Body.Close()
-	if stateCookie == nil || stateCookie.Value == "" {
-		t.Fatal("expected github state cookie")
+	if authorizationURL.Query().Get("code_challenge_method") != "S256" || authorizationURL.Query().Get("code_challenge") == "" {
+		t.Fatalf("expected GitHub PKCE challenge, got %s", authorizationURL.String())
 	}
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+stateCookie.Value, nil)
+	wrongBindingRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.AddCookie(stateCookie)
+	wrongBindingRequest.AddCookie(&http.Cookie{Name: bindingCookie.Name, Value: strings.Repeat("x", oauthEncodedSecretLength)})
+	wrongBindingResponse, err := client.Do(wrongBindingRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongBindingResponse.Body.Close()
+	if wrongBindingResponse.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected wrong browser binding rejection, got %s", wrongBindingResponse.Status)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+state, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(bindingCookie)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -256,11 +286,13 @@ func TestGitHubOAuthFlow(t *testing.T) {
 	if sessionCookie == nil || sessionCookie.Value == "" {
 		t.Fatal("expected session cookie")
 	}
-	clearedStateCookie := findCookie(resp.Cookies(), "cc_github_state")
-	if clearedStateCookie == nil || clearedStateCookie.MaxAge >= 0 {
-		t.Fatalf("expected github state cookie to be cleared, got %#v", clearedStateCookie)
+	tokenRequest := <-tokenRequests
+	if tokenRequest.RedirectURL != server.URL+"/api/auth/github/callback" {
+		t.Fatalf("unexpected token redirect URI %q", tokenRequest.RedirectURL)
 	}
-
+	if desktopCodeChallenge(tokenRequest.Verifier) != authorizationURL.Query().Get("code_challenge") {
+		t.Fatal("token exchange verifier did not match the authorization PKCE challenge")
+	}
 	req, err = http.NewRequest(http.MethodGet, server.URL+"/api/me", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -337,7 +369,13 @@ func TestGitHubOAuthFlow(t *testing.T) {
 		{"missing profile id", "missing-id", http.StatusBadGateway},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			path := server.URL + "/api/auth/github/callback?state=" + stateCookie.Value
+			startResp, err := client.Get(server.URL + "/api/auth/github/start")
+			if err != nil {
+				t.Fatal(err)
+			}
+			testState, testBinding, _ := oauthStartResponse(t, startResp)
+			startResp.Body.Close()
+			path := server.URL + "/api/auth/github/callback?state=" + testState
 			if tc.code != "" {
 				path += "&code=" + tc.code
 			}
@@ -345,7 +383,7 @@ func TestGitHubOAuthFlow(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			req.AddCookie(stateCookie)
+			req.AddCookie(testBinding)
 			resp, err := client.Do(req)
 			if err != nil {
 				t.Fatal(err)
@@ -368,8 +406,180 @@ func TestGitHubOAuthFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	srv := New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{PublicURL: "https://public.example"}})
-	if got := srv.githubRedirectURL(req); got != "https://public.example/api/auth/github/callback" {
+	if got, err := srv.githubRedirectURL(req); err != nil || got != "https://public.example/api/auth/github/callback" {
 		t.Fatalf("unexpected public redirect url %q", got)
+	}
+}
+
+func TestNamespacedOAuthSessionsCoexistAcrossSameHostPorts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "shared-token"})
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 91, "login": "shared", "email": "shared@example.com"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(provider.Close)
+
+	newInstance := func(namespace string) (*httptest.Server, *sqlitestore.Store, authpolicy.CookieNames) {
+		t.Helper()
+		st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), namespace+".db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = st.Close() })
+		if err := st.Migrate(ctx); err != nil {
+			t.Fatal(err)
+		}
+		var handler http.Handler
+		server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler.ServeHTTP(w, r)
+		}))
+		t.Cleanup(server.Close)
+		names, err := authpolicy.NewCookieNames(namespace, server.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler = New(st, realtime.NewHub(), Options{
+			CookieNames:    names,
+			DisableDevAuth: true,
+			GitHubOAuth: GitHubOAuthConfig{
+				ClientID:     "client",
+				ClientSecret: "secret",
+				PublicURL:    server.URL,
+				AuthURL:      provider.URL + "/authorize",
+				TokenURL:     provider.URL + "/token",
+				UserURL:      provider.URL + "/user",
+				EmailsURL:    provider.URL + "/emails",
+			},
+		}).Handler()
+		return server, st, names
+	}
+
+	first, _, firstNames := newInstance("first")
+	second, _, secondNames := newInstance("second")
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+		Jar:           jar,
+		Transport:     &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}},
+	}
+	signIn := func(server *httptest.Server, names authpolicy.CookieNames) {
+		t.Helper()
+		resp, err := client.Get(server.URL + "/api/auth/github/start")
+		if err != nil {
+			t.Fatal(err)
+		}
+		state, _, _ := oauthStartResponseWithCookieName(t, resp, names.OAuthBinding)
+		resp.Body.Close()
+		resp, err = client.Get(server.URL + "/api/auth/github/callback?code=ok&state=" + state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusFound || findCookie(resp.Cookies(), names.Session) == nil {
+			t.Fatalf("expected namespaced session from %s, got %s %#v", server.URL, resp.Status, resp.Cookies())
+		}
+	}
+	signIn(first, firstNames)
+	signIn(second, secondNames)
+
+	for _, server := range []*httptest.Server{first, second} {
+		resp, err := client.Get(server.URL + "/api/me")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("expected independent session at %s, got %s", server.URL, resp.Status)
+		}
+	}
+	firstURL, _ := url.Parse(first.URL)
+	cookies := jar.Cookies(firstURL)
+	if findCookie(cookies, firstNames.Session) == nil || findCookie(cookies, secondNames.Session) == nil {
+		t.Fatalf("expected both port-shared cookies to coexist, got %#v", cookies)
+	}
+}
+
+func TestGitHubOAuthAllowsConcurrentStartsForOneBrowser(t *testing.T) {
+	t.Parallel()
+	st := newEmptyHTTPStore(t)
+	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": r.FormValue("code")})
+		case "/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": 92, "login": "concurrent", "email": "concurrent@example.com"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(provider.Close)
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{
+		ClientID:     "client",
+		ClientSecret: "secret",
+		AuthURL:      provider.URL + "/authorize",
+		TokenURL:     provider.URL + "/token",
+		UserURL:      provider.URL + "/user",
+		EmailsURL:    provider.URL + "/emails",
+	}}).Handler())
+	t.Cleanup(server.Close)
+	client := &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }}
+
+	firstResponse, err := client.Get(server.URL + "/api/auth/github/start")
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstState, bindingCookie, _ := oauthStartResponse(t, firstResponse)
+	firstResponse.Body.Close()
+
+	secondRequest, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/start", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRequest.AddCookie(bindingCookie)
+	secondResponse, err := client.Do(secondRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondURL, err := url.Parse(secondResponse.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondState := secondURL.Query().Get("state")
+	secondResponse.Body.Close()
+	if !validDesktopCode(secondState, oauthEncodedSecretLength, oauthEncodedSecretLength) || secondState == firstState {
+		t.Fatalf("unexpected concurrent state values %q and %q", firstState, secondState)
+	}
+
+	for _, state := range []string{firstState, secondState} {
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code="+state+"&state="+state, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.AddCookie(bindingCookie)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusFound {
+			t.Fatalf("expected concurrent callback success, got %s", resp.Status)
+		}
 	}
 }
 
@@ -388,6 +598,7 @@ func TestGitHubOAuthModeratorOrgJoinsGuestWorkspaceAsModerator(t *testing.T) {
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/token":
+			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]string{"access_token": "mod-token"})
 		case "/user":
 			_ = json.NewEncoder(w).Encode(map[string]any{"id": 43, "login": "mod", "email": "mod@example.com"})
@@ -423,17 +634,14 @@ func TestGitHubOAuthModeratorOrgJoinsGuestWorkspaceAsModerator(t *testing.T) {
 	if scope := location.Query().Get("scope"); scope != "read:user user:email read:org" {
 		t.Fatalf("unexpected scope %q", scope)
 	}
-	stateCookie := findCookie(resp.Cookies(), "cc_github_state")
+	state, bindingCookie, _ := oauthStartResponse(t, resp)
 	resp.Body.Close()
-	if stateCookie == nil {
-		t.Fatal("expected state cookie")
-	}
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+stateCookie.Value, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=ok&state="+state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.AddCookie(stateCookie)
+	req.AddCookie(bindingCookie)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -545,6 +753,7 @@ func TestGitHubOAuthAllowedOrg(t *testing.T) {
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/token":
+			w.Header().Set("Content-Type", "application/json")
 			if err := r.ParseForm(); err != nil {
 				t.Fatal(err)
 			}
@@ -597,17 +806,14 @@ func TestGitHubOAuthAllowedOrg(t *testing.T) {
 	if scope := location.Query().Get("scope"); scope != "read:user user:email read:org" {
 		t.Fatalf("unexpected scope %q", scope)
 	}
-	stateCookie := findCookie(resp.Cookies(), "cc_github_state")
+	state, bindingCookie, _ := oauthStartResponse(t, resp)
 	resp.Body.Close()
-	if stateCookie == nil {
-		t.Fatal("expected state cookie")
-	}
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=member&state="+stateCookie.Value, nil)
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=member&state="+state, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.AddCookie(stateCookie)
+	req.AddCookie(bindingCookie)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -642,11 +848,17 @@ func TestGitHubOAuthAllowedOrg(t *testing.T) {
 		t.Fatalf("expected default workspace membership, got %s %#v", resp.Status, workspaces.Workspaces)
 	}
 
-	req, err = http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=denied&state="+stateCookie.Value, nil)
+	resp, err = client.Get(server.URL + "/api/auth/github/start")
 	if err != nil {
 		t.Fatal(err)
 	}
-	req.AddCookie(stateCookie)
+	deniedState, deniedBinding, _ := oauthStartResponse(t, resp)
+	resp.Body.Close()
+	req, err = http.NewRequest(http.MethodGet, server.URL+"/api/auth/github/callback?code=denied&state="+deniedState, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(deniedBinding)
 	resp, err = client.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -761,13 +973,29 @@ func TestGitHubOAuthErrors(t *testing.T) {
 	expectStatus(t, http.MethodGet, server.URL+"/api/auth/github/start", nil, http.StatusNotImplemented)
 	expectStatus(t, http.MethodGet, server.URL+"/api/auth/github/callback?code=x&state=bad", nil, http.StatusBadRequest)
 
-	srv := New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{ClientID: "c", ClientSecret: "s", TokenURL: "://bad", UserURL: "://bad"}})
+	duplicateBindingServer := New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{
+		ClientID:     "c",
+		ClientSecret: "s",
+		AuthURL:      "https://github.example/authorize",
+	}}).Handler()
+	duplicateBindingRequest := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/auth/github/start", nil)
+	duplicateBindingRequest.RemoteAddr = "127.0.0.1:12345"
+	duplicateBindingRequest.AddCookie(&http.Cookie{Name: "cc_oauth_binding", Value: strings.Repeat("a", oauthEncodedSecretLength)})
+	duplicateBindingRequest.AddCookie(&http.Cookie{Name: "cc_oauth_binding", Value: strings.Repeat("b", oauthEncodedSecretLength)})
+	duplicateBindingRecorder := httptest.NewRecorder()
+	duplicateBindingServer.ServeHTTP(duplicateBindingRecorder, duplicateBindingRequest)
+	if duplicateBindingRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected duplicate OAuth binding rejection, got %d", duplicateBindingRecorder.Code)
+	}
+
+	srv := New(st, realtime.NewHub(), Options{GitHubOAuth: GitHubOAuthConfig{ClientID: "c", ClientSecret: "s", PublicURL: "https://example.test", TokenURL: "://bad", UserURL: "://bad"}})
 	req := httptest.NewRequest(http.MethodGet, "https://example.test/callback", nil)
 	req.TLS = &tls.ConnectionState{}
-	if got := srv.githubRedirectURL(req); got != "https://example.test/api/auth/github/callback" {
-		t.Fatalf("unexpected tls redirect %q", got)
+	redirectURL, err := srv.githubRedirectURL(req)
+	if err != nil || redirectURL != "https://example.test/api/auth/github/callback" {
+		t.Fatalf("unexpected tls redirect %q: %v", redirectURL, err)
 	}
-	if _, err := srv.exchangeGitHubCode(context.Background(), req, "x"); err == nil {
+	if _, err := srv.exchangeGitHubCode(context.Background(), "x", strings.Repeat("v", 43), redirectURL); err == nil {
 		t.Fatal("expected bad token url error")
 	}
 	if err := srv.githubGetJSON(context.Background(), "://bad", "token", &struct{}{}); err == nil {
@@ -782,4 +1010,33 @@ func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
 		}
 	}
 	return nil
+}
+
+type oauthTokenRequest struct {
+	RedirectURL string
+	Verifier    string
+}
+
+func oauthStartResponse(t *testing.T, response *http.Response) (string, *http.Cookie, *url.URL) {
+	return oauthStartResponseWithCookieName(t, response, "cc_oauth_binding")
+}
+
+func oauthStartResponseWithCookieName(t *testing.T, response *http.Response, bindingCookieName string) (string, *http.Cookie, *url.URL) {
+	t.Helper()
+	authorizationURL, err := url.Parse(response.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := authorizationURL.Query().Get("state")
+	if !validDesktopCode(state, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		t.Fatalf("invalid OAuth state in authorization URL: %q", state)
+	}
+	bindingCookie := findCookie(response.Cookies(), bindingCookieName)
+	if bindingCookie == nil || !validDesktopCode(bindingCookie.Value, oauthEncodedSecretLength, oauthEncodedSecretLength) {
+		t.Fatalf("missing OAuth browser binding cookie: %#v", bindingCookie)
+	}
+	if !bindingCookie.HttpOnly || bindingCookie.Path != "/" || bindingCookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("unsafe OAuth browser binding cookie: %#v", bindingCookie)
+	}
+	return state, bindingCookie, authorizationURL
 }

--- a/apps/api/internal/httpapi/observability.go
+++ b/apps/api/internal/httpapi/observability.go
@@ -65,14 +65,18 @@ type metricValue struct {
 }
 
 type metricsRegistry struct {
-	mu      sync.Mutex
-	values  map[metricKey]metricValue
-	ready   bool
-	readyMu sync.RWMutex
+	mu                sync.Mutex
+	values            map[metricKey]metricValue
+	githubOAuthEvents map[string]uint64
+	ready             bool
+	readyMu           sync.RWMutex
 }
 
 func newMetricsRegistry() *metricsRegistry {
-	return &metricsRegistry{values: make(map[metricKey]metricValue)}
+	return &metricsRegistry{
+		values:            make(map[metricKey]metricValue),
+		githubOAuthEvents: make(map[string]uint64),
+	}
 }
 
 func (m *metricsRegistry) middleware(next http.Handler) http.Handler {
@@ -108,6 +112,15 @@ func (m *metricsRegistry) readiness() bool {
 	m.readyMu.RLock()
 	defer m.readyMu.RUnlock()
 	return m.ready
+}
+
+func (s *Server) recordGitHubOAuthEvent(event string) {
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.mu.Lock()
+	s.metrics.githubOAuthEvents[event]++
+	s.metrics.mu.Unlock()
 }
 
 func (s *Server) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -147,6 +160,12 @@ func (m *metricsRegistry) render(build buildMetadata) string {
 		keys = append(keys, key)
 		values[key] = value
 	}
+	oauthEvents := make([]string, 0, len(m.githubOAuthEvents))
+	oauthEventValues := make(map[string]uint64, len(m.githubOAuthEvents))
+	for event, value := range m.githubOAuthEvents {
+		oauthEvents = append(oauthEvents, event)
+		oauthEventValues[event] = value
+	}
 	m.mu.Unlock()
 	sort.Slice(keys, func(i, j int) bool {
 		if keys[i].Method != keys[j].Method {
@@ -157,6 +176,7 @@ func (m *metricsRegistry) render(build buildMetadata) string {
 		}
 		return keys[i].StatusClass < keys[j].StatusClass
 	})
+	sort.Strings(oauthEvents)
 	var out strings.Builder
 	out.WriteString("# HELP clickclack_build_info ClickClack build metadata.\n")
 	out.WriteString("# TYPE clickclack_build_info gauge\n")
@@ -178,6 +198,11 @@ func (m *metricsRegistry) render(build buildMetadata) string {
 		fmt.Fprintf(&out, "clickclack_http_requests_total{%s} %d\n", labels, value.Count)
 		fmt.Fprintf(&out, "clickclack_http_request_duration_seconds_sum{%s} %g\n", labels, value.DurationSeconds)
 		fmt.Fprintf(&out, "clickclack_http_request_duration_seconds_count{%s} %d\n", labels, value.Count)
+	}
+	out.WriteString("# HELP clickclack_github_oauth_events_total GitHub OAuth lifecycle events by bounded event category.\n")
+	out.WriteString("# TYPE clickclack_github_oauth_events_total counter\n")
+	for _, event := range oauthEvents {
+		fmt.Fprintf(&out, "clickclack_github_oauth_events_total{event=\"%s\"} %d\n", metricLabel(event), oauthEventValues[event])
 	}
 	return out.String()
 }

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/coder/websocket"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
 	"github.com/openclaw/clickclack/apps/api/internal/realtime"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/uploadstore"
@@ -29,6 +30,7 @@ type Server struct {
 	uploadDir      string
 	uploadStorage  uploadstore.Store
 	githubOAuth    GitHubOAuthConfig
+	cookies        authpolicy.CookieNames
 	desktopOAuth   *desktopOAuthBroker
 	disableDevAuth bool
 	pushNotifier   PushNotifier
@@ -57,6 +59,7 @@ type Options struct {
 	UploadDir      string
 	UploadStorage  uploadstore.Store
 	GitHubOAuth    GitHubOAuthConfig
+	CookieNames    authpolicy.CookieNames
 	DisableDevAuth bool
 	PushNotifier   PushNotifier
 	MetricsEnabled bool
@@ -74,12 +77,17 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 	if options.MetricsEnabled {
 		metrics = newMetricsRegistry()
 	}
+	cookieNames := options.CookieNames
+	if cookieNames.Session == "" {
+		cookieNames = authpolicy.DefaultCookieNames()
+	}
 	return &Server{
 		store:          st,
 		hub:            hub,
 		uploadDir:      options.UploadDir,
 		uploadStorage:  uploadStorage,
 		githubOAuth:    options.GitHubOAuth.withDefaults(),
+		cookies:        cookieNames,
 		desktopOAuth:   newDesktopOAuthBroker(),
 		disableDevAuth: options.DisableDevAuth,
 		pushNotifier:   options.PushNotifier,
@@ -190,7 +198,7 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) requireCookieCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isSafeMethod(r.Method) || hasBearerAuth(r) || !hasSessionCookie(r) {
+		if isSafeMethod(r.Method) || hasBearerAuth(r) || !s.hasSessionCookie(r) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -215,8 +223,8 @@ func hasBearerAuth(r *http.Request) bool {
 	return strings.HasPrefix(r.Header.Get("Authorization"), "Bearer ")
 }
 
-func hasSessionCookie(r *http.Request) bool {
-	cookie, err := r.Cookie("cc_session")
+func (s *Server) hasSessionCookie(r *http.Request) bool {
+	cookie, err := r.Cookie(s.cookies.Session)
 	return err == nil && cookie.Value != ""
 }
 
@@ -1255,7 +1263,7 @@ func (s *Server) currentActor(r *http.Request) (actor, error) {
 		user, err := s.store.GetSessionUser(r.Context(), token)
 		return actor{user: user}, err
 	}
-	if cookie, err := r.Cookie("cc_session"); err == nil && cookie.Value != "" {
+	if cookie, err := r.Cookie(s.cookies.Session); err == nil && cookie.Value != "" {
 		user, err := s.store.GetSessionUser(r.Context(), cookie.Value)
 		return actor{user: user}, err
 	}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1278,7 +1278,11 @@ func (s *Server) currentActor(r *http.Request) (actor, error) {
 		user, err := s.store.GetSessionUser(r.Context(), token)
 		return actor{user: user}, err
 	}
-	if cookie, err := requestCookie(r, s.cookies.Session); err == nil && cookie.Value != "" {
+	cookie, err := requestCookie(r, s.cookies.Session)
+	if errors.Is(err, errAmbiguousCookie) {
+		return actor{}, err
+	}
+	if err == nil && cookie.Value != "" {
 		user, err := s.store.GetSessionUser(r.Context(), cookie.Value)
 		return actor{user: user}, err
 	}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -31,7 +31,6 @@ type Server struct {
 	uploadStorage  uploadstore.Store
 	githubOAuth    GitHubOAuthConfig
 	cookies        authpolicy.CookieNames
-	desktopOAuth   *desktopOAuthBroker
 	disableDevAuth bool
 	pushNotifier   PushNotifier
 	metrics        *metricsRegistry
@@ -47,6 +46,8 @@ const (
 	idleTimeout                   = 120 * time.Second
 	uploadCleanupSweepLimit       = 100
 )
+
+var errAmbiguousCookie = errors.New("multiple cookies with the same name are not allowed")
 
 type actor struct {
 	user        store.User
@@ -88,7 +89,6 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 		uploadStorage:  uploadStorage,
 		githubOAuth:    options.GitHubOAuth.withDefaults(),
 		cookies:        cookieNames,
-		desktopOAuth:   newDesktopOAuthBroker(),
 		disableDevAuth: options.DisableDevAuth,
 		pushNotifier:   options.PushNotifier,
 		metrics:        metrics,
@@ -224,8 +224,23 @@ func hasBearerAuth(r *http.Request) bool {
 }
 
 func (s *Server) hasSessionCookie(r *http.Request) bool {
-	cookie, err := r.Cookie(s.cookies.Session)
-	return err == nil && cookie.Value != ""
+	cookies := r.CookiesNamed(s.cookies.Session)
+	if len(cookies) > 1 {
+		return true
+	}
+	return len(cookies) == 1 && cookies[0].Value != ""
+}
+
+func requestCookie(r *http.Request, name string) (*http.Cookie, error) {
+	cookies := r.CookiesNamed(name)
+	switch len(cookies) {
+	case 0:
+		return nil, http.ErrNoCookie
+	case 1:
+		return cookies[0], nil
+	default:
+		return nil, errAmbiguousCookie
+	}
 }
 
 type pathOnlyLogFormatter struct {
@@ -1263,7 +1278,7 @@ func (s *Server) currentActor(r *http.Request) (actor, error) {
 		user, err := s.store.GetSessionUser(r.Context(), token)
 		return actor{user: user}, err
 	}
-	if cookie, err := r.Cookie(s.cookies.Session); err == nil && cookie.Value != "" {
+	if cookie, err := requestCookie(r, s.cookies.Session); err == nil && cookie.Value != "" {
 		user, err := s.store.GetSessionUser(r.Context(), cookie.Value)
 		return actor{user: user}, err
 	}

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
 	"github.com/openclaw/clickclack/apps/api/internal/realtime"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	postgresstore "github.com/openclaw/clickclack/apps/api/internal/store/postgres"
@@ -2472,6 +2473,71 @@ func TestSecureCookiesFollowPublicURL(t *testing.T) {
 	cookie := findCookie(resp.Cookies(), "cc_session")
 	if cookie == nil || !cookie.Secure {
 		t.Fatalf("expected secure session cookie, got %#v", cookie)
+	}
+}
+
+func TestNamespacedSessionCookiePolicy(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newEmptyHTTPStore(t)
+	user, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Cookie User", Email: "cookie@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	session, err := st.CreateSession(ctx, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cookieNames, err := authpolicy.NewCookieNames("prod", "https://chat.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := New(st, realtime.NewHub(), Options{
+		CookieNames:    cookieNames,
+		DisableDevAuth: true,
+		GitHubOAuth:    GitHubOAuthConfig{PublicURL: "https://chat.example.com"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: "cc_session", Value: session.Token})
+	recorder := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected legacy cookie to be ignored, got %d", recorder.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: session.Token})
+	recorder = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected namespaced cookie authentication, got %d", recorder.Code)
+	}
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	req = httptest.NewRequest(http.MethodPost, "https://chat.example.com/test", nil)
+	req.AddCookie(&http.Cookie{Name: "cc_session", Value: "foreign"})
+	recorder = httptest.NewRecorder()
+	srv.requireCookieCSRF(next).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("expected foreign cookie to bypass session CSRF handling, got %d", recorder.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "https://chat.example.com/test", nil)
+	req.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: session.Token})
+	recorder = httptest.NewRecorder()
+	srv.requireCookieCSRF(next).ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusForbidden {
+		t.Fatalf("expected active session cookie to require CSRF proof, got %d", recorder.Code)
+	}
+
+	recorder = httptest.NewRecorder()
+	srv.setSessionCookie(recorder, httptest.NewRequest(http.MethodGet, "https://chat.example.com/", nil), session)
+	cookie := findCookie(recorder.Result().Cookies(), cookieNames.Session)
+	if cookie == nil || !cookie.Secure || !cookie.HttpOnly || cookie.Path != "/" || cookie.SameSite != http.SameSiteLaxMode {
+		t.Fatalf("unexpected namespaced session cookie: %#v", cookie)
 	}
 }
 

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2514,6 +2514,15 @@ func TestNamespacedSessionCookiePolicy(t *testing.T) {
 		t.Fatalf("expected namespaced cookie authentication, got %d", recorder.Code)
 	}
 
+	req = httptest.NewRequest(http.MethodGet, "https://chat.example.com/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: session.Token})
+	req.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: "shadowed"})
+	recorder = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected duplicate session cookies to be rejected, got %d", recorder.Code)
+	}
+
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2523,6 +2523,17 @@ func TestNamespacedSessionCookiePolicy(t *testing.T) {
 		t.Fatalf("expected duplicate session cookies to be rejected, got %d", recorder.Code)
 	}
 
+	devServer := New(st, realtime.NewHub(), Options{CookieNames: cookieNames})
+	devRequest := httptest.NewRequest(http.MethodGet, "http://127.0.0.1:8080/api/me", nil)
+	devRequest.RemoteAddr = "127.0.0.1:12345"
+	devRequest.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: session.Token})
+	devRequest.AddCookie(&http.Cookie{Name: cookieNames.Session, Value: "shadowed"})
+	devRecorder := httptest.NewRecorder()
+	devServer.Handler().ServeHTTP(devRecorder, devRequest)
+	if devRecorder.Code != http.StatusUnauthorized {
+		t.Fatalf("expected duplicate cookies to block the dev fallback, got %d", devRecorder.Code)
+	}
+
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/apps/api/internal/store/postgres/migrations/0016_oauth_transactions.sql
+++ b/apps/api/internal/store/postgres/migrations/0016_oauth_transactions.sql
@@ -1,0 +1,28 @@
+CREATE TABLE oauth_transactions (
+  id TEXT PRIMARY KEY,
+  state_hash TEXT NOT NULL UNIQUE,
+  browser_binding_hash TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
+  pkce_verifier TEXT NOT NULL,
+  desktop_challenge TEXT NOT NULL DEFAULT '',
+  created_at_unix BIGINT NOT NULL,
+  expires_at_unix BIGINT NOT NULL
+);
+
+CREATE INDEX idx_oauth_transactions_binding_expiry
+  ON oauth_transactions(browser_binding_hash, expires_at_unix);
+
+CREATE INDEX idx_oauth_transactions_expiry
+  ON oauth_transactions(expires_at_unix);
+
+CREATE TABLE desktop_oauth_grants (
+  id TEXT PRIMARY KEY,
+  grant_hash TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  desktop_challenge TEXT NOT NULL,
+  created_at_unix BIGINT NOT NULL,
+  expires_at_unix BIGINT NOT NULL
+);
+
+CREATE INDEX idx_desktop_oauth_grants_expiry
+  ON desktop_oauth_grants(expires_at_unix);

--- a/apps/api/internal/store/postgres/migrations/0017_desktop_oauth_protocol.sql
+++ b/apps/api/internal/store/postgres/migrations/0017_desktop_oauth_protocol.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_transactions
+ADD COLUMN desktop_protocol BIGINT NOT NULL DEFAULT 0;

--- a/apps/api/internal/store/postgres/oauth.go
+++ b/apps/api/internal/store/postgres/oauth.go
@@ -1,0 +1,221 @@
+package postgres
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/postgres/storedb"
+)
+
+const (
+	maxPendingOAuthTransactions        = 8192
+	maxPendingOAuthTransactionsPerUser = 8
+	maxPendingDesktopOAuthGrants       = 4096
+)
+
+func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OAuthTransaction) error {
+	if err := validateOAuthTransaction(transaction); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	if _, err := qtx.DeleteExpiredOAuthTransactions(ctx, transaction.CreatedAt.Unix()); err != nil {
+		return err
+	}
+	count, err := qtx.CountOAuthTransactions(ctx)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingOAuthTransactions {
+		return store.ErrOAuthCapacityExceeded
+	}
+	count, err = qtx.CountOAuthTransactionsForBinding(ctx, transaction.BrowserBindingHash)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingOAuthTransactionsPerUser {
+		return store.ErrOAuthCapacityExceeded
+	}
+	if transaction.ID == "" {
+		transaction.ID = newID("oat")
+	}
+	if err := qtx.InsertOAuthTransaction(ctx, storedb.InsertOAuthTransactionParams{
+		ID:                 transaction.ID,
+		StateHash:          transaction.StateHash,
+		BrowserBindingHash: transaction.BrowserBindingHash,
+		Mode:               transaction.Mode,
+		PkceVerifier:       transaction.PKCEVerifier,
+		DesktopChallenge:   transaction.DesktopChallenge,
+		CreatedAtUnix:      transaction.CreatedAt.Unix(),
+		ExpiresAtUnix:      transaction.ExpiresAt.Unix(),
+	}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ConsumeOAuthTransaction(ctx context.Context, stateHash, browserBindingHash string, current time.Time) (store.OAuthTransaction, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetOAuthTransactionForConsume(ctx, strings.TrimSpace(stateHash))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	if row.ExpiresAtUnix <= current.Unix() {
+		if _, err := qtx.DeleteOAuthTransaction(ctx, storedb.DeleteOAuthTransactionParams{ID: row.ID, StateHash: row.StateHash}); err != nil {
+			return store.OAuthTransaction{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return store.OAuthTransaction{}, err
+		}
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if subtle.ConstantTimeCompare([]byte(row.BrowserBindingHash), []byte(strings.TrimSpace(browserBindingHash))) != 1 {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	deleted, err := qtx.DeleteOAuthTransaction(ctx, storedb.DeleteOAuthTransactionParams{ID: row.ID, StateHash: row.StateHash})
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	if deleted != 1 {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if err := tx.Commit(); err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	return oauthTransactionFromDB(row), nil
+}
+
+func (s *Store) CreateDesktopOAuthGrant(ctx context.Context, grant store.DesktopOAuthGrant) error {
+	if err := validateDesktopOAuthGrant(grant); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	if _, err := qtx.DeleteExpiredDesktopOAuthGrants(ctx, grant.CreatedAt.Unix()); err != nil {
+		return err
+	}
+	count, err := qtx.CountDesktopOAuthGrants(ctx)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingDesktopOAuthGrants {
+		return store.ErrOAuthCapacityExceeded
+	}
+	if grant.ID == "" {
+		grant.ID = newID("odg")
+	}
+	if err := qtx.InsertDesktopOAuthGrant(ctx, storedb.InsertDesktopOAuthGrantParams{
+		ID:               grant.ID,
+		GrantHash:        grant.GrantHash,
+		UserID:           grant.UserID,
+		DesktopChallenge: grant.DesktopChallenge,
+		CreatedAtUnix:    grant.CreatedAt.Unix(),
+		ExpiresAtUnix:    grant.ExpiresAt.Unix(),
+	}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ConsumeDesktopOAuthGrant(ctx context.Context, grantHash, desktopChallenge string, current time.Time) (store.Session, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.Session{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetDesktopOAuthGrantForConsume(ctx, strings.TrimSpace(grantHash))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	if err != nil {
+		return store.Session{}, err
+	}
+	if row.ExpiresAtUnix <= current.Unix() {
+		if _, err := qtx.DeleteDesktopOAuthGrant(ctx, storedb.DeleteDesktopOAuthGrantParams{ID: row.ID, GrantHash: row.GrantHash}); err != nil {
+			return store.Session{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return store.Session{}, err
+		}
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	if subtle.ConstantTimeCompare([]byte(row.DesktopChallenge), []byte(strings.TrimSpace(desktopChallenge))) != 1 {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	deleted, err := qtx.DeleteDesktopOAuthGrant(ctx, storedb.DeleteDesktopOAuthGrantParams{ID: row.ID, GrantHash: row.GrantHash})
+	if err != nil {
+		return store.Session{}, err
+	}
+	if deleted != 1 {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	session, err := createSessionTx(ctx, qtx, row.UserID)
+	if err != nil {
+		return store.Session{}, err
+	}
+	return session, tx.Commit()
+}
+
+func oauthTransactionFromDB(row storedb.OauthTransaction) store.OAuthTransaction {
+	return store.OAuthTransaction{
+		ID:                 row.ID,
+		StateHash:          row.StateHash,
+		BrowserBindingHash: row.BrowserBindingHash,
+		Mode:               row.Mode,
+		PKCEVerifier:       row.PkceVerifier,
+		DesktopChallenge:   row.DesktopChallenge,
+		CreatedAt:          time.Unix(row.CreatedAtUnix, 0).UTC(),
+		ExpiresAt:          time.Unix(row.ExpiresAtUnix, 0).UTC(),
+	}
+}
+
+func validateOAuthTransaction(transaction store.OAuthTransaction) error {
+	if transaction.StateHash == "" || transaction.BrowserBindingHash == "" || transaction.PKCEVerifier == "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode != store.OAuthModeBrowser && transaction.Mode != store.OAuthModeDesktop {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopChallenge == "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeBrowser && transaction.DesktopChallenge != "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.CreatedAt.IsZero() || !transaction.ExpiresAt.After(transaction.CreatedAt) {
+		return store.ErrOAuthTransactionInvalid
+	}
+	return nil
+}
+
+func validateDesktopOAuthGrant(grant store.DesktopOAuthGrant) error {
+	if grant.GrantHash == "" || grant.UserID == "" || grant.DesktopChallenge == "" {
+		return store.ErrDesktopOAuthGrantInvalid
+	}
+	if grant.CreatedAt.IsZero() || !grant.ExpiresAt.After(grant.CreatedAt) {
+		return store.ErrDesktopOAuthGrantInvalid
+	}
+	return nil
+}

--- a/apps/api/internal/store/postgres/oauth.go
+++ b/apps/api/internal/store/postgres/oauth.go
@@ -55,6 +55,7 @@ func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OA
 		Mode:               transaction.Mode,
 		PkceVerifier:       transaction.PKCEVerifier,
 		DesktopChallenge:   transaction.DesktopChallenge,
+		DesktopProtocol:    transaction.DesktopProtocol,
 		CreatedAtUnix:      transaction.CreatedAt.Unix(),
 		ExpiresAtUnix:      transaction.ExpiresAt.Unix(),
 	}); err != nil {
@@ -186,6 +187,7 @@ func oauthTransactionFromDB(row storedb.OauthTransaction) store.OAuthTransaction
 		Mode:               row.Mode,
 		PKCEVerifier:       row.PkceVerifier,
 		DesktopChallenge:   row.DesktopChallenge,
+		DesktopProtocol:    row.DesktopProtocol,
 		CreatedAt:          time.Unix(row.CreatedAtUnix, 0).UTC(),
 		ExpiresAt:          time.Unix(row.ExpiresAtUnix, 0).UTC(),
 	}
@@ -201,7 +203,10 @@ func validateOAuthTransaction(transaction store.OAuthTransaction) error {
 	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopChallenge == "" {
 		return store.ErrOAuthTransactionInvalid
 	}
-	if transaction.Mode == store.OAuthModeBrowser && transaction.DesktopChallenge != "" {
+	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopProtocol != 1 && transaction.DesktopProtocol != 2 {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeBrowser && (transaction.DesktopChallenge != "" || transaction.DesktopProtocol != 0) {
 		return store.ErrOAuthTransactionInvalid
 	}
 	if transaction.CreatedAt.IsZero() || !transaction.ExpiresAt.After(transaction.CreatedAt) {

--- a/apps/api/internal/store/postgres/oauth.go
+++ b/apps/api/internal/store/postgres/oauth.go
@@ -13,9 +13,12 @@ import (
 )
 
 const (
-	maxPendingOAuthTransactions        = 8192
-	maxPendingOAuthTransactionsPerUser = 8
-	maxPendingDesktopOAuthGrants       = 4096
+	maxPendingOAuthTransactions           = 8192
+	maxPendingOAuthTransactionsPerBinding = 8
+	maxPendingDesktopOAuthGrants          = 4096
+
+	postgresOAuthTransactionCapacityLockKey int64 = 0x63636f6175746874
+	postgresDesktopGrantCapacityLockKey     int64 = 0x63636f6175746867
 )
 
 func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OAuthTransaction) error {
@@ -27,6 +30,9 @@ func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OA
 		return err
 	}
 	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, postgresOAuthTransactionCapacityLockKey); err != nil {
+		return err
+	}
 	qtx := s.q.WithTx(tx)
 	if _, err := qtx.DeleteExpiredOAuthTransactions(ctx, transaction.CreatedAt.Unix()); err != nil {
 		return err
@@ -42,7 +48,7 @@ func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OA
 	if err != nil {
 		return err
 	}
-	if count >= maxPendingOAuthTransactionsPerUser {
+	if count >= maxPendingOAuthTransactionsPerBinding {
 		return store.ErrOAuthCapacityExceeded
 	}
 	if transaction.ID == "" {
@@ -112,6 +118,9 @@ func (s *Store) CreateDesktopOAuthGrant(ctx context.Context, grant store.Desktop
 		return err
 	}
 	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock($1)`, postgresDesktopGrantCapacityLockKey); err != nil {
+		return err
+	}
 	qtx := s.q.WithTx(tx)
 	if _, err := qtx.DeleteExpiredDesktopOAuthGrants(ctx, grant.CreatedAt.Unix()); err != nil {
 		return err

--- a/apps/api/internal/store/postgres/oauth_test.go
+++ b/apps/api/internal/store/postgres/oauth_test.go
@@ -5,6 +5,9 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -67,6 +70,61 @@ func TestPostgresOAuthTransactionsAndDesktopGrants(t *testing.T) {
 	}
 	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now); !errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
 		t.Fatalf("expected grant replay rejection, got %v", err)
+	}
+}
+
+func TestPostgresOAuthTransactionCapacityIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	bindingHash := postgresOAuthHash("shared-binding")
+	newTransaction := func(index int) store.OAuthTransaction {
+		return store.OAuthTransaction{
+			StateHash:          postgresOAuthHash(fmt.Sprintf("state-%d", index)),
+			BrowserBindingHash: bindingHash,
+			Mode:               store.OAuthModeBrowser,
+			PKCEVerifier:       fmt.Sprintf("verifier-%d", index),
+			CreatedAt:          now,
+			ExpiresAt:          now.Add(10 * time.Minute),
+		}
+	}
+	for index := 0; index < maxPendingOAuthTransactionsPerBinding-1; index++ {
+		if err := st.CreateOAuthTransaction(ctx, newTransaction(index)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const contenders = 16
+	start := make(chan struct{})
+	var successes atomic.Int64
+	var wg sync.WaitGroup
+	errs := make(chan error, contenders)
+	for index := 0; index < contenders; index++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			err := st.CreateOAuthTransaction(ctx, newTransaction(100+index))
+			if err == nil {
+				successes.Add(1)
+				return
+			}
+			if !errors.Is(err, store.ErrOAuthCapacityExceeded) {
+				errs <- err
+			}
+		}(index)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("unexpected concurrent create error: %v", err)
+	}
+	if successes.Load() != 1 {
+		t.Fatalf("expected exactly one final transaction, got %d", successes.Load())
 	}
 }
 

--- a/apps/api/internal/store/postgres/oauth_test.go
+++ b/apps/api/internal/store/postgres/oauth_test.go
@@ -1,0 +1,75 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestPostgresOAuthTransactionsAndDesktopGrants(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	user, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "OAuth User", Email: "oauth@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	transaction := store.OAuthTransaction{
+		StateHash:          postgresOAuthHash("state"),
+		BrowserBindingHash: postgresOAuthHash("binding"),
+		Mode:               store.OAuthModeDesktop,
+		PKCEVerifier:       "pkce-verifier",
+		DesktopChallenge:   "desktop-challenge",
+		CreatedAt:          now,
+		ExpiresAt:          now.Add(10 * time.Minute),
+	}
+	if err := st.CreateOAuthTransaction(ctx, transaction); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, postgresOAuthHash("wrong-binding"), now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {
+		t.Fatalf("expected wrong binding rejection, got %v", err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {
+		t.Fatalf("expected transaction replay rejection, got %v", err)
+	}
+
+	grant := store.DesktopOAuthGrant{
+		GrantHash:        postgresOAuthHash("grant"),
+		UserID:           user.ID,
+		DesktopChallenge: "desktop-challenge",
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(5 * time.Minute),
+	}
+	if err := st.CreateDesktopOAuthGrant(ctx, grant); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, "wrong-challenge", now); !errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+		t.Fatalf("expected wrong challenge rejection, got %v", err)
+	}
+	session, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.UserID != user.ID || session.Token == "" {
+		t.Fatalf("unexpected desktop session: %#v", session)
+	}
+	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now); !errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+		t.Fatalf("expected grant replay rejection, got %v", err)
+	}
+}
+
+func postgresOAuthHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/apps/api/internal/store/postgres/oauth_test.go
+++ b/apps/api/internal/store/postgres/oauth_test.go
@@ -28,6 +28,7 @@ func TestPostgresOAuthTransactionsAndDesktopGrants(t *testing.T) {
 		Mode:               store.OAuthModeDesktop,
 		PKCEVerifier:       "pkce-verifier",
 		DesktopChallenge:   "desktop-challenge",
+		DesktopProtocol:    2,
 		CreatedAt:          now,
 		ExpiresAt:          now.Add(10 * time.Minute),
 	}

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -42,6 +42,66 @@ WHERE s.token_hash = sqlc.arg(token_hash)
 INSERT INTO sessions (id, token, token_hash, user_id, created_at, expires_at)
 VALUES (sqlc.arg(id), sqlc.arg(token), sqlc.arg(token_hash), sqlc.arg(user_id), sqlc.arg(created_at), sqlc.arg(expires_at));
 
+-- name: DeleteExpiredOAuthTransactions :execrows
+DELETE FROM oauth_transactions
+WHERE expires_at_unix <= sqlc.arg(now_unix);
+
+-- name: CountOAuthTransactions :one
+SELECT COUNT(*)
+FROM oauth_transactions;
+
+-- name: CountOAuthTransactionsForBinding :one
+SELECT COUNT(*)
+FROM oauth_transactions
+WHERE browser_binding_hash = sqlc.arg(browser_binding_hash);
+
+-- name: InsertOAuthTransaction :exec
+INSERT INTO oauth_transactions (
+  id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+  created_at_unix, expires_at_unix
+) VALUES (
+  sqlc.arg(id), sqlc.arg(state_hash), sqlc.arg(browser_binding_hash), sqlc.arg(mode),
+  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(created_at_unix),
+  sqlc.arg(expires_at_unix)
+);
+
+-- name: GetOAuthTransactionForConsume :one
+SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+       created_at_unix, expires_at_unix
+FROM oauth_transactions
+WHERE state_hash = sqlc.arg(state_hash)
+FOR UPDATE;
+
+-- name: DeleteOAuthTransaction :execrows
+DELETE FROM oauth_transactions
+WHERE id = sqlc.arg(id) AND state_hash = sqlc.arg(state_hash);
+
+-- name: DeleteExpiredDesktopOAuthGrants :execrows
+DELETE FROM desktop_oauth_grants
+WHERE expires_at_unix <= sqlc.arg(now_unix);
+
+-- name: CountDesktopOAuthGrants :one
+SELECT COUNT(*)
+FROM desktop_oauth_grants;
+
+-- name: InsertDesktopOAuthGrant :exec
+INSERT INTO desktop_oauth_grants (
+  id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+) VALUES (
+  sqlc.arg(id), sqlc.arg(grant_hash), sqlc.arg(user_id), sqlc.arg(desktop_challenge),
+  sqlc.arg(created_at_unix), sqlc.arg(expires_at_unix)
+);
+
+-- name: GetDesktopOAuthGrantForConsume :one
+SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+FROM desktop_oauth_grants
+WHERE grant_hash = sqlc.arg(grant_hash)
+FOR UPDATE;
+
+-- name: DeleteDesktopOAuthGrant :execrows
+DELETE FROM desktop_oauth_grants
+WHERE id = sqlc.arg(id) AND grant_hash = sqlc.arg(grant_hash);
+
 -- name: GetUserByIdentityEmail :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -58,16 +58,16 @@ WHERE browser_binding_hash = sqlc.arg(browser_binding_hash);
 -- name: InsertOAuthTransaction :exec
 INSERT INTO oauth_transactions (
   id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-  created_at_unix, expires_at_unix
+  desktop_protocol, created_at_unix, expires_at_unix
 ) VALUES (
   sqlc.arg(id), sqlc.arg(state_hash), sqlc.arg(browser_binding_hash), sqlc.arg(mode),
-  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(created_at_unix),
-  sqlc.arg(expires_at_unix)
+  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(desktop_protocol),
+  sqlc.arg(created_at_unix), sqlc.arg(expires_at_unix)
 );
 
 -- name: GetOAuthTransactionForConsume :one
 SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-       created_at_unix, expires_at_unix
+       desktop_protocol, created_at_unix, expires_at_unix
 FROM oauth_transactions
 WHERE state_hash = sqlc.arg(state_hash)
 FOR UPDATE;

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -457,6 +457,7 @@ CREATE TABLE oauth_transactions (
   mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
   pkce_verifier TEXT NOT NULL,
   desktop_challenge TEXT NOT NULL DEFAULT '',
+  desktop_protocol BIGINT NOT NULL DEFAULT 0,
   created_at_unix BIGINT NOT NULL,
   expires_at_unix BIGINT NOT NULL
 );

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -449,3 +449,32 @@ CREATE TABLE connected_accounts (
 
 CREATE INDEX idx_connected_accounts_user
   ON connected_accounts(workspace_id, user_id, revoked_at);
+
+CREATE TABLE oauth_transactions (
+  id TEXT PRIMARY KEY,
+  state_hash TEXT NOT NULL UNIQUE,
+  browser_binding_hash TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
+  pkce_verifier TEXT NOT NULL,
+  desktop_challenge TEXT NOT NULL DEFAULT '',
+  created_at_unix BIGINT NOT NULL,
+  expires_at_unix BIGINT NOT NULL
+);
+
+CREATE INDEX idx_oauth_transactions_binding_expiry
+  ON oauth_transactions(browser_binding_hash, expires_at_unix);
+
+CREATE INDEX idx_oauth_transactions_expiry
+  ON oauth_transactions(expires_at_unix);
+
+CREATE TABLE desktop_oauth_grants (
+  id TEXT PRIMARY KEY,
+  grant_hash TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  desktop_challenge TEXT NOT NULL,
+  created_at_unix BIGINT NOT NULL,
+  expires_at_unix BIGINT NOT NULL
+);
+
+CREATE INDEX idx_desktop_oauth_grants_expiry
+  ON desktop_oauth_grants(expires_at_unix);

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -86,6 +86,15 @@ type ConnectedAccount struct {
 	RevokedAt         sql.NullString `json:"revoked_at"`
 }
 
+type DesktopOauthGrant struct {
+	ID               string `json:"id"`
+	GrantHash        string `json:"grant_hash"`
+	UserID           string `json:"user_id"`
+	DesktopChallenge string `json:"desktop_challenge"`
+	CreatedAtUnix    int64  `json:"created_at_unix"`
+	ExpiresAtUnix    int64  `json:"expires_at_unix"`
+}
+
 type DirectConversation struct {
 	ID           string         `json:"id"`
 	WorkspaceID  string         `json:"workspace_id"`
@@ -204,6 +213,17 @@ type MessageAttachment struct {
 	MessageID string `json:"message_id"`
 	UploadID  string `json:"upload_id"`
 	CreatedAt string `json:"created_at"`
+}
+
+type OauthTransaction struct {
+	ID                 string `json:"id"`
+	StateHash          string `json:"state_hash"`
+	BrowserBindingHash string `json:"browser_binding_hash"`
+	Mode               string `json:"mode"`
+	PkceVerifier       string `json:"pkce_verifier"`
+	DesktopChallenge   string `json:"desktop_challenge"`
+	CreatedAtUnix      int64  `json:"created_at_unix"`
+	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }
 
 type PendingUploadCleanup struct {

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -222,6 +222,7 @@ type OauthTransaction struct {
 	Mode               string `json:"mode"`
 	PkceVerifier       string `json:"pkce_verifier"`
 	DesktopChallenge   string `json:"desktop_challenge"`
+	DesktopProtocol    int64  `json:"desktop_protocol"`
 	CreatedAtUnix      int64  `json:"created_at_unix"`
 	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -176,6 +176,43 @@ func (q *Queries) ClearMemberTimeout(ctx context.Context, arg ClearMemberTimeout
 	return err
 }
 
+const countDesktopOAuthGrants = `-- name: CountDesktopOAuthGrants :one
+SELECT COUNT(*)
+FROM desktop_oauth_grants
+`
+
+func (q *Queries) CountDesktopOAuthGrants(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countDesktopOAuthGrants)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countOAuthTransactions = `-- name: CountOAuthTransactions :one
+SELECT COUNT(*)
+FROM oauth_transactions
+`
+
+func (q *Queries) CountOAuthTransactions(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countOAuthTransactions)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countOAuthTransactionsForBinding = `-- name: CountOAuthTransactionsForBinding :one
+SELECT COUNT(*)
+FROM oauth_transactions
+WHERE browser_binding_hash = $1
+`
+
+func (q *Queries) CountOAuthTransactionsForBinding(ctx context.Context, browserBindingHash string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countOAuthTransactionsForBinding, browserBindingHash)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countRecentWorkspaceMessagesByAuthor = `-- name: CountRecentWorkspaceMessagesByAuthor :one
 SELECT COUNT(*)
 FROM messages m
@@ -306,6 +343,50 @@ func (q *Queries) CountWorkspaceMembersByRole(ctx context.Context, arg CountWork
 	return count, err
 }
 
+const deleteDesktopOAuthGrant = `-- name: DeleteDesktopOAuthGrant :execrows
+DELETE FROM desktop_oauth_grants
+WHERE id = $1 AND grant_hash = $2
+`
+
+type DeleteDesktopOAuthGrantParams struct {
+	ID        string `json:"id"`
+	GrantHash string `json:"grant_hash"`
+}
+
+func (q *Queries) DeleteDesktopOAuthGrant(ctx context.Context, arg DeleteDesktopOAuthGrantParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteDesktopOAuthGrant, arg.ID, arg.GrantHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredDesktopOAuthGrants = `-- name: DeleteExpiredDesktopOAuthGrants :execrows
+DELETE FROM desktop_oauth_grants
+WHERE expires_at_unix <= $1
+`
+
+func (q *Queries) DeleteExpiredDesktopOAuthGrants(ctx context.Context, nowUnix int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredDesktopOAuthGrants, nowUnix)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredOAuthTransactions = `-- name: DeleteExpiredOAuthTransactions :execrows
+DELETE FROM oauth_transactions
+WHERE expires_at_unix <= $1
+`
+
+func (q *Queries) DeleteExpiredOAuthTransactions(ctx context.Context, nowUnix int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredOAuthTransactions, nowUnix)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteExpiredUploadQuotaReservations = `-- name: DeleteExpiredUploadQuotaReservations :exec
 DELETE FROM upload_quota_reservations
 WHERE expires_at <= $1
@@ -331,6 +412,24 @@ type DeleteMessageBodyParams struct {
 
 func (q *Queries) DeleteMessageBody(ctx context.Context, arg DeleteMessageBodyParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteMessageBody, arg.DeletedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteOAuthTransaction = `-- name: DeleteOAuthTransaction :execrows
+DELETE FROM oauth_transactions
+WHERE id = $1 AND state_hash = $2
+`
+
+type DeleteOAuthTransactionParams struct {
+	ID        string `json:"id"`
+	StateHash string `json:"state_hash"`
+}
+
+func (q *Queries) DeleteOAuthTransaction(ctx context.Context, arg DeleteOAuthTransactionParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOAuthTransaction, arg.ID, arg.StateHash)
 	if err != nil {
 		return 0, err
 	}
@@ -776,6 +875,27 @@ func (q *Queries) GetChannelWorkspace(ctx context.Context, id string) (string, e
 	return workspace_id, err
 }
 
+const getDesktopOAuthGrantForConsume = `-- name: GetDesktopOAuthGrantForConsume :one
+SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+FROM desktop_oauth_grants
+WHERE grant_hash = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetDesktopOAuthGrantForConsume(ctx context.Context, grantHash string) (DesktopOauthGrant, error) {
+	row := q.db.QueryRowContext(ctx, getDesktopOAuthGrantForConsume, grantHash)
+	var i DesktopOauthGrant
+	err := row.Scan(
+		&i.ID,
+		&i.GrantHash,
+		&i.UserID,
+		&i.DesktopChallenge,
+		&i.CreatedAtUnix,
+		&i.ExpiresAtUnix,
+	)
+	return i, err
+}
+
 const getDirectByIDAndWorkspace = `-- name: GetDirectByIDAndWorkspace :one
 SELECT dc.id, COALESCE(dc.route_id, '') AS route_id, dc.workspace_id, dc.created_at
 FROM direct_conversations dc
@@ -1001,6 +1121,30 @@ func (q *Queries) GetNotificationSettings(ctx context.Context, userID string) (G
 	row := q.db.QueryRowContext(ctx, getNotificationSettings, userID)
 	var i GetNotificationSettingsRow
 	err := row.Scan(&i.PushoverEnabled, &i.PushoverUserKey)
+	return i, err
+}
+
+const getOAuthTransactionForConsume = `-- name: GetOAuthTransactionForConsume :one
+SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+       created_at_unix, expires_at_unix
+FROM oauth_transactions
+WHERE state_hash = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetOAuthTransactionForConsume(ctx context.Context, stateHash string) (OauthTransaction, error) {
+	row := q.db.QueryRowContext(ctx, getOAuthTransactionForConsume, stateHash)
+	var i OauthTransaction
+	err := row.Scan(
+		&i.ID,
+		&i.StateHash,
+		&i.BrowserBindingHash,
+		&i.Mode,
+		&i.PkceVerifier,
+		&i.DesktopChallenge,
+		&i.CreatedAtUnix,
+		&i.ExpiresAtUnix,
+	)
 	return i, err
 }
 
@@ -1513,6 +1657,36 @@ func (q *Queries) InsertDefaultWorkspaceMember(ctx context.Context, arg InsertDe
 	return err
 }
 
+const insertDesktopOAuthGrant = `-- name: InsertDesktopOAuthGrant :exec
+INSERT INTO desktop_oauth_grants (
+  id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+) VALUES (
+  $1, $2, $3, $4,
+  $5, $6
+)
+`
+
+type InsertDesktopOAuthGrantParams struct {
+	ID               string `json:"id"`
+	GrantHash        string `json:"grant_hash"`
+	UserID           string `json:"user_id"`
+	DesktopChallenge string `json:"desktop_challenge"`
+	CreatedAtUnix    int64  `json:"created_at_unix"`
+	ExpiresAtUnix    int64  `json:"expires_at_unix"`
+}
+
+func (q *Queries) InsertDesktopOAuthGrant(ctx context.Context, arg InsertDesktopOAuthGrantParams) error {
+	_, err := q.db.ExecContext(ctx, insertDesktopOAuthGrant,
+		arg.ID,
+		arg.GrantHash,
+		arg.UserID,
+		arg.DesktopChallenge,
+		arg.CreatedAtUnix,
+		arg.ExpiresAtUnix,
+	)
+	return err
+}
+
 const insertDirectConversation = `-- name: InsertDirectConversation :execrows
 INSERT INTO direct_conversations (id, route_id, workspace_id, created_at, member_set_key)
 VALUES ($1, $2, $3, $4, $5)
@@ -1742,6 +1916,42 @@ func (q *Queries) InsertMagicLink(ctx context.Context, arg InsertMagicLinkParams
 		arg.DisplayName,
 		arg.CreatedAt,
 		arg.ExpiresAt,
+	)
+	return err
+}
+
+const insertOAuthTransaction = `-- name: InsertOAuthTransaction :exec
+INSERT INTO oauth_transactions (
+  id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+  created_at_unix, expires_at_unix
+) VALUES (
+  $1, $2, $3, $4,
+  $5, $6, $7,
+  $8
+)
+`
+
+type InsertOAuthTransactionParams struct {
+	ID                 string `json:"id"`
+	StateHash          string `json:"state_hash"`
+	BrowserBindingHash string `json:"browser_binding_hash"`
+	Mode               string `json:"mode"`
+	PkceVerifier       string `json:"pkce_verifier"`
+	DesktopChallenge   string `json:"desktop_challenge"`
+	CreatedAtUnix      int64  `json:"created_at_unix"`
+	ExpiresAtUnix      int64  `json:"expires_at_unix"`
+}
+
+func (q *Queries) InsertOAuthTransaction(ctx context.Context, arg InsertOAuthTransactionParams) error {
+	_, err := q.db.ExecContext(ctx, insertOAuthTransaction,
+		arg.ID,
+		arg.StateHash,
+		arg.BrowserBindingHash,
+		arg.Mode,
+		arg.PkceVerifier,
+		arg.DesktopChallenge,
+		arg.CreatedAtUnix,
+		arg.ExpiresAtUnix,
 	)
 	return err
 }

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1126,7 +1126,7 @@ func (q *Queries) GetNotificationSettings(ctx context.Context, userID string) (G
 
 const getOAuthTransactionForConsume = `-- name: GetOAuthTransactionForConsume :one
 SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-       created_at_unix, expires_at_unix
+       desktop_protocol, created_at_unix, expires_at_unix
 FROM oauth_transactions
 WHERE state_hash = $1
 FOR UPDATE
@@ -1142,6 +1142,7 @@ func (q *Queries) GetOAuthTransactionForConsume(ctx context.Context, stateHash s
 		&i.Mode,
 		&i.PkceVerifier,
 		&i.DesktopChallenge,
+		&i.DesktopProtocol,
 		&i.CreatedAtUnix,
 		&i.ExpiresAtUnix,
 	)
@@ -1923,11 +1924,11 @@ func (q *Queries) InsertMagicLink(ctx context.Context, arg InsertMagicLinkParams
 const insertOAuthTransaction = `-- name: InsertOAuthTransaction :exec
 INSERT INTO oauth_transactions (
   id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-  created_at_unix, expires_at_unix
+  desktop_protocol, created_at_unix, expires_at_unix
 ) VALUES (
   $1, $2, $3, $4,
   $5, $6, $7,
-  $8
+  $8, $9
 )
 `
 
@@ -1938,6 +1939,7 @@ type InsertOAuthTransactionParams struct {
 	Mode               string `json:"mode"`
 	PkceVerifier       string `json:"pkce_verifier"`
 	DesktopChallenge   string `json:"desktop_challenge"`
+	DesktopProtocol    int64  `json:"desktop_protocol"`
 	CreatedAtUnix      int64  `json:"created_at_unix"`
 	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }
@@ -1950,6 +1952,7 @@ func (q *Queries) InsertOAuthTransaction(ctx context.Context, arg InsertOAuthTra
 		arg.Mode,
 		arg.PkceVerifier,
 		arg.DesktopChallenge,
+		arg.DesktopProtocol,
 		arg.CreatedAtUnix,
 		arg.ExpiresAtUnix,
 	)

--- a/apps/api/internal/store/sqlite/migrations/0023_oauth_transactions.sql
+++ b/apps/api/internal/store/sqlite/migrations/0023_oauth_transactions.sql
@@ -1,0 +1,28 @@
+CREATE TABLE oauth_transactions (
+  id TEXT PRIMARY KEY,
+  state_hash TEXT NOT NULL UNIQUE,
+  browser_binding_hash TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
+  pkce_verifier TEXT NOT NULL,
+  desktop_challenge TEXT NOT NULL DEFAULT '',
+  created_at_unix INTEGER NOT NULL,
+  expires_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX idx_oauth_transactions_binding_expiry
+  ON oauth_transactions(browser_binding_hash, expires_at_unix);
+
+CREATE INDEX idx_oauth_transactions_expiry
+  ON oauth_transactions(expires_at_unix);
+
+CREATE TABLE desktop_oauth_grants (
+  id TEXT PRIMARY KEY,
+  grant_hash TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  desktop_challenge TEXT NOT NULL,
+  created_at_unix INTEGER NOT NULL,
+  expires_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX idx_desktop_oauth_grants_expiry
+  ON desktop_oauth_grants(expires_at_unix);

--- a/apps/api/internal/store/sqlite/migrations/0024_desktop_oauth_protocol.sql
+++ b/apps/api/internal/store/sqlite/migrations/0024_desktop_oauth_protocol.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_transactions
+ADD COLUMN desktop_protocol INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/internal/store/sqlite/oauth.go
+++ b/apps/api/internal/store/sqlite/oauth.go
@@ -1,0 +1,221 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/subtle"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
+)
+
+const (
+	maxPendingOAuthTransactions        = 8192
+	maxPendingOAuthTransactionsPerUser = 8
+	maxPendingDesktopOAuthGrants       = 4096
+)
+
+func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OAuthTransaction) error {
+	if err := validateOAuthTransaction(transaction); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	if _, err := qtx.DeleteExpiredOAuthTransactions(ctx, transaction.CreatedAt.Unix()); err != nil {
+		return err
+	}
+	count, err := qtx.CountOAuthTransactions(ctx)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingOAuthTransactions {
+		return store.ErrOAuthCapacityExceeded
+	}
+	count, err = qtx.CountOAuthTransactionsForBinding(ctx, transaction.BrowserBindingHash)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingOAuthTransactionsPerUser {
+		return store.ErrOAuthCapacityExceeded
+	}
+	if transaction.ID == "" {
+		transaction.ID = newID("oat")
+	}
+	if err := qtx.InsertOAuthTransaction(ctx, storedb.InsertOAuthTransactionParams{
+		ID:                 transaction.ID,
+		StateHash:          transaction.StateHash,
+		BrowserBindingHash: transaction.BrowserBindingHash,
+		Mode:               transaction.Mode,
+		PkceVerifier:       transaction.PKCEVerifier,
+		DesktopChallenge:   transaction.DesktopChallenge,
+		CreatedAtUnix:      transaction.CreatedAt.Unix(),
+		ExpiresAtUnix:      transaction.ExpiresAt.Unix(),
+	}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ConsumeOAuthTransaction(ctx context.Context, stateHash, browserBindingHash string, current time.Time) (store.OAuthTransaction, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetOAuthTransactionForConsume(ctx, strings.TrimSpace(stateHash))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	if row.ExpiresAtUnix <= current.Unix() {
+		if _, err := qtx.DeleteOAuthTransaction(ctx, storedb.DeleteOAuthTransactionParams{ID: row.ID, StateHash: row.StateHash}); err != nil {
+			return store.OAuthTransaction{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return store.OAuthTransaction{}, err
+		}
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if subtle.ConstantTimeCompare([]byte(row.BrowserBindingHash), []byte(strings.TrimSpace(browserBindingHash))) != 1 {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	deleted, err := qtx.DeleteOAuthTransaction(ctx, storedb.DeleteOAuthTransactionParams{ID: row.ID, StateHash: row.StateHash})
+	if err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	if deleted != 1 {
+		return store.OAuthTransaction{}, store.ErrOAuthTransactionInvalid
+	}
+	if err := tx.Commit(); err != nil {
+		return store.OAuthTransaction{}, err
+	}
+	return oauthTransactionFromDB(row), nil
+}
+
+func (s *Store) CreateDesktopOAuthGrant(ctx context.Context, grant store.DesktopOAuthGrant) error {
+	if err := validateDesktopOAuthGrant(grant); err != nil {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	if _, err := qtx.DeleteExpiredDesktopOAuthGrants(ctx, grant.CreatedAt.Unix()); err != nil {
+		return err
+	}
+	count, err := qtx.CountDesktopOAuthGrants(ctx)
+	if err != nil {
+		return err
+	}
+	if count >= maxPendingDesktopOAuthGrants {
+		return store.ErrOAuthCapacityExceeded
+	}
+	if grant.ID == "" {
+		grant.ID = newID("odg")
+	}
+	if err := qtx.InsertDesktopOAuthGrant(ctx, storedb.InsertDesktopOAuthGrantParams{
+		ID:               grant.ID,
+		GrantHash:        grant.GrantHash,
+		UserID:           grant.UserID,
+		DesktopChallenge: grant.DesktopChallenge,
+		CreatedAtUnix:    grant.CreatedAt.Unix(),
+		ExpiresAtUnix:    grant.ExpiresAt.Unix(),
+	}); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func (s *Store) ConsumeDesktopOAuthGrant(ctx context.Context, grantHash, desktopChallenge string, current time.Time) (store.Session, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.Session{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetDesktopOAuthGrantForConsume(ctx, strings.TrimSpace(grantHash))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	if err != nil {
+		return store.Session{}, err
+	}
+	if row.ExpiresAtUnix <= current.Unix() {
+		if _, err := qtx.DeleteDesktopOAuthGrant(ctx, storedb.DeleteDesktopOAuthGrantParams{ID: row.ID, GrantHash: row.GrantHash}); err != nil {
+			return store.Session{}, err
+		}
+		if err := tx.Commit(); err != nil {
+			return store.Session{}, err
+		}
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	if subtle.ConstantTimeCompare([]byte(row.DesktopChallenge), []byte(strings.TrimSpace(desktopChallenge))) != 1 {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	deleted, err := qtx.DeleteDesktopOAuthGrant(ctx, storedb.DeleteDesktopOAuthGrantParams{ID: row.ID, GrantHash: row.GrantHash})
+	if err != nil {
+		return store.Session{}, err
+	}
+	if deleted != 1 {
+		return store.Session{}, store.ErrDesktopOAuthGrantInvalid
+	}
+	session, err := createSessionTx(ctx, qtx, row.UserID)
+	if err != nil {
+		return store.Session{}, err
+	}
+	return session, tx.Commit()
+}
+
+func oauthTransactionFromDB(row storedb.OauthTransaction) store.OAuthTransaction {
+	return store.OAuthTransaction{
+		ID:                 row.ID,
+		StateHash:          row.StateHash,
+		BrowserBindingHash: row.BrowserBindingHash,
+		Mode:               row.Mode,
+		PKCEVerifier:       row.PkceVerifier,
+		DesktopChallenge:   row.DesktopChallenge,
+		CreatedAt:          time.Unix(row.CreatedAtUnix, 0).UTC(),
+		ExpiresAt:          time.Unix(row.ExpiresAtUnix, 0).UTC(),
+	}
+}
+
+func validateOAuthTransaction(transaction store.OAuthTransaction) error {
+	if transaction.StateHash == "" || transaction.BrowserBindingHash == "" || transaction.PKCEVerifier == "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode != store.OAuthModeBrowser && transaction.Mode != store.OAuthModeDesktop {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopChallenge == "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeBrowser && transaction.DesktopChallenge != "" {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.CreatedAt.IsZero() || !transaction.ExpiresAt.After(transaction.CreatedAt) {
+		return store.ErrOAuthTransactionInvalid
+	}
+	return nil
+}
+
+func validateDesktopOAuthGrant(grant store.DesktopOAuthGrant) error {
+	if grant.GrantHash == "" || grant.UserID == "" || grant.DesktopChallenge == "" {
+		return store.ErrDesktopOAuthGrantInvalid
+	}
+	if grant.CreatedAt.IsZero() || !grant.ExpiresAt.After(grant.CreatedAt) {
+		return store.ErrDesktopOAuthGrantInvalid
+	}
+	return nil
+}

--- a/apps/api/internal/store/sqlite/oauth.go
+++ b/apps/api/internal/store/sqlite/oauth.go
@@ -55,6 +55,7 @@ func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OA
 		Mode:               transaction.Mode,
 		PkceVerifier:       transaction.PKCEVerifier,
 		DesktopChallenge:   transaction.DesktopChallenge,
+		DesktopProtocol:    transaction.DesktopProtocol,
 		CreatedAtUnix:      transaction.CreatedAt.Unix(),
 		ExpiresAtUnix:      transaction.ExpiresAt.Unix(),
 	}); err != nil {
@@ -186,6 +187,7 @@ func oauthTransactionFromDB(row storedb.OauthTransaction) store.OAuthTransaction
 		Mode:               row.Mode,
 		PKCEVerifier:       row.PkceVerifier,
 		DesktopChallenge:   row.DesktopChallenge,
+		DesktopProtocol:    row.DesktopProtocol,
 		CreatedAt:          time.Unix(row.CreatedAtUnix, 0).UTC(),
 		ExpiresAt:          time.Unix(row.ExpiresAtUnix, 0).UTC(),
 	}
@@ -201,7 +203,10 @@ func validateOAuthTransaction(transaction store.OAuthTransaction) error {
 	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopChallenge == "" {
 		return store.ErrOAuthTransactionInvalid
 	}
-	if transaction.Mode == store.OAuthModeBrowser && transaction.DesktopChallenge != "" {
+	if transaction.Mode == store.OAuthModeDesktop && transaction.DesktopProtocol != 1 && transaction.DesktopProtocol != 2 {
+		return store.ErrOAuthTransactionInvalid
+	}
+	if transaction.Mode == store.OAuthModeBrowser && (transaction.DesktopChallenge != "" || transaction.DesktopProtocol != 0) {
 		return store.ErrOAuthTransactionInvalid
 	}
 	if transaction.CreatedAt.IsZero() || !transaction.ExpiresAt.After(transaction.CreatedAt) {

--- a/apps/api/internal/store/sqlite/oauth.go
+++ b/apps/api/internal/store/sqlite/oauth.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	maxPendingOAuthTransactions        = 8192
-	maxPendingOAuthTransactionsPerUser = 8
-	maxPendingDesktopOAuthGrants       = 4096
+	maxPendingOAuthTransactions           = 8192
+	maxPendingOAuthTransactionsPerBinding = 8
+	maxPendingDesktopOAuthGrants          = 4096
 )
 
 func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OAuthTransaction) error {
@@ -42,7 +42,7 @@ func (s *Store) CreateOAuthTransaction(ctx context.Context, transaction store.OA
 	if err != nil {
 		return err
 	}
-	if count >= maxPendingOAuthTransactionsPerUser {
+	if count >= maxPendingOAuthTransactionsPerBinding {
 		return store.ErrOAuthCapacityExceeded
 	}
 	if transaction.ID == "" {

--- a/apps/api/internal/store/sqlite/oauth_test.go
+++ b/apps/api/internal/store/sqlite/oauth_test.go
@@ -27,6 +27,7 @@ func TestOAuthTransactionsAndDesktopGrants(t *testing.T) {
 		Mode:               store.OAuthModeDesktop,
 		PKCEVerifier:       "pkce-verifier",
 		DesktopChallenge:   "desktop-challenge",
+		DesktopProtocol:    2,
 		CreatedAt:          now,
 		ExpiresAt:          now.Add(10 * time.Minute),
 	}
@@ -40,7 +41,7 @@ func TestOAuthTransactionsAndDesktopGrants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if consumed.Mode != store.OAuthModeDesktop || consumed.PKCEVerifier != transaction.PKCEVerifier || consumed.DesktopChallenge != transaction.DesktopChallenge {
+	if consumed.Mode != store.OAuthModeDesktop || consumed.PKCEVerifier != transaction.PKCEVerifier || consumed.DesktopChallenge != transaction.DesktopChallenge || consumed.DesktopProtocol != 2 {
 		t.Fatalf("unexpected consumed transaction: %#v", consumed)
 	}
 	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {

--- a/apps/api/internal/store/sqlite/oauth_test.go
+++ b/apps/api/internal/store/sqlite/oauth_test.go
@@ -1,0 +1,156 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestOAuthTransactionsAndDesktopGrants(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+	user, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "OAuth User", Email: "oauth@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	transaction := store.OAuthTransaction{
+		StateHash:          testOAuthHash("state"),
+		BrowserBindingHash: testOAuthHash("binding"),
+		Mode:               store.OAuthModeDesktop,
+		PKCEVerifier:       "pkce-verifier",
+		DesktopChallenge:   "desktop-challenge",
+		CreatedAt:          now,
+		ExpiresAt:          now.Add(10 * time.Minute),
+	}
+	if err := st.CreateOAuthTransaction(ctx, transaction); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, testOAuthHash("wrong-binding"), now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {
+		t.Fatalf("expected wrong binding rejection, got %v", err)
+	}
+	consumed, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if consumed.Mode != store.OAuthModeDesktop || consumed.PKCEVerifier != transaction.PKCEVerifier || consumed.DesktopChallenge != transaction.DesktopChallenge {
+		t.Fatalf("unexpected consumed transaction: %#v", consumed)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {
+		t.Fatalf("expected transaction replay rejection, got %v", err)
+	}
+
+	expired := transaction
+	expired.StateHash = testOAuthHash("expired-state")
+	expired.ExpiresAt = now.Add(-time.Second)
+	expired.CreatedAt = now.Add(-time.Minute)
+	if err := st.CreateOAuthTransaction(ctx, expired); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, expired.StateHash, expired.BrowserBindingHash, now); !errors.Is(err, store.ErrOAuthTransactionInvalid) {
+		t.Fatalf("expected expired transaction rejection, got %v", err)
+	}
+
+	grant := store.DesktopOAuthGrant{
+		GrantHash:        testOAuthHash("grant"),
+		UserID:           user.ID,
+		DesktopChallenge: "desktop-challenge",
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(5 * time.Minute),
+	}
+	if err := st.CreateDesktopOAuthGrant(ctx, grant); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, "wrong-challenge", now); !errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+		t.Fatalf("expected wrong challenge rejection, got %v", err)
+	}
+	var sessionsBefore int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sessions`).Scan(&sessionsBefore); err != nil {
+		t.Fatal(err)
+	}
+	if sessionsBefore != 0 {
+		t.Fatalf("wrong challenge created %d sessions", sessionsBefore)
+	}
+	session, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if session.UserID != user.ID || session.Token == "" {
+		t.Fatalf("unexpected desktop session: %#v", session)
+	}
+	if _, err := st.GetSessionUser(ctx, session.Token); err != nil {
+		t.Fatalf("created session did not authenticate: %v", err)
+	}
+	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now); !errors.Is(err, store.ErrDesktopOAuthGrantInvalid) {
+		t.Fatalf("expected grant replay rejection, got %v", err)
+	}
+}
+
+func TestOAuthStateSurvivesSQLiteRestart(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "restart.db")
+	st, err := Open("sqlite://" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	user, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Restart User", Email: "restart@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	transaction := store.OAuthTransaction{
+		StateHash:          testOAuthHash("restart-state"),
+		BrowserBindingHash: testOAuthHash("restart-binding"),
+		Mode:               store.OAuthModeBrowser,
+		PKCEVerifier:       "restart-verifier",
+		CreatedAt:          now,
+		ExpiresAt:          now.Add(10 * time.Minute),
+	}
+	grant := store.DesktopOAuthGrant{
+		GrantHash:        testOAuthHash("restart-grant"),
+		UserID:           user.ID,
+		DesktopChallenge: "restart-challenge",
+		CreatedAt:        now,
+		ExpiresAt:        now.Add(5 * time.Minute),
+	}
+	if err := st.CreateOAuthTransaction(ctx, transaction); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateDesktopOAuthGrant(ctx, grant); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	st, err = Open("sqlite://" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ConsumeOAuthTransaction(ctx, transaction.StateHash, transaction.BrowserBindingHash, now); err != nil {
+		t.Fatalf("consume transaction after restart: %v", err)
+	}
+	if _, err := st.ConsumeDesktopOAuthGrant(ctx, grant.GrantHash, grant.DesktopChallenge, now); err != nil {
+		t.Fatalf("consume grant after restart: %v", err)
+	}
+}
+
+func testOAuthHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:])
+}

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -42,6 +42,64 @@ WHERE s.token_hash = sqlc.arg(token_hash)
 INSERT INTO sessions (id, token, token_hash, user_id, created_at, expires_at)
 VALUES (sqlc.arg(id), sqlc.arg(token), sqlc.arg(token_hash), sqlc.arg(user_id), sqlc.arg(created_at), sqlc.arg(expires_at));
 
+-- name: DeleteExpiredOAuthTransactions :execrows
+DELETE FROM oauth_transactions
+WHERE expires_at_unix <= sqlc.arg(now_unix);
+
+-- name: CountOAuthTransactions :one
+SELECT COUNT(*)
+FROM oauth_transactions;
+
+-- name: CountOAuthTransactionsForBinding :one
+SELECT COUNT(*)
+FROM oauth_transactions
+WHERE browser_binding_hash = sqlc.arg(browser_binding_hash);
+
+-- name: InsertOAuthTransaction :exec
+INSERT INTO oauth_transactions (
+  id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+  created_at_unix, expires_at_unix
+) VALUES (
+  sqlc.arg(id), sqlc.arg(state_hash), sqlc.arg(browser_binding_hash), sqlc.arg(mode),
+  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(created_at_unix),
+  sqlc.arg(expires_at_unix)
+);
+
+-- name: GetOAuthTransactionForConsume :one
+SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+       created_at_unix, expires_at_unix
+FROM oauth_transactions
+WHERE state_hash = sqlc.arg(state_hash);
+
+-- name: DeleteOAuthTransaction :execrows
+DELETE FROM oauth_transactions
+WHERE id = sqlc.arg(id) AND state_hash = sqlc.arg(state_hash);
+
+-- name: DeleteExpiredDesktopOAuthGrants :execrows
+DELETE FROM desktop_oauth_grants
+WHERE expires_at_unix <= sqlc.arg(now_unix);
+
+-- name: CountDesktopOAuthGrants :one
+SELECT COUNT(*)
+FROM desktop_oauth_grants;
+
+-- name: InsertDesktopOAuthGrant :exec
+INSERT INTO desktop_oauth_grants (
+  id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+) VALUES (
+  sqlc.arg(id), sqlc.arg(grant_hash), sqlc.arg(user_id), sqlc.arg(desktop_challenge),
+  sqlc.arg(created_at_unix), sqlc.arg(expires_at_unix)
+);
+
+-- name: GetDesktopOAuthGrantForConsume :one
+SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+FROM desktop_oauth_grants
+WHERE grant_hash = sqlc.arg(grant_hash);
+
+-- name: DeleteDesktopOAuthGrant :execrows
+DELETE FROM desktop_oauth_grants
+WHERE id = sqlc.arg(id) AND grant_hash = sqlc.arg(grant_hash);
+
 -- name: GetUserByIdentityEmail :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -58,16 +58,16 @@ WHERE browser_binding_hash = sqlc.arg(browser_binding_hash);
 -- name: InsertOAuthTransaction :exec
 INSERT INTO oauth_transactions (
   id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-  created_at_unix, expires_at_unix
+  desktop_protocol, created_at_unix, expires_at_unix
 ) VALUES (
   sqlc.arg(id), sqlc.arg(state_hash), sqlc.arg(browser_binding_hash), sqlc.arg(mode),
-  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(created_at_unix),
-  sqlc.arg(expires_at_unix)
+  sqlc.arg(pkce_verifier), sqlc.arg(desktop_challenge), sqlc.arg(desktop_protocol),
+  sqlc.arg(created_at_unix), sqlc.arg(expires_at_unix)
 );
 
 -- name: GetOAuthTransactionForConsume :one
 SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-       created_at_unix, expires_at_unix
+       desktop_protocol, created_at_unix, expires_at_unix
 FROM oauth_transactions
 WHERE state_hash = sqlc.arg(state_hash);
 

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -454,6 +454,7 @@ CREATE TABLE oauth_transactions (
   mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
   pkce_verifier TEXT NOT NULL,
   desktop_challenge TEXT NOT NULL DEFAULT '',
+  desktop_protocol INTEGER NOT NULL DEFAULT 0,
   created_at_unix INTEGER NOT NULL,
   expires_at_unix INTEGER NOT NULL
 );

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -446,3 +446,32 @@ CREATE TABLE connected_accounts (
 
 CREATE INDEX idx_connected_accounts_user
   ON connected_accounts(workspace_id, user_id, revoked_at);
+
+CREATE TABLE oauth_transactions (
+  id TEXT PRIMARY KEY,
+  state_hash TEXT NOT NULL UNIQUE,
+  browser_binding_hash TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('browser', 'desktop')),
+  pkce_verifier TEXT NOT NULL,
+  desktop_challenge TEXT NOT NULL DEFAULT '',
+  created_at_unix INTEGER NOT NULL,
+  expires_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX idx_oauth_transactions_binding_expiry
+  ON oauth_transactions(browser_binding_hash, expires_at_unix);
+
+CREATE INDEX idx_oauth_transactions_expiry
+  ON oauth_transactions(expires_at_unix);
+
+CREATE TABLE desktop_oauth_grants (
+  id TEXT PRIMARY KEY,
+  grant_hash TEXT NOT NULL UNIQUE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  desktop_challenge TEXT NOT NULL,
+  created_at_unix INTEGER NOT NULL,
+  expires_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX idx_desktop_oauth_grants_expiry
+  ON desktop_oauth_grants(expires_at_unix);

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -86,6 +86,15 @@ type ConnectedAccount struct {
 	RevokedAt         sql.NullString `json:"revoked_at"`
 }
 
+type DesktopOauthGrant struct {
+	ID               string `json:"id"`
+	GrantHash        string `json:"grant_hash"`
+	UserID           string `json:"user_id"`
+	DesktopChallenge string `json:"desktop_challenge"`
+	CreatedAtUnix    int64  `json:"created_at_unix"`
+	ExpiresAtUnix    int64  `json:"expires_at_unix"`
+}
+
 type DirectConversation struct {
 	ID           string         `json:"id"`
 	WorkspaceID  string         `json:"workspace_id"`
@@ -204,6 +213,17 @@ type MessageAttachment struct {
 	MessageID string `json:"message_id"`
 	UploadID  string `json:"upload_id"`
 	CreatedAt string `json:"created_at"`
+}
+
+type OauthTransaction struct {
+	ID                 string `json:"id"`
+	StateHash          string `json:"state_hash"`
+	BrowserBindingHash string `json:"browser_binding_hash"`
+	Mode               string `json:"mode"`
+	PkceVerifier       string `json:"pkce_verifier"`
+	DesktopChallenge   string `json:"desktop_challenge"`
+	CreatedAtUnix      int64  `json:"created_at_unix"`
+	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }
 
 type PendingUploadCleanup struct {

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -222,6 +222,7 @@ type OauthTransaction struct {
 	Mode               string `json:"mode"`
 	PkceVerifier       string `json:"pkce_verifier"`
 	DesktopChallenge   string `json:"desktop_challenge"`
+	DesktopProtocol    int64  `json:"desktop_protocol"`
 	CreatedAtUnix      int64  `json:"created_at_unix"`
 	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1122,7 +1122,7 @@ func (q *Queries) GetNotificationSettings(ctx context.Context, userID string) (G
 
 const getOAuthTransactionForConsume = `-- name: GetOAuthTransactionForConsume :one
 SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-       created_at_unix, expires_at_unix
+       desktop_protocol, created_at_unix, expires_at_unix
 FROM oauth_transactions
 WHERE state_hash = ?1
 `
@@ -1137,6 +1137,7 @@ func (q *Queries) GetOAuthTransactionForConsume(ctx context.Context, stateHash s
 		&i.Mode,
 		&i.PkceVerifier,
 		&i.DesktopChallenge,
+		&i.DesktopProtocol,
 		&i.CreatedAtUnix,
 		&i.ExpiresAtUnix,
 	)
@@ -1917,11 +1918,11 @@ func (q *Queries) InsertMagicLink(ctx context.Context, arg InsertMagicLinkParams
 const insertOAuthTransaction = `-- name: InsertOAuthTransaction :exec
 INSERT INTO oauth_transactions (
   id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
-  created_at_unix, expires_at_unix
+  desktop_protocol, created_at_unix, expires_at_unix
 ) VALUES (
   ?1, ?2, ?3, ?4,
   ?5, ?6, ?7,
-  ?8
+  ?8, ?9
 )
 `
 
@@ -1932,6 +1933,7 @@ type InsertOAuthTransactionParams struct {
 	Mode               string `json:"mode"`
 	PkceVerifier       string `json:"pkce_verifier"`
 	DesktopChallenge   string `json:"desktop_challenge"`
+	DesktopProtocol    int64  `json:"desktop_protocol"`
 	CreatedAtUnix      int64  `json:"created_at_unix"`
 	ExpiresAtUnix      int64  `json:"expires_at_unix"`
 }
@@ -1944,6 +1946,7 @@ func (q *Queries) InsertOAuthTransaction(ctx context.Context, arg InsertOAuthTra
 		arg.Mode,
 		arg.PkceVerifier,
 		arg.DesktopChallenge,
+		arg.DesktopProtocol,
 		arg.CreatedAtUnix,
 		arg.ExpiresAtUnix,
 	)

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -173,6 +173,43 @@ func (q *Queries) ClearMemberTimeout(ctx context.Context, arg ClearMemberTimeout
 	return err
 }
 
+const countDesktopOAuthGrants = `-- name: CountDesktopOAuthGrants :one
+SELECT COUNT(*)
+FROM desktop_oauth_grants
+`
+
+func (q *Queries) CountDesktopOAuthGrants(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countDesktopOAuthGrants)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countOAuthTransactions = `-- name: CountOAuthTransactions :one
+SELECT COUNT(*)
+FROM oauth_transactions
+`
+
+func (q *Queries) CountOAuthTransactions(ctx context.Context) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countOAuthTransactions)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countOAuthTransactionsForBinding = `-- name: CountOAuthTransactionsForBinding :one
+SELECT COUNT(*)
+FROM oauth_transactions
+WHERE browser_binding_hash = ?1
+`
+
+func (q *Queries) CountOAuthTransactionsForBinding(ctx context.Context, browserBindingHash string) (int64, error) {
+	row := q.db.QueryRowContext(ctx, countOAuthTransactionsForBinding, browserBindingHash)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const countRecentWorkspaceMessagesByAuthor = `-- name: CountRecentWorkspaceMessagesByAuthor :one
 SELECT COUNT(*)
 FROM messages m
@@ -303,6 +340,50 @@ func (q *Queries) CountWorkspaceMembersByRole(ctx context.Context, arg CountWork
 	return count, err
 }
 
+const deleteDesktopOAuthGrant = `-- name: DeleteDesktopOAuthGrant :execrows
+DELETE FROM desktop_oauth_grants
+WHERE id = ?1 AND grant_hash = ?2
+`
+
+type DeleteDesktopOAuthGrantParams struct {
+	ID        string `json:"id"`
+	GrantHash string `json:"grant_hash"`
+}
+
+func (q *Queries) DeleteDesktopOAuthGrant(ctx context.Context, arg DeleteDesktopOAuthGrantParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteDesktopOAuthGrant, arg.ID, arg.GrantHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredDesktopOAuthGrants = `-- name: DeleteExpiredDesktopOAuthGrants :execrows
+DELETE FROM desktop_oauth_grants
+WHERE expires_at_unix <= ?1
+`
+
+func (q *Queries) DeleteExpiredDesktopOAuthGrants(ctx context.Context, nowUnix int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredDesktopOAuthGrants, nowUnix)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredOAuthTransactions = `-- name: DeleteExpiredOAuthTransactions :execrows
+DELETE FROM oauth_transactions
+WHERE expires_at_unix <= ?1
+`
+
+func (q *Queries) DeleteExpiredOAuthTransactions(ctx context.Context, nowUnix int64) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredOAuthTransactions, nowUnix)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteExpiredUploadQuotaReservations = `-- name: DeleteExpiredUploadQuotaReservations :exec
 DELETE FROM upload_quota_reservations
 WHERE expires_at <= ?1
@@ -328,6 +409,24 @@ type DeleteMessageBodyParams struct {
 
 func (q *Queries) DeleteMessageBody(ctx context.Context, arg DeleteMessageBodyParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteMessageBody, arg.DeletedAt, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteOAuthTransaction = `-- name: DeleteOAuthTransaction :execrows
+DELETE FROM oauth_transactions
+WHERE id = ?1 AND state_hash = ?2
+`
+
+type DeleteOAuthTransactionParams struct {
+	ID        string `json:"id"`
+	StateHash string `json:"state_hash"`
+}
+
+func (q *Queries) DeleteOAuthTransaction(ctx context.Context, arg DeleteOAuthTransactionParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteOAuthTransaction, arg.ID, arg.StateHash)
 	if err != nil {
 		return 0, err
 	}
@@ -773,6 +872,26 @@ func (q *Queries) GetChannelWorkspace(ctx context.Context, id string) (string, e
 	return workspace_id, err
 }
 
+const getDesktopOAuthGrantForConsume = `-- name: GetDesktopOAuthGrantForConsume :one
+SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+FROM desktop_oauth_grants
+WHERE grant_hash = ?1
+`
+
+func (q *Queries) GetDesktopOAuthGrantForConsume(ctx context.Context, grantHash string) (DesktopOauthGrant, error) {
+	row := q.db.QueryRowContext(ctx, getDesktopOAuthGrantForConsume, grantHash)
+	var i DesktopOauthGrant
+	err := row.Scan(
+		&i.ID,
+		&i.GrantHash,
+		&i.UserID,
+		&i.DesktopChallenge,
+		&i.CreatedAtUnix,
+		&i.ExpiresAtUnix,
+	)
+	return i, err
+}
+
 const getDirectByIDAndWorkspace = `-- name: GetDirectByIDAndWorkspace :one
 SELECT dc.id, COALESCE(dc.route_id, '') AS route_id, dc.workspace_id, dc.created_at
 FROM direct_conversations dc
@@ -998,6 +1117,29 @@ func (q *Queries) GetNotificationSettings(ctx context.Context, userID string) (G
 	row := q.db.QueryRowContext(ctx, getNotificationSettings, userID)
 	var i GetNotificationSettingsRow
 	err := row.Scan(&i.PushoverEnabled, &i.PushoverUserKey)
+	return i, err
+}
+
+const getOAuthTransactionForConsume = `-- name: GetOAuthTransactionForConsume :one
+SELECT id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+       created_at_unix, expires_at_unix
+FROM oauth_transactions
+WHERE state_hash = ?1
+`
+
+func (q *Queries) GetOAuthTransactionForConsume(ctx context.Context, stateHash string) (OauthTransaction, error) {
+	row := q.db.QueryRowContext(ctx, getOAuthTransactionForConsume, stateHash)
+	var i OauthTransaction
+	err := row.Scan(
+		&i.ID,
+		&i.StateHash,
+		&i.BrowserBindingHash,
+		&i.Mode,
+		&i.PkceVerifier,
+		&i.DesktopChallenge,
+		&i.CreatedAtUnix,
+		&i.ExpiresAtUnix,
+	)
 	return i, err
 }
 
@@ -1509,6 +1651,36 @@ func (q *Queries) InsertDefaultWorkspaceMember(ctx context.Context, arg InsertDe
 	return err
 }
 
+const insertDesktopOAuthGrant = `-- name: InsertDesktopOAuthGrant :exec
+INSERT INTO desktop_oauth_grants (
+  id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
+) VALUES (
+  ?1, ?2, ?3, ?4,
+  ?5, ?6
+)
+`
+
+type InsertDesktopOAuthGrantParams struct {
+	ID               string `json:"id"`
+	GrantHash        string `json:"grant_hash"`
+	UserID           string `json:"user_id"`
+	DesktopChallenge string `json:"desktop_challenge"`
+	CreatedAtUnix    int64  `json:"created_at_unix"`
+	ExpiresAtUnix    int64  `json:"expires_at_unix"`
+}
+
+func (q *Queries) InsertDesktopOAuthGrant(ctx context.Context, arg InsertDesktopOAuthGrantParams) error {
+	_, err := q.db.ExecContext(ctx, insertDesktopOAuthGrant,
+		arg.ID,
+		arg.GrantHash,
+		arg.UserID,
+		arg.DesktopChallenge,
+		arg.CreatedAtUnix,
+		arg.ExpiresAtUnix,
+	)
+	return err
+}
+
 const insertDirectConversation = `-- name: InsertDirectConversation :execrows
 INSERT INTO direct_conversations (id, route_id, workspace_id, created_at, member_set_key)
 VALUES (?1, ?2, ?3, ?4, ?5)
@@ -1738,6 +1910,42 @@ func (q *Queries) InsertMagicLink(ctx context.Context, arg InsertMagicLinkParams
 		arg.DisplayName,
 		arg.CreatedAt,
 		arg.ExpiresAt,
+	)
+	return err
+}
+
+const insertOAuthTransaction = `-- name: InsertOAuthTransaction :exec
+INSERT INTO oauth_transactions (
+  id, state_hash, browser_binding_hash, mode, pkce_verifier, desktop_challenge,
+  created_at_unix, expires_at_unix
+) VALUES (
+  ?1, ?2, ?3, ?4,
+  ?5, ?6, ?7,
+  ?8
+)
+`
+
+type InsertOAuthTransactionParams struct {
+	ID                 string `json:"id"`
+	StateHash          string `json:"state_hash"`
+	BrowserBindingHash string `json:"browser_binding_hash"`
+	Mode               string `json:"mode"`
+	PkceVerifier       string `json:"pkce_verifier"`
+	DesktopChallenge   string `json:"desktop_challenge"`
+	CreatedAtUnix      int64  `json:"created_at_unix"`
+	ExpiresAtUnix      int64  `json:"expires_at_unix"`
+}
+
+func (q *Queries) InsertOAuthTransaction(ctx context.Context, arg InsertOAuthTransactionParams) error {
+	_, err := q.db.ExecContext(ctx, insertOAuthTransaction,
+		arg.ID,
+		arg.StateHash,
+		arg.BrowserBindingHash,
+		arg.Mode,
+		arg.PkceVerifier,
+		arg.DesktopChallenge,
+		arg.CreatedAtUnix,
+		arg.ExpiresAtUnix,
 	)
 	return err
 }

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -720,6 +720,7 @@ type OAuthTransaction struct {
 	Mode               string
 	PKCEVerifier       string
 	DesktopChallenge   string
+	DesktopProtocol    int64
 	CreatedAt          time.Time
 	ExpiresAt          time.Time
 }

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"time"
 )
 
 // ErrQuotedMessageOutOfScope is returned when a message tries to quote another
@@ -33,6 +34,12 @@ var ErrPostRateLimited = errors.New("waiting room post limit reached")
 // ErrUploadQuotaExceeded is returned when a user has exhausted their upload
 // budget in a workspace.
 var ErrUploadQuotaExceeded = errors.New("upload quota exceeded")
+
+var (
+	ErrOAuthTransactionInvalid  = errors.New("invalid or expired oauth transaction")
+	ErrOAuthCapacityExceeded    = errors.New("too many pending oauth requests")
+	ErrDesktopOAuthGrantInvalid = errors.New("invalid or expired desktop oauth grant")
+)
 
 // ErrInvalidMessageKind is returned when a caller supplies a message kind that
 // is not one of the recognised values. HTTP callers surface it as a 400.
@@ -701,6 +708,31 @@ type Session struct {
 	ExpiresAt string `json:"expires_at"`
 }
 
+const (
+	OAuthModeBrowser = "browser"
+	OAuthModeDesktop = "desktop"
+)
+
+type OAuthTransaction struct {
+	ID                 string
+	StateHash          string
+	BrowserBindingHash string
+	Mode               string
+	PKCEVerifier       string
+	DesktopChallenge   string
+	CreatedAt          time.Time
+	ExpiresAt          time.Time
+}
+
+type DesktopOAuthGrant struct {
+	ID               string
+	GrantHash        string
+	UserID           string
+	DesktopChallenge string
+	CreatedAt        time.Time
+	ExpiresAt        time.Time
+}
+
 type ReadReceipt struct {
 	ScopeID     string `json:"scope_id"`
 	UserID      string `json:"user_id"`
@@ -847,5 +879,9 @@ type Store interface {
 	ConsumeMagicLink(ctx context.Context, token string) (User, Session, error)
 	CreateSession(ctx context.Context, userID string) (Session, error)
 	GetSessionUser(ctx context.Context, token string) (User, error)
+	CreateOAuthTransaction(ctx context.Context, transaction OAuthTransaction) error
+	ConsumeOAuthTransaction(ctx context.Context, stateHash, browserBindingHash string, now time.Time) (OAuthTransaction, error)
+	CreateDesktopOAuthGrant(ctx context.Context, grant DesktopOAuthGrant) error
+	ConsumeDesktopOAuthGrant(ctx context.Context, grantHash, desktopChallenge string, now time.Time) (Session, error)
 	GetBotTokenAuth(ctx context.Context, token string) (BotTokenAuth, error)
 }

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -17,6 +17,7 @@ protocols:
   - name: ClickClack link
     schemes:
       - clickclack
+      - chat.clickclack.desktop
 mac:
   category: public.app-category.social-networking
   icon: assets/icon.icns

--- a/apps/desktop/src/contract.test.ts
+++ b/apps/desktop/src/contract.test.ts
@@ -52,15 +52,27 @@ test("builds and validates the desktop OAuth handoff", () => {
   const challenge = "a".repeat(43);
   assert.equal(
     desktopOAuthStartURL("https://chat.example.com", challenge),
-    `https://chat.example.com/api/auth/github/desktop/start?code_challenge=${challenge}`,
+    `https://chat.example.com/api/auth/github/desktop/start?code_challenge=${challenge}&desktop_protocol=2`,
   );
   assert.throws(() => desktopOAuthStartURL("https://chat.example.com", "short"), /challenge/);
   assert.equal(
     desktopOAuthCallbackCode(`clickclack://auth/callback?code=${"a1".repeat(16)}`),
     "a1".repeat(16),
   );
+  assert.equal(
+    desktopOAuthCallbackCode(`chat.clickclack.desktop:/auth/callback?code=${"a1".repeat(16)}`),
+    "a1".repeat(16),
+  );
+  assert.equal(
+    desktopOAuthCallbackCode(`chat.clickclack.desktop:/auth/callback?code=${"A".repeat(43)}`),
+    "A".repeat(43),
+  );
   assert.equal(desktopOAuthCallbackCode("clickclack://auth/callback?code=bad"), null);
   assert.equal(desktopOAuthCallbackCode(`clickclack://app/callback?code=${"a1".repeat(16)}`), null);
+  assert.equal(
+    desktopOAuthCallbackCode(`chat.clickclack.desktop:/wrong?code=${"a1".repeat(16)}`),
+    null,
+  );
 });
 
 test("exposes the desktop bridge only to the configured server origin", () => {

--- a/apps/desktop/src/contract.ts
+++ b/apps/desktop/src/contract.ts
@@ -2,6 +2,9 @@ export const DEFAULT_SERVER_URL = "https://app.clickclack.chat";
 export const DEFAULT_APP_ROUTE = "/app";
 export const DESKTOP_SERVER_ORIGIN_ARG = "--clickclack-server-origin=";
 export const DESKTOP_TITLEBAR_ARG = "--clickclack-integrated-titlebar";
+export const DESKTOP_AUTH_PROTOCOL = "chat.clickclack.desktop";
+export const LEGACY_DESKTOP_PROTOCOL = "clickclack";
+export const DESKTOP_OAUTH_PROTOCOL_VERSION = 2;
 
 export type WindowState = {
   height?: number;
@@ -124,6 +127,7 @@ export function desktopOAuthStartURL(serverUrl: string, codeChallenge: string): 
   }
   const value = new URL("/api/auth/github/desktop/start", normalizeServerURL(serverUrl));
   value.searchParams.set("code_challenge", codeChallenge);
+  value.searchParams.set("desktop_protocol", String(DESKTOP_OAUTH_PROTOCOL_VERSION));
   return value.toString();
 }
 
@@ -134,15 +138,19 @@ export function desktopOAuthCallbackCode(input: string): string | null {
   } catch {
     return null;
   }
-  if (
-    value.protocol !== "clickclack:" ||
-    value.hostname !== "auth" ||
-    value.pathname !== "/callback"
-  ) {
+  const legacy =
+    value.protocol === `${LEGACY_DESKTOP_PROTOCOL}:` &&
+    value.hostname === "auth" &&
+    value.pathname === "/callback";
+  const current =
+    value.protocol === `${DESKTOP_AUTH_PROTOCOL}:` &&
+    value.hostname === "" &&
+    value.pathname === "/auth/callback";
+  if (!legacy && !current) {
     return null;
   }
   const code = value.searchParams.get("code") ?? "";
-  return /^[a-f0-9]{32}$/.test(code) ? code : null;
+  return /^[a-f0-9]{32}$/.test(code) || /^[A-Za-z0-9_-]{43}$/.test(code) ? code : null;
 }
 
 export function desktopBridgeAllowed(currentOrigin: string, trustedOrigin: string | undefined) {
@@ -176,7 +184,7 @@ export function deepLinkToRoute(input: string): string | null {
   } catch {
     return null;
   }
-  if (value.protocol !== "clickclack:") return null;
+  if (value.protocol !== `${LEGACY_DESKTOP_PROTOCOL}:`) return null;
   if (value.hostname === "app") {
     return safeAppRoute(`/app${value.pathname}${value.search}${value.hash}`);
   }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -20,6 +20,7 @@ import path from "node:path";
 import {
   appURL,
   clampUnreadCount,
+  DESKTOP_AUTH_PROTOCOL,
   deepLinkToRoute,
   defaultSettings,
   desktopTitleBarOptions,
@@ -30,6 +31,7 @@ import {
   desktopOAuthStartURL,
   mergeSettings,
   hasIntegratedTitleBarCapability,
+  LEGACY_DESKTOP_PROTOCOL,
   normalizeServerURL,
   safeAppRoute,
   sanitizeNotification,
@@ -38,7 +40,7 @@ import {
   type WindowState,
 } from "./contract";
 
-const PROTOCOL = "clickclack";
+const PROTOCOLS = [LEGACY_DESKTOP_PROTOCOL, DESKTOP_AUTH_PROTOCOL] as const;
 const SETTINGS_FILE = "desktop.json";
 const APP_NAME = "ClickClack";
 
@@ -62,7 +64,7 @@ if (!app.requestSingleInstanceLock()) {
 } else {
   registerProtocol();
   app.on("second-instance", (_event, commandLine) => {
-    const link = commandLine.find((argument) => argument.startsWith(`${PROTOCOL}://`));
+    const link = protocolURLFromArgs(commandLine);
     if (link) handleProtocolURL(link);
     else openRouteWhenReady(currentRoute);
   });
@@ -87,7 +89,7 @@ async function start() {
   createApplicationMenu();
   createTray();
 
-  const startupLink = process.argv.find((argument) => argument.startsWith(`${PROTOCOL}://`));
+  const startupLink = protocolURLFromArgs(process.argv);
   const initialRoute = pendingRoute ?? (startupLink ? deepLinkToRoute(startupLink) : null);
   pendingRoute = null;
   if (initialRoute) currentRoute = initialRoute;
@@ -112,11 +114,17 @@ async function start() {
 }
 
 function registerProtocol() {
-  if (process.defaultApp && process.argv[1]) {
-    app.setAsDefaultProtocolClient(PROTOCOL, process.execPath, [path.resolve(process.argv[1])]);
-    return;
+  for (const protocol of PROTOCOLS) {
+    if (process.defaultApp && process.argv[1]) {
+      app.setAsDefaultProtocolClient(protocol, process.execPath, [path.resolve(process.argv[1])]);
+      continue;
+    }
+    app.setAsDefaultProtocolClient(protocol);
   }
-  app.setAsDefaultProtocolClient(PROTOCOL);
+}
+
+function protocolURLFromArgs(args: readonly string[]): string | undefined {
+  return args.find((argument) => PROTOCOLS.some((protocol) => argument.startsWith(`${protocol}:`)));
 }
 
 function createMainWindow(route = currentRoute): BrowserWindow {
@@ -298,7 +306,7 @@ function guardMainFrameNavigation(
     return;
   }
   event.preventDefault();
-  if (url.startsWith(`${PROTOCOL}://`)) {
+  if (url.startsWith(`${LEGACY_DESKTOP_PROTOCOL}://`)) {
     openRoute(deepLinkToRoute(url));
   } else if (isExternalURL(url)) {
     void shell.openExternal(url);
@@ -666,11 +674,20 @@ async function completeDesktopOAuth(code: string) {
       },
     );
     if (!response.ok) throw new Error(`Server returned HTTP ${response.status}`);
-    const cookies = await session.defaultSession.cookies.get({
-      name: "cc_session",
-      url: pending.serverUrl,
-    });
-    if (cookies.length === 0) throw new Error("Server did not create a desktop session");
+    await response.arrayBuffer();
+    const meResponse = await session.defaultSession.fetch(
+      new URL("/api/me", pending.serverUrl).toString(),
+      {
+        credentials: "include",
+        method: "GET",
+        redirect: "error",
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!meResponse.ok) {
+      throw new Error(`Server did not establish a desktop session (HTTP ${meResponse.status})`);
+    }
+    await meResponse.arrayBuffer();
     pendingDesktopAuth = null;
     currentRoute = "/app";
     const window = mainWindow ?? createMainWindow(currentRoute);

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -16,7 +16,7 @@ The server resolves callers in this order (see
 [../features/auth.md](../features/auth.md)):
 
 1. `Authorization: Bearer <token>` (session token, magic-link result).
-2. `cc_session` cookie.
+2. Session cookie (`cc_session` by default, or the configured namespaced name).
 3. `X-ClickClack-User: usr_...` header (local/dev impersonation for tests).
 4. Dev fallback to the first user in the DB (only with
 `--dev-bootstrap=true`).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,9 +10,14 @@ read_when:
 earlier ones for any given key:
 
 1. Hard-coded defaults (`Addr=":8080"`, `Data="./data"`).
-2. Environment variables.
-3. JSON config file passed via `--config`.
+2. JSON config file passed via `--config`.
+3. Environment variables.
 4. CLI flags that were explicitly set.
+
+An explicitly present `dev_bootstrap` value in the config file is the one
+exception: it is not replaced by `CLICKCLACK_DEV_BOOTSTRAP`. This prevents a
+stale process environment from silently enabling development authentication
+against a deployment file that explicitly disables it.
 
 Source: `apps/api/internal/config/config.go` and the `applyFlagOverrides`
 hook in `cmd/clickclack/main.go`.
@@ -66,7 +71,8 @@ hook in `cmd/clickclack/main.go`.
 ```
 
 Pass with `--config /etc/clickclack/config.json`. Values from the file
-override env vars; CLI flags override the file if explicitly set.
+are overridden by environment variables; CLI flags override both when
+explicitly set. The `dev_bootstrap` exception is described above.
 
 ## Public origin and cookie namespace
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,8 @@ hook in `cmd/clickclack/main.go`.
 | `--metrics-enabled`   | `CLICKCLACK_METRICS_ENABLED`     | `false`     | Expose metadata-only Prometheus metrics at `/metrics`; keep private. |
 | `--config`            | —                                | unset       | JSON config file. |
 | `--dev-bootstrap`     | `CLICKCLACK_DEV_BOOTSTRAP`       | `false`     | `serve` only. Creates a default user/workspace/channel and enables local dev auth fallbacks when explicitly set to `true`. |
-| —                     | `CLICKCLACK_PUBLIC_URL`          | unset       | External URL. Used to build the GitHub OAuth callback. |
+| —                     | `CLICKCLACK_PUBLIC_URL`          | unset       | Canonical external origin. Required for GitHub OAuth and namespaced cookies. |
+| —                     | `CLICKCLACK_COOKIE_NAMESPACE`    | unset       | Stable lowercase cookie namespace for multiple trusted ClickClack instances on one hostname. |
 | —                     | `CLICKCLACK_GITHUB_CLIENT_ID`    | unset       | GitHub OAuth app client ID. |
 | —                     | `CLICKCLACK_GITHUB_CLIENT_SECRET`| unset       | GitHub OAuth app client secret. |
 | —                     | `CLICKCLACK_GITHUB_ALLOWED_ORG`  | unset       | Optional GitHub org login gate. Requires `read:org` scope. |
@@ -52,6 +53,7 @@ hook in `cmd/clickclack/main.go`.
   "metrics_enabled": false,
   "dev_bootstrap": false,
   "public_url": "https://chat.example.com",
+  "cookie_namespace": "production",
   "github_client_id": "Iv1.xxxxxxxxxxxx",
   "github_client_secret": "...",
   "github_allowed_org": "openclaw",
@@ -65,6 +67,46 @@ hook in `cmd/clickclack/main.go`.
 
 Pass with `--config /etc/clickclack/config.json`. Values from the file
 override env vars; CLI flags override the file if explicitly set.
+
+## Public origin and cookie namespace
+
+`CLICKCLACK_PUBLIC_URL` is an origin, not an application base path. It must:
+
+- use HTTPS for every non-loopback host
+- contain a host and optional non-default port
+- contain no credentials, path, query, fragment, or trailing-dot hostname
+
+For example, `https://chat.example.com` and `http://127.0.0.1:8080` are valid.
+`http://chat.example.com`, `https://chat.example.com/clickclack`, and
+`https://user@chat.example.com` fail startup validation. GitHub OAuth
+credentials also fail startup validation unless the public URL is set.
+
+The default cookie names remain `cc_session` and `cc_oauth_binding`. Set
+`CLICKCLACK_COOKIE_NAMESPACE` only when multiple trusted ClickClack instances
+must share one hostname:
+
+```sh
+CLICKCLACK_PUBLIC_URL=https://chat.example.com:8443
+CLICKCLACK_COOKIE_NAMESPACE=production
+```
+
+The namespace must be at most 32 characters and contain lowercase letters,
+digits, and interior hyphens. HTTPS deployments receive `__Host-` cookie names,
+such as `__Host-cc-production-session`; loopback HTTP uses
+`cc-production-session`.
+
+Treat the namespace as durable deployment identity:
+
+- Every replica serving the same public origin and database must use the same
+  namespace.
+- Different instances on the same hostname must use different namespaces.
+- Changing it signs browsers out and strands in-progress OAuth browser state
+  until that state expires.
+
+Cookies are scoped to hostnames, not ports. Namespaces prevent accidental
+same-name collisions; they are not a security boundary between mutually
+untrusted services. Put untrusted instances on separate hostnames. Use separate
+registrable domains when compromise of one deployment must not affect another.
 
 ## DB URL
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,7 +80,7 @@ docker run --rm -p 8080:8080 -v clickclack-data:/app/data clickclack
 Stages:
 
 1. `node:24-alpine` — installs pnpm dependencies and runs `pnpm build`.
-2. `golang:1.26-alpine` — builds the Go binary, importing the SPA dist.
+2. `golang:1.26.5-alpine` — builds the Go binary, importing the SPA dist.
 3. `alpine:3.23` — runtime image, runs as the `clickclack` user, exposes
    `8080`, mounts `/app/data` as a volume.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -160,6 +160,12 @@ Required for TLS and request size limits. The WebSocket endpoint enforces the
 request host by default and also allows `CLICKCLACK_PUBLIC_URL` as an origin
 when configured.
 
+Terminate TLS only at infrastructure you trust, redirect HTTP to HTTPS, and
+send HSTS from the public HTTPS origin after confirming every subdomain covered
+by the policy is HTTPS-ready. Rate-limit the public GitHub OAuth start endpoints
+at this edge. ClickClack intentionally does not trust arbitrary
+`X-Forwarded-For` values for security decisions.
+
 A minimal nginx block:
 
 ```nginx
@@ -179,6 +185,8 @@ If you want GitHub login, set:
 
 ```sh
 CLICKCLACK_PUBLIC_URL=https://chat.example.com
+# Optional only when trusted ClickClack instances share this hostname:
+# CLICKCLACK_COOKIE_NAMESPACE=production
 CLICKCLACK_GITHUB_CLIENT_ID=...
 CLICKCLACK_GITHUB_CLIENT_SECRET=...
 # Optional org gate:
@@ -196,6 +204,35 @@ post-limited guests until approved. When the org gate is set, ClickClack asks
 GitHub for `read:org` and only accepts active members of that org. See
 [features/auth.md](features/auth.md) and
 [features/moderation.md](features/moderation.md).
+
+`CLICKCLACK_PUBLIC_URL` is startup-validated as an exact origin. Non-loopback
+origins must use HTTPS and cannot contain a path, credentials, query, or
+fragment. GitHub OAuth credentials are rejected without it.
+
+GitHub OAuth apps have one configured callback URL. Each ClickClack public
+origin, including a distinct non-default port, therefore needs matching OAuth
+app configuration. Never point multiple unrelated public origins at one
+instance and rely on the request `Host` header to choose a callback.
+
+HTTP cookies do not include ports in their scope. When multiple trusted
+ClickClack instances share one hostname, assign each a unique, stable
+`CLICKCLACK_COOKIE_NAMESPACE`; all replicas of one instance must use the same
+value. This avoids accidental cookie-name collisions but does not isolate
+mutually untrusted services. Use separate hostnames, or separate registrable
+domains for stronger isolation.
+
+OAuth state and desktop grants are stored in the configured database, so
+callbacks can land on a different replica and survive process restarts.
+Internet-facing proxies should rate-limit:
+
+```text
+GET  /api/auth/github/start
+GET  /api/auth/github/desktop/start
+POST /api/auth/github/desktop/consume
+```
+
+Use limits appropriate to expected sign-in traffic and alert on sustained
+`429`, `503`, or `clickclack_github_oauth_events_total` rejection events.
 
 ## Migrations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -233,6 +233,11 @@ POST /api/auth/github/desktop/consume
 
 Use limits appropriate to expected sign-in traffic and alert on sustained
 `429`, `503`, or `clickclack_github_oauth_events_total` rejection events.
+Configure proxy and CDN access logs to omit query strings on OAuth routes:
+GitHub callbacks contain short-lived authorization codes, and start URLs
+contain state or desktop challenge values. Never log `Authorization`, `Cookie`,
+or `Set-Cookie` headers. ClickClack's own request logger records route patterns
+without query strings.
 
 ## Migrations
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -63,9 +63,14 @@ session and remains scoped to the selected origin.
 
 GitHub sign-in opens in the system browser, where existing GitHub sessions,
 passkeys, password managers, and two-factor authentication already work. After
-GitHub approves the login, `clickclack://auth/callback` returns a one-time grant
-to the running app. The app redeems it against the exact server that initiated
-the flow and reloads itself as the signed-in workspace.
+GitHub approves the login, `chat.clickclack.desktop:/auth/callback` returns a
+one-time grant to the running app. The app redeems it against the exact server
+that initiated the flow, verifies the resulting session through `/api/me`, and
+then reloads itself as the signed-in workspace. The app also accepts the legacy
+`clickclack://auth/callback` format when connecting to an older server.
+
+Servers using namespaced cookies require desktop OAuth protocol 2. They return
+an update-required page before sending an older desktop client to GitHub.
 
 ## Security model
 
@@ -79,10 +84,10 @@ Navigation stays on the configured ClickClack origin. GitHub OAuth and other
 HTTP(S) and mail links open in the system browser. The callback carries only an
 opaque, short-lived grant: GitHub access tokens and ClickClack session tokens
 never appear in the callback URL. Redemption requires the verifier held by the
-initiating app, is single-use, and expires after five minutes. Permission
-requests from remote content are denied. Server configuration is accepted only
-from the bundled local settings window and is written atomically with user-only
-permissions.
+initiating app, is single-use, survives server restart or replica handoff, and
+expires after five minutes. Permission requests from remote content are denied.
+Server configuration is accepted only from the bundled local settings window
+and is written atomically with user-only permissions.
 
 ## Build locally
 

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -12,8 +12,8 @@ resolver lives in `apps/api/internal/httpapi/server.go` (`currentActor`).
 
 1. `Authorization: Bearer <token>` — bearer session token or `ccb_...` bot
    token. Bot tokens resolve to the bot user plus token workspace/scopes.
-2. `cc_session` cookie — HTTP-only session cookie set by magic-link consume and
-   GitHub OAuth callback.
+2. Session cookie — `cc_session` by default, or the configured namespaced
+   cookie. It is HTTP-only and set by magic-link consume and GitHub OAuth.
 3. `X-ClickClack-User: usr_...` header — explicit user impersonation for local
    development and tests, accepted only from loopback clients using local
    request hosts.
@@ -83,10 +83,12 @@ CLI will not send a stored bearer token to a different `--server`, and it skips
 stored bearer tokens when `--user` / `CLICKCLACK_USER_ID` is set without an
 explicit `--token`.
 
-`ConsumeMagicLink` returns `{user, session, token}` and sets `cc_session` as an
-HTTP-only cookie. Browsers can drop the body; non-browser clients should hold
-the `session.token` for the `Authorization` header. Session cookies default to
-`Secure` outside local dev HTTP, even if a reverse proxy omits HTTPS headers.
+`ConsumeMagicLink` returns `{user, session, token}` and sets the configured
+HTTP-only session cookie. Browsers can drop the body; non-browser clients
+should hold the `session.token` for the `Authorization` header. Session cookies
+default to `Secure` outside local dev HTTP, even if a reverse proxy omits HTTPS
+headers. Duplicate cookies with the active session-cookie name are rejected
+instead of relying on cookie ordering.
 
 ## GitHub OAuth (optional)
 
@@ -95,6 +97,8 @@ the equivalent config keys) before serving:
 
 ```sh
 CLICKCLACK_PUBLIC_URL=https://chat.example.com
+# Optional only when trusted instances share one hostname:
+# CLICKCLACK_COOKIE_NAMESPACE=production
 CLICKCLACK_GITHUB_CLIENT_ID=...
 CLICKCLACK_GITHUB_CLIENT_SECRET=...
 # Optional org gate:
@@ -107,35 +111,65 @@ Without a client ID and client secret, `GET /api/auth/github/start` returns `501
 
 Flow:
 
-1. `GET /api/auth/github/start` sets a state cookie and redirects to GitHub.
+1. `GET /api/auth/github/start` creates a database-backed, ten-minute OAuth
+   transaction, sets an HTTP-only browser-binding cookie, and redirects to
+   GitHub with a SHA-256 PKCE challenge.
 2. GitHub redirects back to `GET /api/auth/github/callback?code&state`.
-3. The handler exchanges the code, fetches `/user` and primary `/user/emails`,
-   checks org membership when `CLICKCLACK_GITHUB_ALLOWED_ORG` is set, checks
-   moderator org membership when configured, upserts a user keyed by
-   `(provider="github", provider_subject=<github id>)`, joins the org-gated
-   default workspace or the open `Guests` workspace, creates a session, sets
-   `cc_session`, redirects to `/`.
+3. The handler atomically consumes the state only when the browser binding
+   matches, exchanges the code with the stored PKCE verifier and exact redirect
+   URI, fetches `/user` and primary `/user/emails`, checks configured org
+   membership, and upserts the GitHub identity.
+4. The handler joins the appropriate workspace, creates a session, sets the
+   configured session cookie, and redirects to `/`.
+
+The server stores hashes of state and browser-binding values. The short-lived
+PKCE verifier is stored because the callback must send it to GitHub. State is
+single-use, survives process restarts and multiple replicas, and permits up to
+eight concurrent starts for one browser. Expired rows are removed during new
+starts. Global pending-row limits bound abandoned or hostile starts.
 
 The desktop app uses the same GitHub callback through a system-browser handoff:
 
 1. The app creates a high-entropy verifier and opens
-   `GET /api/auth/github/desktop/start?code_challenge=<SHA-256 challenge>` in the
-   default browser.
+   `GET /api/auth/github/desktop/start?code_challenge=<SHA-256 challenge>&desktop_protocol=2`
+   in the default browser.
 2. After the normal GitHub callback succeeds, the server redirects to
-   `clickclack://auth/callback?code=<opaque one-time grant>`. No GitHub or
-   ClickClack session token is placed in the URL.
+   `chat.clickclack.desktop:/auth/callback?code=<opaque one-time grant>`. No
+   GitHub or ClickClack session token is placed in the URL.
 3. The app posts the grant and its verifier to
-   `POST /api/auth/github/desktop/consume`. The exact initiating server sets the
-   Electron session cookie, invalidates the grant, and the app reloads `/app`.
+   `POST /api/auth/github/desktop/consume`. The exact initiating server
+   atomically invalidates the grant, creates a session, and sets the configured
+   cookie in Electron's persistent session.
+4. The app calls `/api/me` through that same Electron session and loads `/app`
+   only after the server confirms the authenticated user. The desktop client
+   never depends on a particular cookie name.
 
-Desktop state expires after ten minutes; completed grants expire after five.
-The verifier binding prevents another local application from redeeming a custom
-protocol callback it intercepts. Pending challenges live only in the initiating
-browser's HTTP-only state cookies, so abandoned public starts do not consume
-server-side state or block other users from beginning sign-in.
+Desktop transactions expire after ten minutes; completed grants expire after
+five. Grants are persisted so the callback and redemption can hit different
+replicas or a restarted process. The verifier binding prevents another local
+application from redeeming a custom-protocol callback it intercepts. Grant
+codes are stored only as hashes and are single-use.
 
-The redirect URL is derived from `CLICKCLACK_PUBLIC_URL` when set, otherwise
-from the request scheme/host. Configure GitHub with `<public-url>/api/auth/github/callback`.
+Protocol-1 desktop clients remain compatible with deployments using the default
+cookie names and receive the legacy `clickclack://auth/callback` handoff.
+Namespaced deployments return HTTP 426 before redirecting an old client to
+GitHub, because that client cannot verify a namespaced session. Protocol-2
+clients accept both callback formats so they can sign in to old and new
+servers.
+
+The redirect URL is always derived from `CLICKCLACK_PUBLIC_URL` in production.
+Request-host derivation exists only for explicit loopback development. Configure
+GitHub with `<public-url>/api/auth/github/callback`.
+
+OAuth starts are public endpoints. The database enforces global and per-browser
+pending-row bounds, but internet-facing deployments must also rate-limit
+`/api/auth/github/start` and `/api/auth/github/desktop/start` at the trusted
+edge. Do not derive security limits from untrusted forwarded IP headers.
+
+When metrics are enabled, `clickclack_github_oauth_events_total` exposes only a
+fixed event category, including starts, state rejection, provider failure,
+capacity rejection, desktop protocol mismatch, and successful handoff. It never
+labels state, grants, users, cookies, callback parameters, or tokens.
 
 Without `CLICKCLACK_GITHUB_ALLOWED_ORG`, any GitHub account can sign in and is
 automatically joined to an isolated `Guests` workspace. When

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -49,8 +49,8 @@ SESSION=$(go run ./apps/api/cmd/clickclack login \
 ```
 
 That `ses_...` is what bots and CLIs put in `Authorization: Bearer`. The
-browser already has it as the `cc_session` cookie if you ran consume from the
-SPA.
+browser already has it as the default `cc_session` cookie if you ran consume
+from the SPA. Production deployments can select a stable namespaced cookie.
 
 To store the session for future CLI commands, omit `--no-store`.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/clickclack
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/coder/websocket v1.8.15

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/oklog/ulid/v2 v2.1.1
+	golang.org/x/oauth2 v0.36.0
 	modernc.org/sqlite v1.53.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
 golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -114,11 +114,20 @@ paths:
             minLength: 43
             maxLength: 43
             pattern: "^[A-Za-z0-9_-]+$"
+        - name: desktop_protocol
+          in: query
+          required: false
+          description: Desktop OAuth handoff version. Omitted clients use legacy protocol 1.
+          schema:
+            type: integer
+            enum: [1, 2]
       responses:
         "302":
           description: Redirect the system browser to GitHub OAuth authorization
         "400":
-          description: Invalid desktop code challenge
+          description: Invalid desktop code challenge or unsupported protocol
+        "426":
+          description: Desktop app upgrade required before a namespaced server can begin authentication
         "501":
           description: GitHub OAuth not configured
   /api/auth/github/desktop/consume:

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -1609,6 +1609,8 @@ export interface operations {
     parameters: {
       query: {
         code_challenge: string;
+        /** @description Desktop OAuth handoff version. Omitted clients use legacy protocol 1. */
+        desktop_protocol?: 1 | 2;
       };
       header?: never;
       path?: never;
@@ -1623,8 +1625,15 @@ export interface operations {
         };
         content?: never;
       };
-      /** @description Invalid desktop code challenge */
+      /** @description Invalid desktop code challenge or unsupported protocol */
       400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Desktop app upgrade required before a namespaced server can begin authentication */
+      426: {
         headers: {
           [name: string]: unknown;
         };


### PR DESCRIPTION
## Why

HTTP cookies are scoped by hostname, not port. Multiple ClickClack instances on one hostname can therefore overwrite or misread each other's session and OAuth cookies. A configurable session-cookie name alone does not make that deployment production-safe: OAuth state also needs browser binding, state and desktop grants must survive restarts and replica handoff, callback origins must not come from request headers, and desktop clients need a versioned migration path.

## What changed

- Replaced the arbitrary cookie-name setting with a stable `CLICKCLACK_COOKIE_NAMESPACE` policy. The default remains `cc_session` / `cc_oauth_binding`; namespaced HTTPS deployments use `__Host-cc-<namespace>-...` cookies.
- Added strict `CLICKCLACK_PUBLIC_URL` startup validation and canonicalization. Production OAuth uses that exact origin and redirect URI instead of request-host derivation.
- Persisted OAuth transactions and desktop grants in SQLite and PostgreSQL with migrations, expiry, bounded pending rows, single-use consumption, and serialized PostgreSQL capacity enforcement.
- Added browser-binding cookies and SHA-256 PKCE to GitHub OAuth. State, bindings, and desktop grants are stored as hashes; provider and internal failures return fixed public errors.
- Reworked desktop OAuth as protocol 2 with a reverse-domain callback, verifier-bound one-time grants, Electron-session redemption, and an authenticated `/api/me` check. Existing protocol-1 clients remain supported on default-cookie deployments; namespaced deployments reject them with HTTP 426 before GitHub authorization.
- Rejects duplicate active session or OAuth-binding cookies instead of depending on cookie order or falling through to development authentication.
- Added bounded OAuth lifecycle metrics without secrets or high-cardinality labels.
- Updated OpenAPI, generated SDK types, configuration/auth/deployment/desktop docs, and both Docker build images.
- Raised the Go toolchain and pinned Docker builder image to Go 1.26.5 after vulnerability scanning found reachable standard-library issues in the previous build toolchain.

## Security and compatibility

- Cookie namespaces prevent accidental collisions between trusted ClickClack instances. They are not a security boundary for mutually untrusted services; those services require separate hostnames or domains.
- One ClickClack deployment must use one stable namespace across every replica. Changing it signs browser users out.
- The default cookie names and legacy desktop callback remain unchanged when no namespace is configured.
- Protocol-2 desktop clients can authenticate against both legacy and namespaced servers. Protocol-1 clients continue to work only with default-cookie servers.
- OAuth transaction state survives process restarts and cross-replica callbacks. Desktop grant redemption and session creation are atomic.
- OAuth query strings, authorization headers, and cookie headers must be excluded from proxy access logs.

## Deployment requirements

1. Set `CLICKCLACK_PUBLIC_URL` to the exact external origin. Non-loopback deployments require HTTPS.
2. Configure the GitHub OAuth callback as `<public-url>/api/auth/github/callback`. Distinct public origins or non-default ports need matching GitHub OAuth app configuration.
3. Set a unique, stable `CLICKCLACK_COOKIE_NAMESPACE` only when trusted ClickClack instances share one hostname.
4. Apply the included SQLite or PostgreSQL migrations before serving the new version.
5. Terminate TLS at trusted infrastructure, enable HSTS after validating the covered hostnames, and rate-limit the public OAuth start endpoints at the edge.
6. Upgrade desktop clients to protocol 2 before enabling a cookie namespace.

## Verification

Independent review covered cookie ambiguity, callback-origin handling, OAuth error disclosure, state/grant lifecycle, PostgreSQL concurrency, restart/replica behavior, desktop compatibility, generated contracts, and sibling request-origin paths.

Remote validation used AWS Crabbox leases `cbx_f60e802956d5` and `cbx_486658c4addd`:

- Full `pnpm check` with PostgreSQL 18.4, including Go, TypeScript, desktop, lint, format, and generated-web tests.
- SQLC regeneration produced byte-identical generated stores.
- Race detector passed for auth policy, config, HTTP/OAuth, PostgreSQL, and SQLite.
- Dead-code analysis passed.
- Go coverage: 85.8% against the 85% gate.
- `govulncheck` on Go 1.26.5: no vulnerabilities found.
- `pnpm audit --prod --audit-level high`: no known vulnerabilities found.
- Both production Dockerfiles built from the pinned Go 1.26.5 digest.
- The standard container started as UID 1000 and returned `healthz=ok` and `readyz=ready`.
- Documentation site built successfully.
- Linux desktop AppImage and deb packages built successfully.

GitHub CI remains the landing gate for the pushed head, including native macOS and Windows desktop packaging.

## Remaining external proof

No live GitHub OAuth app credentials were used during this rewrite. Deterministic provider tests exercise exact redirect URIs, PKCE exchange, callback binding, provider failures, persisted state, grant redemption, and authenticated follow-up behavior. A live GitHub smoke remains release-environment validation rather than a merge-time automated test.
