### PR TITLE
test: stabilize realtime e2e readiness

### DIFF
--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1687,11 +1687,18 @@ test("browser notifications announce incoming messages outside the active conver
   const workspacesResponse = await page.request.get("/api/workspaces");
   const workspaces = (await workspacesResponse.json()) as { workspaces: { id: string }[] };
   const workspaceId = workspaces.workspaces[0].id;
+
+  await page.goto("/app");
+  await expect(page.getByRole("heading", { name: "#general" })).toBeVisible();
+  await expect(page.locator('.shell[data-connected="true"]')).toBeVisible();
+
   const channelName = `notify-${randomUUID()}`;
   const channelResponse = await page.request.post(`/api/workspaces/${workspaceId}/channels`, {
     data: { name: channelName, kind: "public" },
   });
   const channel = (await channelResponse.json()) as { channel: { id: string; name: string } };
+  await expect(page.getByRole("link", { name: `# ${channel.channel.name}` })).toBeVisible();
+
   const senderID = clickclack([
     "admin",
     "user",
@@ -1706,9 +1713,6 @@ test("browser notifications announce incoming messages outside the active conver
     `${channelName}@example.com`,
   ]);
 
-  await page.goto("/app");
-  await expect(page.getByRole("heading", { name: "#general" })).toBeVisible();
-  await expect(page.locator('.shell[data-connected="true"]')).toBeVisible();
   const remoteResponse = await page.request.post(`/api/channels/${channel.channel.id}/messages`, {
     headers: { "X-ClickClack-User": senderID },
     data: { body: "ping from another channel" },

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -385,8 +385,15 @@ test("channels can be reordered accessibly and persist locally", async ({ page, 
   const mobilePage = await mobileContext.newPage();
   await mobilePage.goto(`/app/${workspace.route_id}`);
   await waitForAppReady(mobilePage);
-  await mobilePage.getByRole("button", { name: "Toggle navigation" }).click();
-  await mobilePage.getByRole("button", { name: `Move #${names[1]}` }).click();
+  await expect
+    .poll(() => channelNames(mobilePage))
+    .toEqual([names[0], addedName, names[1], names[2]]);
+  const mobileNavigationToggle = mobilePage.getByRole("button", { name: "Toggle navigation" });
+  await mobileNavigationToggle.click();
+  await expect(mobileNavigationToggle).toHaveAttribute("aria-expanded", "true");
+  const mobileMoveButton = mobilePage.getByRole("button", { name: `Move #${names[1]}` });
+  await expect(mobileMoveButton).toBeInViewport();
+  await mobileMoveButton.click();
   await mobilePage
     .getByRole("menu", { name: `Move #${names[1]}` })
     .getByRole("menuitem", { name: "Move up" })


### PR DESCRIPTION
## Summary
- wait for the mobile channel list to finish restoring before opening the reorder menu
- wait for the notification channel to arrive through realtime before posting the background message

## Verification
- `pnpm check`
- `pnpm test:e2e -- --reporter=line` (74 passed)
- mobile channel reorder: 20 repeated runs passed
- browser notifications: 20 repeated runs passed
- sidebar collapse stress: 20 repeated runs passed
