### PR TITLE
fix: make upload and message retries idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added owner-scoped message nonce lookup so durable clients can distinguish completed sends from interrupted requests and recover attachments safely. Thanks @shakkernerd.
 - Added durable upload idempotency and nonce lookup so retried bot deliveries reuse the original upload without consuming more storage or quota. Thanks @shakkernerd.
 - Allowed disabled Pushover notification settings to clear the stored user key through the public API contract.
 - Unified the desktop shell chrome like Slack: title bar, workspace rail, and sidebar share one continuous plate with the conversation floating on it as a rounded card, the sidebar workspace header and the in-card channel header are gone on desktop — the workspace name (click for workspace settings) and the current channel or DM title live in the title bar — and the always-on "Connected" labels are gone everywhere (app settings stay on the native menu and Cmd/Ctrl+,; a pulsing "Connecting…" note appears only while the realtime link is down). The browser app keeps its sidebar workspace header and channel header unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added durable upload idempotency and nonce lookup so retried bot deliveries reuse the original upload without consuming more storage or quota. Thanks @shakkernerd.
 - Allowed disabled Pushover notification settings to clear the stored user key through the public API contract.
 - Unified the desktop shell chrome like Slack: title bar, workspace rail, and sidebar share one continuous plate with the conversation floating on it as a rounded card, the sidebar workspace header and the in-card channel header are gone on desktop — the workspace name (click for workspace settings) and the current channel or DM title live in the title bar — and the always-on "Connected" labels are gone everywhere (app settings stay on the native menu and Cmd/Ctrl+,; a pulsing "Connecting…" note appears only while the realtime link is down). The browser app keeps its sidebar workspace header and channel header unchanged.
 - Fixed live agent-activity bursts so same-turn preambles grow in place without dropping realtime rows or pulling a bottom-pinned timeline away from the live edge.

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -52,6 +52,7 @@ func TestHTTPUnauthorizedRoutes(t *testing.T) {
 		{http.MethodGet, "/api/realtime/ws?workspace_id=wsp_missing", ""},
 		{http.MethodGet, "/api/search?workspace_id=wsp_missing&q=x", ""},
 		{http.MethodPost, "/api/uploads", ""},
+		{http.MethodGet, "/api/uploads/by-nonce?workspace_id=wsp_missing&nonce=missing", ""},
 		{http.MethodGet, "/api/uploads/upl_missing", ""},
 		{http.MethodPost, "/api/messages/msg_missing/attachments", `{"upload_id":"upl_missing"}`},
 		{http.MethodGet, "/api/dms?workspace_id=wsp_missing", ""},

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -53,6 +53,7 @@ func TestHTTPUnauthorizedRoutes(t *testing.T) {
 		{http.MethodGet, "/api/search?workspace_id=wsp_missing&q=x", ""},
 		{http.MethodPost, "/api/uploads", ""},
 		{http.MethodGet, "/api/uploads/by-nonce?workspace_id=wsp_missing&nonce=missing", ""},
+		{http.MethodGet, "/api/messages/by-nonce?workspace_id=wsp_missing&nonce=missing", ""},
 		{http.MethodGet, "/api/uploads/upl_missing", ""},
 		{http.MethodPost, "/api/messages/msg_missing/attachments", `{"upload_id":"upl_missing"}`},
 		{http.MethodGet, "/api/dms?workspace_id=wsp_missing", ""},

--- a/apps/api/internal/httpapi/bot_scope.go
+++ b/apps/api/internal/httpapi/bot_scope.go
@@ -24,13 +24,20 @@ func (s *Server) requireBotMessageResource(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return store.Message{}, false
 	}
+	if !requireBotMessageDirectScope(w, act, message, directScope) {
+		return store.Message{}, false
+	}
+	return message, true
+}
+
+func requireBotMessageDirectScope(w http.ResponseWriter, act actor, message store.Message, directScope string) bool {
 	if act.botTokenID != "" && message.DirectConversationID != "" {
 		if err := act.requireScope(directScope); err != nil {
 			writeError(w, http.StatusForbidden, err)
-			return store.Message{}, false
+			return false
 		}
 	}
-	return message, true
+	return true
 }
 
 func (s *Server) requireBotUploadResource(w http.ResponseWriter, r *http.Request, act actor, upload store.Upload, sameMessageID string) bool {

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -366,6 +366,7 @@ func writeUploadBodyError(w http.ResponseWriter, err error, fallbackStatus int) 
 }
 
 func (s *Server) getUploadByNonce(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-ClickClack-Upload-Nonce", "supported")
 	act, err := s.currentActor(r)
 	if err != nil {
 		writeError(w, http.StatusUnauthorized, err)

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -387,6 +387,12 @@ func (s *Server) authorizeWorkspaceAccess(w http.ResponseWriter, r *http.Request
 
 func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
+	if !utf8.ValidString(nonce) {
+		return "", errors.New("nonce must be valid UTF-8")
+	}
+	if strings.IndexByte(nonce, 0) >= 0 {
+		return "", errors.New("nonce must not contain NUL")
+	}
 	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -125,7 +125,7 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
-	nonce, err := normalizeUploadNonce(r.URL.Query().Get("nonce"))
+	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
@@ -136,7 +136,7 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if workspaceID != "" {
-		if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
+		if !s.authorizeWorkspaceAccess(w, r, act, workspaceID) {
 			return
 		}
 		if nonce != "" {
@@ -354,7 +354,7 @@ func (r *uploadQuotaReader) Read(p []byte) (int, error) {
 }
 
 func (s *Server) authorizeUploadWorkspace(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) (store.UploadQuota, bool) {
-	if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
+	if !s.authorizeWorkspaceAccess(w, r, act, workspaceID) {
 		return store.UploadQuota{}, false
 	}
 	return s.checkUploadQuota(w, r, act, workspaceID)
@@ -373,7 +373,7 @@ func (s *Server) checkUploadQuota(w http.ResponseWriter, r *http.Request, act ac
 	return quota, true
 }
 
-func (s *Server) authorizeUploadWorkspaceAccess(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) bool {
+func (s *Server) authorizeWorkspaceAccess(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) bool {
 	if err := act.requireWorkspace(workspaceID); err != nil {
 		writeError(w, http.StatusForbidden, err)
 		return false
@@ -385,7 +385,7 @@ func (s *Server) authorizeUploadWorkspaceAccess(w http.ResponseWriter, r *http.R
 	return true
 }
 
-func normalizeUploadNonce(value string) (string, error) {
+func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
 	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
@@ -422,7 +422,7 @@ func (s *Server) getUploadByNonce(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("workspace_id is required"))
 		return
 	}
-	nonce, err := normalizeUploadNonce(r.URL.Query().Get("nonce"))
+	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
@@ -431,7 +431,7 @@ func (s *Server) getUploadByNonce(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("nonce is required"))
 		return
 	}
-	if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
+	if !s.authorizeWorkspaceAccess(w, r, act, workspaceID) {
 		return
 	}
 	upload, err := s.store.GetUploadByNonce(r.Context(), act.user.ID, nonce)

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -122,6 +122,39 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
+	nonce, err := normalizeUploadNonce(r.URL.Query().Get("nonce"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+	if nonce != "" && workspaceID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("workspace_id query parameter is required with nonce"))
+		return
+	}
+	if workspaceID != "" {
+		if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
+			return
+		}
+		if nonce != "" {
+			existing, err := s.store.GetUploadByNonce(r.Context(), act.user.ID, nonce)
+			switch {
+			case err == nil:
+				if existing.WorkspaceID != workspaceID {
+					writeStoreError(w, store.ErrUploadNonceConflict)
+					return
+				}
+				writeJSON(w, http.StatusOK, map[string]any{"upload": existing})
+				return
+			case !errors.Is(err, sql.ErrNoRows):
+				writeStoreError(w, err)
+				return
+			}
+		}
+		if _, ok := s.checkUploadQuota(w, r, act, workspaceID); !ok {
+			return
+		}
+	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxUploadBytes)
 	reader, err := r.MultipartReader()
 	if err != nil {
@@ -129,14 +162,6 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	fields := map[string]string{}
-	workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
-	if workspaceID != "" {
-		var ok bool
-		_, ok = s.authorizeUploadWorkspace(w, r, act, workspaceID)
-		if !ok {
-			return
-		}
-	}
 	var upload store.CreateUploadInput
 	var savedPath string
 	var reservationID string
@@ -213,6 +238,7 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		upload = store.CreateUploadInput{
 			WorkspaceID: workspaceID,
 			OwnerID:     act.user.ID,
+			Nonce:       nonce,
 			Filename:    filepath.Base(part.FileName()),
 			ContentType: contentType,
 			ByteSize:    saved.ByteSize,
@@ -237,8 +263,26 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 	if err == nil {
 		committed = true
 		reservationID = ""
+		writeJSON(w, http.StatusCreated, map[string]any{"upload": created})
+		return
 	}
-	writeResultStatus(w, http.StatusCreated, map[string]any{"upload": created}, err)
+	if nonce != "" {
+		// A concurrent request may have committed this nonce after the early lookup.
+		// Keep committed false so the deferred cleanup discards this request's object.
+		existing, lookupErr := s.store.GetUploadByNonce(r.Context(), act.user.ID, nonce)
+		switch {
+		case lookupErr == nil && existing.WorkspaceID == workspaceID:
+			writeJSON(w, http.StatusOK, map[string]any{"upload": existing})
+			return
+		case lookupErr == nil:
+			writeStoreError(w, store.ErrUploadNonceConflict)
+			return
+		case !errors.Is(lookupErr, sql.ErrNoRows):
+			writeStoreError(w, lookupErr)
+			return
+		}
+	}
+	writeStoreError(w, err)
 }
 
 type uploadQuotaReader struct {
@@ -269,14 +313,13 @@ func (r *uploadQuotaReader) Read(p []byte) (int, error) {
 }
 
 func (s *Server) authorizeUploadWorkspace(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) (store.UploadQuota, bool) {
-	if err := act.requireWorkspace(workspaceID); err != nil {
-		writeError(w, http.StatusForbidden, err)
+	if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
 		return store.UploadQuota{}, false
 	}
-	if _, err := s.store.GetWorkspace(r.Context(), workspaceID, act.user.ID); err != nil {
-		writeError(w, http.StatusForbidden, err)
-		return store.UploadQuota{}, false
-	}
+	return s.checkUploadQuota(w, r, act, workspaceID)
+}
+
+func (s *Server) checkUploadQuota(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) (store.UploadQuota, bool) {
 	quota, err := s.store.UploadQuota(r.Context(), workspaceID, act.user.ID)
 	if err != nil {
 		writeStoreError(w, err)
@@ -287,6 +330,26 @@ func (s *Server) authorizeUploadWorkspace(w http.ResponseWriter, r *http.Request
 		return store.UploadQuota{}, false
 	}
 	return quota, true
+}
+
+func (s *Server) authorizeUploadWorkspaceAccess(w http.ResponseWriter, r *http.Request, act actor, workspaceID string) bool {
+	if err := act.requireWorkspace(workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return false
+	}
+	if _, err := s.store.GetWorkspace(r.Context(), workspaceID, act.user.ID); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return false
+	}
+	return true
+}
+
+func normalizeUploadNonce(value string) (string, error) {
+	nonce := strings.TrimSpace(value)
+	if len(nonce) > 128 {
+		return "", errors.New("nonce is too long")
+	}
+	return nonce, nil
 }
 
 func writeUploadBodyError(w http.ResponseWriter, err error, fallbackStatus int) {
@@ -300,6 +363,49 @@ func writeUploadBodyError(w http.ResponseWriter, err error, fallbackStatus int) 
 		return
 	}
 	writeError(w, fallbackStatus, err)
+}
+
+func (s *Server) getUploadByNonce(w http.ResponseWriter, r *http.Request) {
+	act, err := s.currentActor(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	if err := act.requireScope("uploads:write"); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+	workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("workspace_id is required"))
+		return
+	}
+	nonce, err := normalizeUploadNonce(r.URL.Query().Get("nonce"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if nonce == "" {
+		writeError(w, http.StatusBadRequest, errors.New("nonce is required"))
+		return
+	}
+	if !s.authorizeUploadWorkspaceAccess(w, r, act, workspaceID) {
+		return
+	}
+	upload, err := s.store.GetUploadByNonce(r.Context(), act.user.ID, nonce)
+	if errors.Is(err, sql.ErrNoRows) {
+		writeError(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if upload.WorkspaceID != workspaceID {
+		writeStoreError(w, store.ErrUploadNonceConflict)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"upload": upload})
 }
 
 func (s *Server) getUpload(w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -26,6 +26,8 @@ import (
 const (
 	maxUploadBytes       = 64 << 20
 	uploadCleanupTimeout = 5 * time.Second
+	uploadNonceRetryWait = 25 * time.Millisecond
+	uploadNonceRetryMax  = 250 * time.Millisecond
 )
 
 func formInt(values map[string]string, key string) int {
@@ -151,8 +153,7 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 				writeStoreError(w, err)
 				return
 			}
-		}
-		if _, ok := s.checkUploadQuota(w, r, act, workspaceID); !ok {
+		} else if _, ok := s.checkUploadQuota(w, r, act, workspaceID); !ok {
 			return
 		}
 	}
@@ -224,9 +225,13 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}
-		reservation, err := s.store.ReserveUploadQuota(r.Context(), workspaceID, act.user.ID, int64(maxUploadBytes))
+		reservation, replayed, err := s.reserveUploadQuota(r.Context(), workspaceID, act.user.ID, nonce)
 		if err != nil {
 			writeStoreError(w, err)
+			return
+		}
+		if replayed != nil {
+			writeJSON(w, http.StatusOK, map[string]any{"upload": *replayed})
 			return
 		}
 		reservationID = reservation.ID
@@ -284,6 +289,41 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeStoreError(w, err)
+}
+
+func (s *Server) reserveUploadQuota(ctx context.Context, workspaceID, ownerID, nonce string) (store.UploadQuotaReservation, *store.Upload, error) {
+	retryWait := uploadNonceRetryWait
+	for {
+		reservation, err := s.store.ReserveUploadQuota(ctx, workspaceID, ownerID, nonce, int64(maxUploadBytes))
+		if err == nil {
+			return reservation, nil, nil
+		}
+		if nonce == "" || !errors.Is(err, store.ErrUploadNonceInProgress) {
+			return store.UploadQuotaReservation{}, nil, err
+		}
+		existing, lookupErr := s.store.GetUploadByNonce(ctx, ownerID, nonce)
+		switch {
+		case lookupErr == nil && existing.WorkspaceID != workspaceID:
+			return store.UploadQuotaReservation{}, nil, store.ErrUploadNonceConflict
+		case lookupErr == nil:
+			return store.UploadQuotaReservation{}, &existing, nil
+		case !errors.Is(lookupErr, sql.ErrNoRows):
+			return store.UploadQuotaReservation{}, nil, lookupErr
+		}
+		timer := time.NewTimer(retryWait)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return store.UploadQuotaReservation{}, nil, ctx.Err()
+		case <-timer.C:
+		}
+		retryWait = min(retryWait*2, uploadNonceRetryMax)
+	}
 }
 
 type uploadQuotaReader struct {

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -346,7 +347,7 @@ func (s *Server) authorizeUploadWorkspaceAccess(w http.ResponseWriter, r *http.R
 
 func normalizeUploadNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
-	if len(nonce) > 128 {
+	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}
 	return nonce, nil

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -164,6 +165,7 @@ func (s *Server) Handler() http.Handler {
 		r.Get("/channels/{channel_id}/messages", s.listMessages)
 		r.Post("/channels/{channel_id}/messages", s.createMessage)
 		r.Post("/channels/{channel_id}/read", s.markChannelRead)
+		r.Get("/messages/by-nonce", s.getMessageByNonce)
 		r.Get("/messages/{message_id}", s.getMessage)
 		r.Patch("/messages/{message_id}", s.updateMessage)
 		r.Delete("/messages/{message_id}", s.deleteMessage)
@@ -971,6 +973,47 @@ func (s *Server) getMessage(w http.ResponseWriter, r *http.Request) {
 		message, err = s.store.GetMessage(r.Context(), chi.URLParam(r, "message_id"), act.user.ID)
 	}
 	writeResult(w, map[string]any{"message": message}, err)
+}
+
+func (s *Server) getMessageByNonce(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-ClickClack-Message-Nonce", "supported")
+	act, err := s.currentActor(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	if err := act.requireScope("messages:write"); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+	workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, errors.New("workspace_id is required"))
+		return
+	}
+	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if nonce == "" {
+		writeError(w, http.StatusBadRequest, errors.New("nonce is required"))
+		return
+	}
+	if !s.authorizeWorkspaceAccess(w, r, act, workspaceID) {
+		return
+	}
+	message, err := s.store.GetMessageByNonce(r.Context(), act.user.ID, nonce)
+	switch {
+	case err == nil && message.WorkspaceID != workspaceID:
+		writeStoreError(w, store.ErrClientNonceConflict)
+	case err == nil:
+		writeJSON(w, http.StatusOK, map[string]any{"message": message})
+	case errors.Is(err, sql.ErrNoRows):
+		writeError(w, http.StatusNotFound, err)
+	default:
+		writeStoreError(w, err)
+	}
 }
 
 func (s *Server) getThread(w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -176,6 +176,7 @@ func (s *Server) Handler() http.Handler {
 		r.Get("/realtime/ws", s.websocket)
 		r.Get("/search", s.search)
 		r.Post("/uploads", s.createUpload)
+		r.Get("/uploads/by-nonce", s.getUploadByNonce)
 		r.Get("/uploads/{upload_id}", s.getUpload)
 		r.Post("/messages/{message_id}/attachments", s.attachUpload)
 		r.Get("/dms", s.listDirectConversations)
@@ -1450,6 +1451,8 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusTooManyRequests, err)
 	case errors.Is(err, store.ErrUploadQuotaExceeded):
 		writeError(w, http.StatusRequestEntityTooLarge, err)
+	case errors.Is(err, store.ErrUploadNonceConflict):
+		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, store.ErrModerationRestricted):
 		writeError(w, http.StatusForbidden, err)
 	case errors.Is(err, store.ErrNotWorkspaceManager):

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1008,6 +1008,9 @@ func (s *Server) getMessageByNonce(w http.ResponseWriter, r *http.Request) {
 	case err == nil && message.WorkspaceID != workspaceID:
 		writeStoreError(w, store.ErrClientNonceConflict)
 	case err == nil:
+		if !requireBotMessageDirectScope(w, act, message, "dms:write") {
+			return
+		}
 		writeJSON(w, http.StatusOK, map[string]any{"message": message})
 	case errors.Is(err, sql.ErrNoRows):
 		writeError(w, http.StatusNotFound, err)

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -143,6 +143,31 @@ func TestChatAPIVerticalSlice(t *testing.T) {
 	if replayStatus != http.StatusOK || nonceReplay.Message.ID != nonceCreated.Message.ID || nonceReplay.Event != nil {
 		t.Fatalf("unexpected nonce replay response: status=%d payload=%#v", replayStatus, nonceReplay)
 	}
+	nonceLookupURL := server.URL + "/api/messages/by-nonce?workspace_id=" + url.QueryEscape(workspace.ID) + "&nonce=http-nonce-1"
+	nonceLookupResponse, err := http.Get(nonceLookupURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nonceLookupResponse.Body.Close()
+	var nonceLookup struct {
+		Message store.Message `json:"message"`
+	}
+	if err := json.NewDecoder(nonceLookupResponse.Body).Decode(&nonceLookup); err != nil {
+		t.Fatal(err)
+	}
+	if nonceLookupResponse.StatusCode != http.StatusOK ||
+		nonceLookupResponse.Header.Get("X-ClickClack-Message-Nonce") != "supported" ||
+		nonceLookup.Message.ID != nonceCreated.Message.ID {
+		t.Fatalf("unexpected message nonce lookup: status=%s headers=%v message=%#v", nonceLookupResponse.Status, nonceLookupResponse.Header, nonceLookup.Message)
+	}
+	missingNonceResponse, err := http.Get(server.URL + "/api/messages/by-nonce?workspace_id=" + url.QueryEscape(workspace.ID) + "&nonce=missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingNonceResponse.Body.Close()
+	if missingNonceResponse.StatusCode != http.StatusNotFound || missingNonceResponse.Header.Get("X-ClickClack-Message-Nonce") != "supported" {
+		t.Fatalf("unexpected missing message nonce response: status=%s headers=%v", missingNonceResponse.Status, missingNonceResponse.Header)
+	}
 
 	messages := getJSON[struct {
 		Messages []store.Message `json:"messages"`
@@ -191,6 +216,16 @@ func TestChatAPIVerticalSlice(t *testing.T) {
 	attach := postJSON[map[string]bool](t, server.URL+"/api/messages/"+created.Message.ID+"/attachments", map[string]string{"upload_id": upload.ID})
 	if !attach["ok"] {
 		t.Fatal("expected attachment success")
+	}
+	nonceAttach := postJSON[map[string]bool](t, server.URL+"/api/messages/"+nonceCreated.Message.ID+"/attachments", map[string]string{"upload_id": upload.ID})
+	if !nonceAttach["ok"] {
+		t.Fatal("expected nonce message attachment success")
+	}
+	nonceLookup = getJSON[struct {
+		Message store.Message `json:"message"`
+	}](t, nonceLookupURL)
+	if len(nonceLookup.Message.Attachments) != 1 || nonceLookup.Message.Attachments[0].ID != upload.ID {
+		t.Fatalf("message nonce lookup did not hydrate attachments: %#v", nonceLookup.Message.Attachments)
 	}
 	body := getBody(t, server.URL+"/api/uploads/"+upload.ID)
 	if body != "hello upload" {
@@ -2772,14 +2807,14 @@ func TestUploadQuotaReaderStopsOverBudget(t *testing.T) {
 	}
 }
 
-func TestNormalizeUploadNonceCountsCharacters(t *testing.T) {
+func TestNormalizeClientNonceCountsCharacters(t *testing.T) {
 	t.Parallel()
 
 	valid := strings.Repeat("é", 128)
-	if normalized, err := normalizeUploadNonce(valid); err != nil || normalized != valid {
+	if normalized, err := normalizeClientNonce(valid); err != nil || normalized != valid {
 		t.Fatalf("expected 128-character nonce to remain valid: normalized=%q err=%v", normalized, err)
 	}
-	if _, err := normalizeUploadNonce(strings.Repeat("é", 129)); err == nil {
+	if _, err := normalizeClientNonce(strings.Repeat("é", 129)); err == nil {
 		t.Fatal("expected 129-character nonce rejection")
 	}
 }

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -2216,35 +2217,10 @@ func uploadFileAsUserWithContentType(t *testing.T, userID, endpoint, workspaceID
 
 func uploadFileWithNonceStatus(t *testing.T, endpoint, workspaceID, nonce, filename, content string) (store.Upload, int) {
 	t.Helper()
-	endpointURL, err := url.Parse(endpoint)
+	req, err := newUploadWithNonceRequest(endpoint, workspaceID, nonce, filename, content)
 	if err != nil {
 		t.Fatal(err)
 	}
-	query := endpointURL.Query()
-	query.Set("workspace_id", workspaceID)
-	query.Set("nonce", nonce)
-	endpointURL.RawQuery = query.Encode()
-
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	if err := writer.WriteField("workspace_id", workspaceID); err != nil {
-		t.Fatal(err)
-	}
-	part, err := writer.CreateFormFile("file", filename)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := part.Write([]byte(content)); err != nil {
-		t.Fatal(err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatal(err)
-	}
-	req, err := http.NewRequest(http.MethodPost, endpointURL.String(), &body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", writer.FormDataContentType())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
@@ -2257,6 +2233,39 @@ func uploadFileWithNonceStatus(t *testing.T, endpoint, workspaceID, nonce, filen
 		t.Fatal(err)
 	}
 	return out.Upload, resp.StatusCode
+}
+
+func newUploadWithNonceRequest(endpoint, workspaceID, nonce, filename, content string) (*http.Request, error) {
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	query := endpointURL.Query()
+	query.Set("workspace_id", workspaceID)
+	query.Set("nonce", nonce)
+	endpointURL.RawQuery = query.Encode()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("workspace_id", workspaceID); err != nil {
+		return nil, err
+	}
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, endpointURL.String(), &body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
 }
 
 func uploadFileWithoutPartContentType(t *testing.T, endpoint, workspaceID string) store.Upload {
@@ -2839,13 +2848,30 @@ func TestUploadNonceReplaysWithoutConsumingStorageOrQuota(t *testing.T) {
 	if firstStatus != http.StatusCreated || first.Nonce != nonce {
 		t.Fatalf("unexpected initial upload: status=%d upload=%#v", firstStatus, first)
 	}
-	lookup := getJSON[struct {
-		Upload store.Upload `json:"upload"`
-	}](t, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(workspace.ID)+"&nonce="+url.QueryEscape(nonce))
-	if lookup.Upload.ID != first.ID {
-		t.Fatalf("upload nonce lookup returned %#v, want %s", lookup.Upload, first.ID)
+	lookupResponse, err := http.Get(server.URL + "/api/uploads/by-nonce?workspace_id=" + url.QueryEscape(workspace.ID) + "&nonce=" + url.QueryEscape(nonce))
+	if err != nil {
+		t.Fatal(err)
 	}
-	expectStatus(t, http.MethodGet, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(workspace.ID)+"&nonce=missing", nil, http.StatusNotFound)
+	defer lookupResponse.Body.Close()
+	var lookup struct {
+		Upload store.Upload `json:"upload"`
+	}
+	if err := json.NewDecoder(lookupResponse.Body).Decode(&lookup); err != nil {
+		t.Fatal(err)
+	}
+	if lookupResponse.StatusCode != http.StatusOK ||
+		lookupResponse.Header.Get("X-ClickClack-Upload-Nonce") != "supported" ||
+		lookup.Upload.ID != first.ID {
+		t.Fatalf("unexpected upload nonce lookup: status=%s headers=%v upload=%#v", lookupResponse.Status, lookupResponse.Header, lookup.Upload)
+	}
+	missingResponse, err := http.Get(server.URL + "/api/uploads/by-nonce?workspace_id=" + url.QueryEscape(workspace.ID) + "&nonce=missing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	missingResponse.Body.Close()
+	if missingResponse.StatusCode != http.StatusNotFound || missingResponse.Header.Get("X-ClickClack-Upload-Nonce") != "supported" {
+		t.Fatalf("unexpected missing nonce response: status=%s headers=%v", missingResponse.Status, missingResponse.Header)
+	}
 	for i := int64(1); i < store.UploadQuotaCountPerUserWorkspace; i++ {
 		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
 			WorkspaceID: workspace.ID,
@@ -2894,6 +2920,108 @@ func TestUploadNonceReplaysWithoutConsumingStorageOrQuota(t *testing.T) {
 	expectStatus(t, http.MethodGet, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(otherWorkspace.ID)+"&nonce="+url.QueryEscape(nonce), nil, http.StatusConflict)
 	if _, status := uploadFileWithNonceStatus(t, server.URL+"/api/uploads", workspace.ID, strings.Repeat("n", 129), "long.txt", "long body"); status != http.StatusBadRequest {
 		t.Fatalf("expected overlong nonce rejection, got %d", status)
+	}
+}
+
+func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "upload-race-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	storage := newConcurrentUploadStore()
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadStorage: storage}).Handler())
+	t.Cleanup(server.Close)
+
+	type result struct {
+		upload store.Upload
+		status int
+		err    error
+	}
+	results := make(chan result, 2)
+	client := &http.Client{Timeout: 5 * time.Second}
+	for i := range 2 {
+		go func() {
+			req, err := newUploadWithNonceRequest(
+				server.URL+"/api/uploads",
+				workspace.ID,
+				"concurrent-upload",
+				fmt.Sprintf("race-%d.txt", i),
+				"same body",
+			)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				results <- result{err: err}
+				return
+			}
+			defer resp.Body.Close()
+			var body struct {
+				Upload store.Upload `json:"upload"`
+			}
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				results <- result{status: resp.StatusCode, err: err}
+				return
+			}
+			results <- result{upload: body.Upload, status: resp.StatusCode}
+		}()
+	}
+
+	readResult := func() result {
+		select {
+		case value := <-results:
+			return value
+		case <-time.After(10 * time.Second):
+			return result{err: errors.New("timed out waiting for concurrent upload")}
+		}
+	}
+	first := readResult()
+	second := readResult()
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent uploads failed: first=%v second=%v", first.err, second.err)
+	}
+	statuses := map[int]int{first.status: 1}
+	statuses[second.status]++
+	if statuses[http.StatusCreated] != 1 || statuses[http.StatusOK] != 1 {
+		t.Fatalf("unexpected concurrent statuses: first=%d second=%d", first.status, second.status)
+	}
+	if first.upload.ID == "" || first.upload.ID != second.upload.ID {
+		t.Fatalf("concurrent replay returned different uploads: first=%#v second=%#v", first.upload, second.upload)
+	}
+	select {
+	case <-storage.deleted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("losing upload object was not deleted")
+	}
+	select {
+	case path := <-storage.deleted:
+		t.Fatalf("deleted more than one upload object: %s", path)
+	default:
+	}
+	quota, err := st.UploadQuota(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quota.UsedCount != 1 || quota.UsedBytes != int64(len("same body")) {
+		t.Fatalf("losing reservation was not released: %#v", quota)
 	}
 }
 
@@ -3081,6 +3209,52 @@ func (s *quotaObservingUploadStore) Delete(context.Context, string) error {
 }
 
 func (s *quotaObservingUploadStore) ServeHTTP(http.ResponseWriter, *http.Request, uploadstore.Object) error {
+	return uploadstore.ErrNotFound
+}
+
+type concurrentUploadStore struct {
+	mu      sync.Mutex
+	saves   int
+	release chan struct{}
+	deleted chan string
+}
+
+func newConcurrentUploadStore() *concurrentUploadStore {
+	return &concurrentUploadStore{
+		release: make(chan struct{}),
+		deleted: make(chan string, 2),
+	}
+}
+
+func (s *concurrentUploadStore) Save(ctx context.Context, body io.Reader, _ uploadstore.SaveOptions) (uploadstore.SavedObject, error) {
+	size, err := io.Copy(io.Discard, body)
+	if err != nil {
+		return uploadstore.SavedObject{}, err
+	}
+	s.mu.Lock()
+	s.saves++
+	saveID := s.saves
+	if s.saves == 2 {
+		close(s.release)
+	}
+	s.mu.Unlock()
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return uploadstore.SavedObject{}, ctx.Err()
+	}
+	return uploadstore.SavedObject{
+		Path:     fmt.Sprintf("memory://concurrent-upload-%d", saveID),
+		ByteSize: size,
+	}, nil
+}
+
+func (s *concurrentUploadStore) Delete(_ context.Context, path string) error {
+	s.deleted <- path
+	return nil
+}
+
+func (s *concurrentUploadStore) ServeHTTP(http.ResponseWriter, *http.Request, uploadstore.Object) error {
 	return uploadstore.ErrNotFound
 }
 

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2214,6 +2214,51 @@ func uploadFileAsUserWithContentType(t *testing.T, userID, endpoint, workspaceID
 	return out.Upload
 }
 
+func uploadFileWithNonceStatus(t *testing.T, endpoint, workspaceID, nonce, filename, content string) (store.Upload, int) {
+	t.Helper()
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := endpointURL.Query()
+	query.Set("workspace_id", workspaceID)
+	query.Set("nonce", nonce)
+	endpointURL.RawQuery = query.Encode()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("workspace_id", workspaceID); err != nil {
+		t.Fatal(err)
+	}
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write([]byte(content)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, endpointURL.String(), &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Upload store.Upload `json:"upload"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	return out.Upload, resp.StatusCode
+}
+
 func uploadFileWithoutPartContentType(t *testing.T, endpoint, workspaceID string) store.Upload {
 	t.Helper()
 	var body bytes.Buffer
@@ -2758,6 +2803,97 @@ func TestUploadReservesQuotaBeforeObjectStorage(t *testing.T) {
 	}
 	if quota.UsedCount != 1 || quota.UsedBytes != upload.ByteSize {
 		t.Fatalf("reservation was not replaced by final upload row: quota=%#v upload=%#v", quota, upload)
+	}
+}
+
+func TestUploadNonceReplaysWithoutConsumingStorageOrQuota(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "upload-nonce-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	otherWorkspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Other Uploads"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	t.Cleanup(server.Close)
+
+	const nonce = "upload-retry-1"
+	first, firstStatus := uploadFileWithNonceStatus(t, server.URL+"/api/uploads", workspace.ID, nonce, "first.txt", "first body")
+	if firstStatus != http.StatusCreated || first.Nonce != nonce {
+		t.Fatalf("unexpected initial upload: status=%d upload=%#v", firstStatus, first)
+	}
+	lookup := getJSON[struct {
+		Upload store.Upload `json:"upload"`
+	}](t, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(workspace.ID)+"&nonce="+url.QueryEscape(nonce))
+	if lookup.Upload.ID != first.ID {
+		t.Fatalf("upload nonce lookup returned %#v, want %s", lookup.Upload, first.ID)
+	}
+	expectStatus(t, http.MethodGet, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(workspace.ID)+"&nonce=missing", nil, http.StatusNotFound)
+	for i := int64(1); i < store.UploadQuotaCountPerUserWorkspace; i++ {
+		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+			WorkspaceID: workspace.ID,
+			OwnerID:     owner.ID,
+			Filename:    fmt.Sprintf("quota-%d.txt", i),
+			ContentType: "text/plain",
+			ByteSize:    1,
+			StoragePath: fmt.Sprintf("memory://quota-%d.txt", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	quotaBeforeReplay, err := st.UploadQuota(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quotaBeforeReplay.RemainingCount != 0 {
+		t.Fatalf("expected upload count quota to be full, got %#v", quotaBeforeReplay)
+	}
+
+	replayed, replayStatus := uploadFileWithNonceStatus(t, server.URL+"/api/uploads", workspace.ID, nonce, "changed.txt", "changed body")
+	if replayStatus != http.StatusOK || replayed.ID != first.ID || replayed.Filename != first.Filename {
+		t.Fatalf("unexpected upload replay: status=%d upload=%#v first=%#v", replayStatus, replayed, first)
+	}
+	if body := getBody(t, server.URL+"/api/uploads/"+first.ID); body != "first body" {
+		t.Fatalf("upload replay replaced stored bytes: %q", body)
+	}
+	quotaAfterReplay, err := st.UploadQuota(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quotaAfterReplay != quotaBeforeReplay {
+		t.Fatalf("upload replay changed quota: before=%#v after=%#v", quotaBeforeReplay, quotaAfterReplay)
+	}
+	entries, err := os.ReadDir(filepath.Join(dataDir, "uploads"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("upload replay wrote another storage object: %v", entries)
+	}
+
+	if _, status := uploadFileWithNonceStatus(t, server.URL+"/api/uploads", otherWorkspace.ID, nonce, "other.txt", "other body"); status != http.StatusConflict {
+		t.Fatalf("expected cross-workspace nonce conflict, got %d", status)
+	}
+	expectStatus(t, http.MethodGet, server.URL+"/api/uploads/by-nonce?workspace_id="+url.QueryEscape(otherWorkspace.ID)+"&nonce="+url.QueryEscape(nonce), nil, http.StatusConflict)
+	if _, status := uploadFileWithNonceStatus(t, server.URL+"/api/uploads", workspace.ID, strings.Repeat("n", 129), "long.txt", "long body"); status != http.StatusBadRequest {
+		t.Fatalf("expected overlong nonce rejection, got %d", status)
 	}
 }
 

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2772,6 +2772,18 @@ func TestUploadQuotaReaderStopsOverBudget(t *testing.T) {
 	}
 }
 
+func TestNormalizeUploadNonceCountsCharacters(t *testing.T) {
+	t.Parallel()
+
+	valid := strings.Repeat("é", 128)
+	if normalized, err := normalizeUploadNonce(valid); err != nil || normalized != valid {
+		t.Fatalf("expected 128-character nonce to remain valid: normalized=%q err=%v", normalized, err)
+	}
+	if _, err := normalizeUploadNonce(strings.Repeat("é", 129)); err == nil {
+		t.Fatal("expected 129-character nonce rejection")
+	}
+}
+
 func TestUploadReservesQuotaBeforeObjectStorage(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2817,6 +2817,12 @@ func TestNormalizeClientNonceCountsCharacters(t *testing.T) {
 	if _, err := normalizeClientNonce(strings.Repeat("é", 129)); err == nil {
 		t.Fatal("expected 129-character nonce rejection")
 	}
+	if _, err := normalizeClientNonce(string([]byte{0xff})); err == nil {
+		t.Fatal("expected invalid UTF-8 nonce rejection")
+	}
+	if _, err := normalizeClientNonce("invalid\x00nonce"); err == nil {
+		t.Fatal("expected NUL nonce rejection")
+	}
 }
 
 func TestUploadReservesQuotaBeforeObjectStorage(t *testing.T) {
@@ -3134,7 +3140,12 @@ func TestBotGenericRoutesRequireDMScopeForDirectMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	message, _, err := st.CreateDirectMessage(ctx, store.CreateDirectMessageInput{ConversationID: dm.ID, AuthorID: bot.ID, Body: "bot dm"})
+	message, _, err := st.CreateDirectMessage(ctx, store.CreateDirectMessageInput{
+		ConversationID: dm.ID,
+		AuthorID:       bot.ID,
+		Body:           "bot dm",
+		Nonce:          "bot-dm-nonce",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3161,6 +3172,7 @@ func TestBotGenericRoutesRequireDMScopeForDirectMessages(t *testing.T) {
 		body   string
 	}{
 		{http.MethodGet, "/api/messages/" + message.ID, ""},
+		{http.MethodGet, "/api/messages/by-nonce?workspace_id=" + workspace.ID + "&nonce=bot-dm-nonce", ""},
 		{http.MethodPatch, "/api/messages/" + message.ID, `{"body":"blocked"}`},
 		{http.MethodDelete, "/api/messages/" + message.ID, ""},
 		{http.MethodGet, "/api/messages/" + message.ID + "/thread", ""},

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2935,7 +2935,7 @@ func TestUploadNonceReplaysWithoutConsumingStorageOrQuota(t *testing.T) {
 	}
 }
 
-func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.T) {
+func TestConcurrentUploadNonceReplayClaimsNonceBeforeQuota(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	dataDir := t.TempDir()
@@ -2956,6 +2956,18 @@ func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.
 		t.Fatal(err)
 	}
 	workspace := workspaces[0]
+	for i := int64(1); i < store.UploadQuotaCountPerUserWorkspace; i++ {
+		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+			WorkspaceID: workspace.ID,
+			OwnerID:     owner.ID,
+			Filename:    fmt.Sprintf("quota-%d.txt", i),
+			ContentType: "text/plain",
+			ByteSize:    1,
+			StoragePath: fmt.Sprintf("memory://quota-%d.txt", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
 	storage := newConcurrentUploadStore()
 	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadStorage: storage}).Handler())
 	t.Cleanup(server.Close)
@@ -2967,7 +2979,7 @@ func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.
 	}
 	results := make(chan result, 2)
 	client := &http.Client{Timeout: 5 * time.Second}
-	for i := range 2 {
+	startUpload := func(i int) {
 		go func() {
 			req, err := newUploadWithNonceRequest(
 				server.URL+"/api/uploads",
@@ -2996,6 +3008,19 @@ func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.
 			results <- result{upload: body.Upload, status: resp.StatusCode}
 		}()
 	}
+	startUpload(0)
+	select {
+	case <-storage.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first upload did not reach object storage")
+	}
+	startUpload(1)
+	select {
+	case result := <-results:
+		t.Fatalf("concurrent retry completed before the nonce owner committed: %#v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(storage.release)
 
 	readResult := func() result {
 		select {
@@ -3018,22 +3043,24 @@ func TestConcurrentUploadNonceReplayCleansLosingObjectAndReservation(t *testing.
 	if first.upload.ID == "" || first.upload.ID != second.upload.ID {
 		t.Fatalf("concurrent replay returned different uploads: first=%#v second=%#v", first.upload, second.upload)
 	}
-	select {
-	case <-storage.deleted:
-	case <-time.After(2 * time.Second):
-		t.Fatal("losing upload object was not deleted")
+	storage.mu.Lock()
+	saves := storage.saves
+	storage.mu.Unlock()
+	if saves != 1 {
+		t.Fatalf("concurrent retry reached object storage %d times", saves)
 	}
 	select {
 	case path := <-storage.deleted:
-		t.Fatalf("deleted more than one upload object: %s", path)
+		t.Fatalf("nonce claim unexpectedly created a losing object: %s", path)
 	default:
 	}
 	quota, err := st.UploadQuota(ctx, workspace.ID, owner.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if quota.UsedCount != 1 || quota.UsedBytes != int64(len("same body")) {
-		t.Fatalf("losing reservation was not released: %#v", quota)
+	expectedBytes := store.UploadQuotaCountPerUserWorkspace - 1 + int64(len("same body"))
+	if quota.UsedCount != store.UploadQuotaCountPerUserWorkspace || quota.UsedBytes != expectedBytes {
+		t.Fatalf("nonce claim did not preserve exact quota accounting: %#v", quota)
 	}
 }
 
@@ -3227,12 +3254,15 @@ func (s *quotaObservingUploadStore) ServeHTTP(http.ResponseWriter, *http.Request
 type concurrentUploadStore struct {
 	mu      sync.Mutex
 	saves   int
+	started chan struct{}
 	release chan struct{}
 	deleted chan string
+	once    sync.Once
 }
 
 func newConcurrentUploadStore() *concurrentUploadStore {
 	return &concurrentUploadStore{
+		started: make(chan struct{}),
 		release: make(chan struct{}),
 		deleted: make(chan string, 2),
 	}
@@ -3246,10 +3276,8 @@ func (s *concurrentUploadStore) Save(ctx context.Context, body io.Reader, _ uplo
 	s.mu.Lock()
 	s.saves++
 	saveID := s.saves
-	if s.saves == 2 {
-		close(s.release)
-	}
 	s.mu.Unlock()
+	s.once.Do(func() { close(s.started) })
 	select {
 	case <-s.release:
 	case <-ctx.Done():

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -121,6 +121,12 @@ func scanMessage(row scanner) (store.Message, error) {
 
 func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
+	if !utf8.ValidString(nonce) {
+		return "", errors.New("nonce must be valid UTF-8")
+	}
+	if strings.IndexByte(nonce, 0) >= 0 {
+		return "", errors.New("nonce must not contain NUL")
+	}
 	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
@@ -120,7 +121,7 @@ func scanMessage(row scanner) (store.Message, error) {
 
 func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
-	if len(nonce) > 128 {
+	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}
 	return nonce, nil

--- a/apps/api/internal/store/postgres/migrations/0018_upload_client_nonce.sql
+++ b/apps/api/internal/store/postgres/migrations/0018_upload_client_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE uploads ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_uploads_owner_client_nonce
+  ON uploads(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/apps/api/internal/store/postgres/migrations/0019_upload_reservation_nonce.sql
+++ b/apps/api/internal/store/postgres/migrations/0019_upload_reservation_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE upload_quota_reservations ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_upload_quota_reservations_owner_client_nonce
+  ON upload_quota_reservations(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -486,6 +486,25 @@ func (s *Store) GetMessage(ctx context.Context, messageID, userID string) (store
 	return messages[0], nil
 }
 
+func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (store.Message, error) {
+	normalized, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.Message{}, err
+	}
+	if normalized == "" {
+		return store.Message{}, sql.ErrNoRows
+	}
+	message, err := scanMessage(s.db.QueryRowContext(ctx, messageSelect()+` WHERE m.author_id = $1 AND m.client_nonce = $2`, authorID, normalized))
+	if err != nil {
+		return store.Message{}, err
+	}
+	messages, err := s.hydrateAttachments(ctx, []store.Message{message})
+	if err != nil {
+		return store.Message{}, err
+	}
+	return messages[0], nil
+}
+
 func (s *Store) requireMessageAccess(ctx context.Context, message store.Message, userID string) error {
 	if message.DirectConversationID != "" {
 		return s.requireDirectAccess(ctx, message.DirectConversationID, userID)

--- a/apps/api/internal/store/postgres/postgres_test.go
+++ b/apps/api/internal/store/postgres/postgres_test.go
@@ -318,6 +318,16 @@ func TestCreateReservedUploadSerializesWithNonceRetries(t *testing.T) {
 	}
 }
 
+func TestNormalizeClientNonceRejectsDatabaseInvalidText(t *testing.T) {
+	t.Parallel()
+
+	for _, nonce := range []string{string([]byte{0xff}), "invalid\x00nonce"} {
+		if _, err := normalizeClientNonce(nonce); err == nil {
+			t.Fatalf("expected database-invalid nonce rejection for %q", nonce)
+		}
+	}
+}
+
 func applyPostgresMigrationsBefore(t *testing.T, ctx context.Context, st *Store, cutoff string) {
 	t.Helper()
 	if _, err := st.db.ExecContext(ctx, `CREATE TABLE schema_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL)`); err != nil {

--- a/apps/api/internal/store/postgres/postgres_test.go
+++ b/apps/api/internal/store/postgres/postgres_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/url"
@@ -250,6 +251,71 @@ func newIsolatedPostgresTestStore(t *testing.T) *Store {
 		_ = adminDB.Close()
 	})
 	return st
+}
+
+func TestCreateReservedUploadSerializesWithNonceRetries(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Upload Owner", "postgres-upload-nonce@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	const nonce = "postgres-upload-finalization"
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, nonce, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocker, err := st.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blocker.Rollback()
+	if err := lockUploadNonceTx(ctx, blocker, owner.ID, nonce); err != nil {
+		t.Fatal(err)
+	}
+
+	blockedCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	_, err = st.CreateReservedUpload(blockedCtx, reservation.ID, store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Nonce:       nonce,
+		Filename:    "blocked.txt",
+		ContentType: "text/plain",
+		ByteSize:    4,
+		StoragePath: "memory://blocked.txt",
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected finalization to wait for the nonce lock, got %v", err)
+	}
+	if err := blocker.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	upload, err := st.CreateReservedUpload(ctx, reservation.ID, store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Nonce:       nonce,
+		Filename:    "committed.txt",
+		ContentType: "text/plain",
+		ByteSize:    4,
+		StoragePath: "memory://committed.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.Nonce != nonce {
+		t.Fatalf("finalized upload lost nonce: %#v", upload)
+	}
 }
 
 func applyPostgresMigrationsBefore(t *testing.T, ctx context.Context, st *Store, cutoff string) {

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -618,13 +618,18 @@ WHERE workspace_id = sqlc.arg(workspace_id)
   AND user_id = sqlc.arg(user_id);
 
 -- name: InsertUpload :exec
-INSERT INTO uploads (id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
-VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(filename), sqlc.arg(content_type), sqlc.arg(byte_size), sqlc.arg(width), sqlc.arg(height), sqlc.arg(duration_ms), sqlc.arg(storage_path), sqlc.arg(created_at));
+INSERT INTO uploads (id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
+VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(client_nonce), sqlc.arg(filename), sqlc.arg(content_type), sqlc.arg(byte_size), sqlc.arg(width), sqlc.arg(height), sqlc.arg(duration_ms), sqlc.arg(storage_path), sqlc.arg(created_at));
 
 -- name: GetUpload :one
-SELECT id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads
 WHERE id = sqlc.arg(id);
+
+-- name: GetUploadByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+FROM uploads
+WHERE owner_id = sqlc.arg(owner_id) AND client_nonce = sqlc.arg(client_nonce);
 
 -- name: GetUploadWorkspace :one
 SELECT workspace_id

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -660,13 +660,18 @@ SELECT EXISTS (
 ) AS has_other_direct_message_attachment;
 
 -- name: InsertUploadQuotaReservation :exec
-INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, byte_size, created_at, expires_at)
-VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(byte_size), sqlc.arg(created_at), sqlc.arg(expires_at));
+INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at)
+VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(client_nonce), sqlc.arg(byte_size), sqlc.arg(created_at), sqlc.arg(expires_at));
 
 -- name: GetUploadQuotaReservation :one
-SELECT id, workspace_id, owner_id, byte_size, created_at, expires_at
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
 FROM upload_quota_reservations
 WHERE id = sqlc.arg(id);
+
+-- name: GetUploadQuotaReservationByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
+FROM upload_quota_reservations
+WHERE owner_id = sqlc.arg(owner_id) AND client_nonce = sqlc.arg(client_nonce);
 
 -- name: DeleteUploadQuotaReservation :execrows
 DELETE FROM upload_quota_reservations

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -217,6 +217,7 @@ CREATE TABLE upload_quota_reservations (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   owner_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_nonce TEXT NOT NULL DEFAULT '',
   byte_size BIGINT NOT NULL,
   created_at TEXT NOT NULL,
   expires_at TEXT NOT NULL
@@ -224,6 +225,9 @@ CREATE TABLE upload_quota_reservations (
 
 CREATE INDEX idx_upload_quota_reservations_workspace_owner
   ON upload_quota_reservations(workspace_id, owner_id, expires_at);
+CREATE UNIQUE INDEX idx_upload_quota_reservations_owner_client_nonce
+  ON upload_quota_reservations(owner_id, client_nonce)
+  WHERE client_nonce <> '';
 
 CREATE TABLE pending_upload_cleanups (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -199,6 +199,7 @@ CREATE TABLE uploads (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   owner_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_nonce TEXT NOT NULL DEFAULT '',
   filename TEXT NOT NULL,
   content_type TEXT NOT NULL,
   byte_size BIGINT NOT NULL,
@@ -210,6 +211,7 @@ CREATE TABLE uploads (
 );
 
 CREATE INDEX idx_uploads_workspace_owner ON uploads(workspace_id, owner_id);
+CREATE UNIQUE INDEX idx_uploads_owner_client_nonce ON uploads(owner_id, client_nonce) WHERE client_nonce <> '';
 
 CREATE TABLE upload_quota_reservations (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/postgres/sqlc_adapters.go
+++ b/apps/api/internal/store/postgres/sqlc_adapters.go
@@ -130,6 +130,24 @@ func storeUploadFromGetUpload(row storedb.GetUploadRow) store.Upload {
 		ID:          row.ID,
 		WorkspaceID: row.WorkspaceID,
 		OwnerID:     row.OwnerID,
+		Nonce:       row.ClientNonce,
+		Filename:    row.Filename,
+		ContentType: row.ContentType,
+		ByteSize:    row.ByteSize,
+		Width:       int(row.Width),
+		Height:      int(row.Height),
+		DurationMS:  int(row.DurationMs),
+		StoragePath: row.StoragePath,
+		CreatedAt:   row.CreatedAt,
+	}
+}
+
+func storeUploadFromGetUploadByOwnerNonce(row storedb.GetUploadByOwnerNonceRow) store.Upload {
+	return store.Upload{
+		ID:          row.ID,
+		WorkspaceID: row.WorkspaceID,
+		OwnerID:     row.OwnerID,
+		Nonce:       row.ClientNonce,
 		Filename:    row.Filename,
 		ContentType: row.ContentType,
 		ByteSize:    row.ByteSize,

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -319,6 +319,7 @@ type UploadQuotaReservation struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	ByteSize    int64  `json:"byte_size"`
 	CreatedAt   string `json:"created_at"`
 	ExpiresAt   string `json:"expires_at"`

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -304,6 +304,7 @@ type Upload struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1297,7 +1297,7 @@ func (q *Queries) GetUploadByOwnerNonce(ctx context.Context, arg GetUploadByOwne
 }
 
 const getUploadQuotaReservation = `-- name: GetUploadQuotaReservation :one
-SELECT id, workspace_id, owner_id, byte_size, created_at, expires_at
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
 FROM upload_quota_reservations
 WHERE id = $1
 `
@@ -1309,6 +1309,33 @@ func (q *Queries) GetUploadQuotaReservation(ctx context.Context, id string) (Upl
 		&i.ID,
 		&i.WorkspaceID,
 		&i.OwnerID,
+		&i.ClientNonce,
+		&i.ByteSize,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+	)
+	return i, err
+}
+
+const getUploadQuotaReservationByOwnerNonce = `-- name: GetUploadQuotaReservationByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
+FROM upload_quota_reservations
+WHERE owner_id = $1 AND client_nonce = $2
+`
+
+type GetUploadQuotaReservationByOwnerNonceParams struct {
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+func (q *Queries) GetUploadQuotaReservationByOwnerNonce(ctx context.Context, arg GetUploadQuotaReservationByOwnerNonceParams) (UploadQuotaReservation, error) {
+	row := q.db.QueryRowContext(ctx, getUploadQuotaReservationByOwnerNonce, arg.OwnerID, arg.ClientNonce)
+	var i UploadQuotaReservation
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.OwnerID,
+		&i.ClientNonce,
 		&i.ByteSize,
 		&i.CreatedAt,
 		&i.ExpiresAt,
@@ -2162,14 +2189,15 @@ func (q *Queries) InsertUpload(ctx context.Context, arg InsertUploadParams) erro
 }
 
 const insertUploadQuotaReservation = `-- name: InsertUploadQuotaReservation :exec
-INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, byte_size, created_at, expires_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type InsertUploadQuotaReservationParams struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	ByteSize    int64  `json:"byte_size"`
 	CreatedAt   string `json:"created_at"`
 	ExpiresAt   string `json:"expires_at"`
@@ -2180,6 +2208,7 @@ func (q *Queries) InsertUploadQuotaReservation(ctx context.Context, arg InsertUp
 		arg.ID,
 		arg.WorkspaceID,
 		arg.OwnerID,
+		arg.ClientNonce,
 		arg.ByteSize,
 		arg.CreatedAt,
 		arg.ExpiresAt,

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1210,7 +1210,7 @@ func (q *Queries) GetThreadState(ctx context.Context, rootMessageID string) (Thr
 }
 
 const getUpload = `-- name: GetUpload :one
-SELECT id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads
 WHERE id = $1
 `
@@ -1219,6 +1219,7 @@ type GetUploadRow struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`
@@ -1236,6 +1237,53 @@ func (q *Queries) GetUpload(ctx context.Context, id string) (GetUploadRow, error
 		&i.ID,
 		&i.WorkspaceID,
 		&i.OwnerID,
+		&i.ClientNonce,
+		&i.Filename,
+		&i.ContentType,
+		&i.ByteSize,
+		&i.Width,
+		&i.Height,
+		&i.DurationMs,
+		&i.StoragePath,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getUploadByOwnerNonce = `-- name: GetUploadByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+FROM uploads
+WHERE owner_id = $1 AND client_nonce = $2
+`
+
+type GetUploadByOwnerNonceParams struct {
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+type GetUploadByOwnerNonceRow struct {
+	ID          string `json:"id"`
+	WorkspaceID string `json:"workspace_id"`
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	ByteSize    int64  `json:"byte_size"`
+	Width       int64  `json:"width"`
+	Height      int64  `json:"height"`
+	DurationMs  int64  `json:"duration_ms"`
+	StoragePath string `json:"storage_path"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func (q *Queries) GetUploadByOwnerNonce(ctx context.Context, arg GetUploadByOwnerNonceParams) (GetUploadByOwnerNonceRow, error) {
+	row := q.db.QueryRowContext(ctx, getUploadByOwnerNonce, arg.OwnerID, arg.ClientNonce)
+	var i GetUploadByOwnerNonceRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.OwnerID,
+		&i.ClientNonce,
 		&i.Filename,
 		&i.ContentType,
 		&i.ByteSize,
@@ -2076,14 +2124,15 @@ func (q *Queries) InsertThreadState(ctx context.Context, rootMessageID string) e
 }
 
 const insertUpload = `-- name: InsertUpload :exec
-INSERT INTO uploads (id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+INSERT INTO uploads (id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 `
 
 type InsertUploadParams struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`
@@ -2099,6 +2148,7 @@ func (q *Queries) InsertUpload(ctx context.Context, arg InsertUploadParams) erro
 		arg.ID,
 		arg.WorkspaceID,
 		arg.OwnerID,
+		arg.ClientNonce,
 		arg.Filename,
 		arg.ContentType,
 		arg.ByteSize,

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -13,6 +13,10 @@ import (
 const uploadQuotaReservationTTL = 15 * time.Minute
 
 func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput) (store.Upload, error) {
+	nonce, err := normalizeClientNonce(input.Nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.Upload{}, err
@@ -28,6 +32,7 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 		ID:          newID("upl"),
 		WorkspaceID: input.WorkspaceID,
 		OwnerID:     input.OwnerID,
+		Nonce:       nonce,
 		Filename:    input.Filename,
 		ContentType: input.ContentType,
 		ByteSize:    input.ByteSize,
@@ -41,6 +46,7 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 		ID:          upload.ID,
 		WorkspaceID: upload.WorkspaceID,
 		OwnerID:     upload.OwnerID,
+		ClientNonce: upload.Nonce,
 		Filename:    upload.Filename,
 		ContentType: upload.ContentType,
 		ByteSize:    upload.ByteSize,
@@ -107,6 +113,10 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 }
 
 func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, input store.CreateUploadInput) (store.Upload, error) {
+	nonce, err := normalizeClientNonce(input.Nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.Upload{}, err
@@ -142,6 +152,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 		ID:          newID("upl"),
 		WorkspaceID: input.WorkspaceID,
 		OwnerID:     input.OwnerID,
+		Nonce:       nonce,
 		Filename:    input.Filename,
 		ContentType: input.ContentType,
 		ByteSize:    input.ByteSize,
@@ -155,6 +166,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 		ID:          upload.ID,
 		WorkspaceID: upload.WorkspaceID,
 		OwnerID:     upload.OwnerID,
+		ClientNonce: upload.Nonce,
 		Filename:    upload.Filename,
 		ContentType: upload.ContentType,
 		ByteSize:    upload.ByteSize,
@@ -290,6 +302,28 @@ func (s *Store) GetUpload(ctx context.Context, uploadID, userID string) (store.U
 	}
 	if !visible {
 		return store.Upload{}, errors.New("upload is not visible")
+	}
+	return upload, nil
+}
+
+func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (store.Upload, error) {
+	normalized, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
+	if normalized == "" {
+		return store.Upload{}, sql.ErrNoRows
+	}
+	row, err := s.q.GetUploadByOwnerNonce(ctx, storedb.GetUploadByOwnerNonceParams{
+		OwnerID:     ownerID,
+		ClientNonce: normalized,
+	})
+	if err != nil {
+		return store.Upload{}, err
+	}
+	upload := storeUploadFromGetUploadByOwnerNonce(row)
+	if err := s.requireMembership(ctx, upload.WorkspaceID, ownerID); err != nil {
+		return store.Upload{}, err
 	}
 	return upload, nil
 }

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -81,6 +81,8 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, non
 	}
 	qtx := s.q.WithTx(tx)
 	reservationNow := time.Now().UTC()
+	// Reclaim expired nonce claims before lookup so a crashed uploader cannot
+	// strand its nonce after the reservation TTL.
 	if err := qtx.DeleteExpiredUploadQuotaReservations(ctx, uploadReservationTime(reservationNow)); err != nil {
 		return store.UploadQuotaReservation{}, err
 	}

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -161,6 +161,13 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 		return store.Upload{}, err
 	}
 	defer tx.Rollback()
+	if nonce != "" {
+		// Finalization and retries must serialize on the same nonce. Without this
+		// lock, a retry can miss both the committed upload and deleted reservation.
+		if err := lockUploadNonceTx(ctx, tx, input.OwnerID, nonce); err != nil {
+			return store.Upload{}, err
+		}
+	}
 	if err := lockUploadQuotaTx(ctx, tx, input.WorkspaceID, input.OwnerID); err != nil {
 		return store.Upload{}, err
 	}

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -321,11 +321,7 @@ func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (st
 	if err != nil {
 		return store.Upload{}, err
 	}
-	upload := storeUploadFromGetUploadByOwnerNonce(row)
-	if err := s.requireMembership(ctx, upload.WorkspaceID, ownerID); err != nil {
-		return store.Upload{}, err
-	}
-	return upload, nil
+	return storeUploadFromGetUploadByOwnerNonce(row), nil
 }
 
 func (s *Store) UploadHasDirectMessageAttachment(ctx context.Context, uploadID string) (bool, error) {

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -61,12 +61,21 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 	return upload, tx.Commit()
 }
 
-func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID string, byteSize int64) (store.UploadQuotaReservation, error) {
+func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
+	normalizedNonce, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.UploadQuotaReservation{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
 	defer tx.Rollback()
+	if normalizedNonce != "" {
+		if err := lockUploadNonceTx(ctx, tx, userID, normalizedNonce); err != nil {
+			return store.UploadQuotaReservation{}, err
+		}
+	}
 	if err := lockUploadQuotaTx(ctx, tx, workspaceID, userID); err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
@@ -84,6 +93,32 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, userID); err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
+	if normalizedNonce != "" {
+		uploadRow, err := qtx.GetUploadByOwnerNonce(ctx, storedb.GetUploadByOwnerNonceParams{
+			OwnerID:     userID,
+			ClientNonce: normalizedNonce,
+		})
+		switch {
+		case err == nil && storeUploadFromGetUploadByOwnerNonce(uploadRow).WorkspaceID != workspaceID:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceConflict
+		case err == nil:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceInProgress
+		case !errors.Is(err, sql.ErrNoRows):
+			return store.UploadQuotaReservation{}, err
+		}
+		existing, err := qtx.GetUploadQuotaReservationByOwnerNonce(ctx, storedb.GetUploadQuotaReservationByOwnerNonceParams{
+			OwnerID:     userID,
+			ClientNonce: normalizedNonce,
+		})
+		switch {
+		case err == nil && existing.WorkspaceID != workspaceID:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceConflict
+		case err == nil:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceInProgress
+		case !errors.Is(err, sql.ErrNoRows):
+			return store.UploadQuotaReservation{}, err
+		}
+	}
 	quota, err := uploadQuotaTx(ctx, tx, workspaceID, userID)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
@@ -95,6 +130,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 		ID:          newID("uqr"),
 		WorkspaceID: workspaceID,
 		OwnerID:     userID,
+		Nonce:       normalizedNonce,
 		ByteSize:    min(byteSize, quota.RemainingBytes),
 		CreatedAt:   uploadReservationTime(reservationNow),
 		ExpiresAt:   uploadReservationTime(reservationNow.Add(uploadQuotaReservationTTL)),
@@ -103,6 +139,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 		ID:          reservation.ID,
 		WorkspaceID: reservation.WorkspaceID,
 		OwnerID:     reservation.OwnerID,
+		ClientNonce: reservation.Nonce,
 		ByteSize:    reservation.ByteSize,
 		CreatedAt:   reservation.CreatedAt,
 		ExpiresAt:   reservation.ExpiresAt,
@@ -133,7 +170,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 	if err != nil {
 		return store.Upload{}, err
 	}
-	if reservation.WorkspaceID != input.WorkspaceID || reservation.OwnerID != input.OwnerID {
+	if reservation.WorkspaceID != input.WorkspaceID || reservation.OwnerID != input.OwnerID || reservation.ClientNonce != nonce {
 		return store.Upload{}, errors.New("upload quota reservation does not match upload")
 	}
 	if err := requireMembershipTx(ctx, tx, input.WorkspaceID, input.OwnerID); err != nil {
@@ -242,6 +279,11 @@ func canCreateUploadTx(ctx context.Context, tx *sql.Tx, workspaceID, userID stri
 
 func lockUploadQuotaTx(ctx context.Context, tx *sql.Tx, workspaceID, userID string) error {
 	_, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`, "clickclack.upload-quota."+workspaceID, userID)
+	return err
+}
+
+func lockUploadNonceTx(ctx context.Context, tx *sql.Tx, userID, nonce string) error {
+	_, err := tx.ExecContext(ctx, `SELECT pg_advisory_xact_lock(hashtext($1), hashtext($2))`, "clickclack.upload-nonce."+userID, nonce)
 	return err
 }
 

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -121,6 +121,12 @@ func scanMessage(row scanner) (store.Message, error) {
 
 func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
+	if !utf8.ValidString(nonce) {
+		return "", errors.New("nonce must be valid UTF-8")
+	}
+	if strings.IndexByte(nonce, 0) >= 0 {
+		return "", errors.New("nonce must not contain NUL")
+	}
 	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
@@ -120,7 +121,7 @@ func scanMessage(row scanner) (store.Message, error) {
 
 func normalizeClientNonce(value string) (string, error) {
 	nonce := strings.TrimSpace(value)
-	if len(nonce) > 128 {
+	if utf8.RuneCountInString(nonce) > 128 {
 		return "", errors.New("nonce is too long")
 	}
 	return nonce, nil

--- a/apps/api/internal/store/sqlite/migrations/0025_upload_client_nonce.sql
+++ b/apps/api/internal/store/sqlite/migrations/0025_upload_client_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE uploads ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_uploads_owner_client_nonce
+  ON uploads(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/apps/api/internal/store/sqlite/migrations/0026_upload_reservation_nonce.sql
+++ b/apps/api/internal/store/sqlite/migrations/0026_upload_reservation_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE upload_quota_reservations ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_upload_quota_reservations_owner_client_nonce
+  ON upload_quota_reservations(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -652,13 +652,18 @@ SELECT EXISTS (
 ) AS has_other_direct_message_attachment;
 
 -- name: InsertUploadQuotaReservation :exec
-INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, byte_size, created_at, expires_at)
-VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(byte_size), sqlc.arg(created_at), sqlc.arg(expires_at));
+INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at)
+VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(client_nonce), sqlc.arg(byte_size), sqlc.arg(created_at), sqlc.arg(expires_at));
 
 -- name: GetUploadQuotaReservation :one
-SELECT id, workspace_id, owner_id, byte_size, created_at, expires_at
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
 FROM upload_quota_reservations
 WHERE id = sqlc.arg(id);
+
+-- name: GetUploadQuotaReservationByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
+FROM upload_quota_reservations
+WHERE owner_id = sqlc.arg(owner_id) AND client_nonce = sqlc.arg(client_nonce);
 
 -- name: DeleteUploadQuotaReservation :execrows
 DELETE FROM upload_quota_reservations

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -610,13 +610,18 @@ WHERE workspace_id = sqlc.arg(workspace_id)
   AND user_id = sqlc.arg(user_id);
 
 -- name: InsertUpload :exec
-INSERT INTO uploads (id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
-VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(filename), sqlc.arg(content_type), sqlc.arg(byte_size), sqlc.arg(width), sqlc.arg(height), sqlc.arg(duration_ms), sqlc.arg(storage_path), sqlc.arg(created_at));
+INSERT INTO uploads (id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
+VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(owner_id), sqlc.arg(client_nonce), sqlc.arg(filename), sqlc.arg(content_type), sqlc.arg(byte_size), sqlc.arg(width), sqlc.arg(height), sqlc.arg(duration_ms), sqlc.arg(storage_path), sqlc.arg(created_at));
 
 -- name: GetUpload :one
-SELECT id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads
 WHERE id = sqlc.arg(id);
+
+-- name: GetUploadByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+FROM uploads
+WHERE owner_id = sqlc.arg(owner_id) AND client_nonce = sqlc.arg(client_nonce);
 
 -- name: GetUploadWorkspace :one
 SELECT workspace_id

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -196,6 +196,7 @@ CREATE TABLE uploads (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   owner_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_nonce TEXT NOT NULL DEFAULT '',
   filename TEXT NOT NULL,
   content_type TEXT NOT NULL,
   byte_size INTEGER NOT NULL,
@@ -207,6 +208,7 @@ CREATE TABLE uploads (
 );
 
 CREATE INDEX idx_uploads_workspace_owner ON uploads(workspace_id, owner_id);
+CREATE UNIQUE INDEX idx_uploads_owner_client_nonce ON uploads(owner_id, client_nonce) WHERE client_nonce <> '';
 
 CREATE TABLE upload_quota_reservations (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -214,6 +214,7 @@ CREATE TABLE upload_quota_reservations (
   id TEXT PRIMARY KEY,
   workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   owner_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  client_nonce TEXT NOT NULL DEFAULT '',
   byte_size INTEGER NOT NULL,
   created_at TEXT NOT NULL,
   expires_at TEXT NOT NULL
@@ -221,6 +222,9 @@ CREATE TABLE upload_quota_reservations (
 
 CREATE INDEX idx_upload_quota_reservations_workspace_owner
   ON upload_quota_reservations(workspace_id, owner_id, expires_at);
+CREATE UNIQUE INDEX idx_upload_quota_reservations_owner_client_nonce
+  ON upload_quota_reservations(owner_id, client_nonce)
+  WHERE client_nonce <> '';
 
 CREATE TABLE pending_upload_cleanups (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/sqlite/sqlc_adapters.go
+++ b/apps/api/internal/store/sqlite/sqlc_adapters.go
@@ -130,6 +130,24 @@ func storeUploadFromGetUpload(row storedb.GetUploadRow) store.Upload {
 		ID:          row.ID,
 		WorkspaceID: row.WorkspaceID,
 		OwnerID:     row.OwnerID,
+		Nonce:       row.ClientNonce,
+		Filename:    row.Filename,
+		ContentType: row.ContentType,
+		ByteSize:    row.ByteSize,
+		Width:       int(row.Width),
+		Height:      int(row.Height),
+		DurationMS:  int(row.DurationMs),
+		StoragePath: row.StoragePath,
+		CreatedAt:   row.CreatedAt,
+	}
+}
+
+func storeUploadFromGetUploadByOwnerNonce(row storedb.GetUploadByOwnerNonceRow) store.Upload {
+	return store.Upload{
+		ID:          row.ID,
+		WorkspaceID: row.WorkspaceID,
+		OwnerID:     row.OwnerID,
+		Nonce:       row.ClientNonce,
 		Filename:    row.Filename,
 		ContentType: row.ContentType,
 		ByteSize:    row.ByteSize,

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -485,6 +485,25 @@ func (s *Store) GetMessage(ctx context.Context, messageID, userID string) (store
 	return messages[0], nil
 }
 
+func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (store.Message, error) {
+	normalized, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.Message{}, err
+	}
+	if normalized == "" {
+		return store.Message{}, sql.ErrNoRows
+	}
+	message, err := scanMessage(s.db.QueryRowContext(ctx, messageSelect()+` WHERE m.author_id = ? AND m.client_nonce = ?`, authorID, normalized))
+	if err != nil {
+		return store.Message{}, err
+	}
+	messages, err := s.hydrateAttachments(ctx, []store.Message{message})
+	if err != nil {
+		return store.Message{}, err
+	}
+	return messages[0], nil
+}
+
 func (s *Store) requireMessageAccess(ctx context.Context, message store.Message, userID string) error {
 	if message.DirectConversationID != "" {
 		return s.requireDirectAccess(ctx, message.DirectConversationID, userID)

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -363,6 +363,19 @@ func TestUploadNonceValidationCountsCharacters(t *testing.T) {
 	}); err == nil || !strings.Contains(err.Error(), "nonce is too long") {
 		t.Fatalf("expected 129-character nonce rejection, got %v", err)
 	}
+	for _, nonce := range []string{string([]byte{0xff}), "invalid\x00nonce"} {
+		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+			WorkspaceID: workspace.ID,
+			OwnerID:     owner.ID,
+			Nonce:       nonce,
+			Filename:    "invalid.txt",
+			ContentType: "text/plain",
+			ByteSize:    1,
+			StoragePath: "/tmp/invalid.txt",
+		}); err == nil {
+			t.Fatalf("expected database-invalid nonce rejection for %q", nonce)
+		}
+	}
 }
 
 func TestUploadReservationClaimsOwnerNonceBeforeQuota(t *testing.T) {

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -365,6 +365,45 @@ func TestUploadNonceValidationCountsCharacters(t *testing.T) {
 	}
 }
 
+func TestUploadReservationClaimsOwnerNonceBeforeQuota(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "reservation-nonce-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	otherWorkspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Other Upload Claims"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "claim-1", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reservation.Nonce != "claim-1" {
+		t.Fatalf("reservation lost nonce claim: %#v", reservation)
+	}
+	if _, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "claim-1", 10); !errors.Is(err, store.ErrUploadNonceInProgress) {
+		t.Fatalf("expected same-workspace in-progress claim, got %v", err)
+	}
+	if _, err := st.ReserveUploadQuota(ctx, otherWorkspace.ID, owner.ID, "claim-1", 10); !errors.Is(err, store.ErrUploadNonceConflict) {
+		t.Fatalf("expected cross-workspace nonce conflict, got %v", err)
+	}
+	if err := st.ReleaseUploadQuotaReservation(ctx, reservation.ID, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ReserveUploadQuota(ctx, otherWorkspace.ID, owner.ID, "claim-1", 10); err != nil {
+		t.Fatalf("released nonce claim remained locked: %v", err)
+	}
+}
+
 func TestReservedUploadRechecksModerationOnFinalize(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -386,7 +425,7 @@ func TestReservedUploadRechecksModerationOnFinalize(t *testing.T) {
 	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
 		t.Fatal(err)
 	}
-	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, member.ID, 10)
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, member.ID, "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -421,7 +460,7 @@ func TestReservedUploadRejectsNegativeFinalizeSize(t *testing.T) {
 		t.Fatal(err)
 	}
 	workspace := workspaces[0]
-	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, 10)
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -326,6 +326,45 @@ func TestUploadNonceLookupSurvivesWorkspaceMembershipRemoval(t *testing.T) {
 	}
 }
 
+func TestUploadNonceValidationCountsCharacters(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "unicode-upload-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	valid := strings.Repeat("é", 128)
+	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Nonce:       valid,
+		Filename:    "valid.txt",
+		ContentType: "text/plain",
+		ByteSize:    1,
+		StoragePath: "/tmp/valid.txt",
+	}); err != nil {
+		t.Fatalf("expected 128-character nonce to remain valid: %v", err)
+	}
+	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Nonce:       strings.Repeat("é", 129),
+		Filename:    "invalid.txt",
+		ContentType: "text/plain",
+		ByteSize:    1,
+		StoragePath: "/tmp/invalid.txt",
+	}); err == nil || !strings.Contains(err.Error(), "nonce is too long") {
+		t.Fatalf("expected 129-character nonce rejection, got %v", err)
+	}
+}
+
 func TestReservedUploadRechecksModerationOnFinalize(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -404,6 +404,44 @@ func TestUploadReservationClaimsOwnerNonceBeforeQuota(t *testing.T) {
 	}
 }
 
+func TestUploadReservationReclaimsExpiredNonceClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "expired-reservation-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	if _, err := st.db.ExecContext(ctx, `
+		INSERT INTO upload_quota_reservations
+			(id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		"uqr_expired",
+		workspace.ID,
+		owner.ID,
+		"expired-claim",
+		10,
+		"2000-01-01T00:00:00.000000000Z",
+		"2000-01-01T00:01:00.000000000Z",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "expired-claim", 10)
+	if err != nil {
+		t.Fatalf("expired nonce claim was not reclaimed: %v", err)
+	}
+	if reservation.ID == "uqr_expired" || reservation.Nonce != "expired-claim" {
+		t.Fatalf("unexpected replacement reservation: %#v", reservation)
+	}
+}
+
 func TestReservedUploadRechecksModerationOnFinalize(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -287,6 +287,45 @@ func TestUploadQuotaRejectsOwnerWorkspaceOverflow(t *testing.T) {
 	}
 }
 
+func TestUploadNonceLookupSurvivesWorkspaceMembershipRemoval(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "stale-upload-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	created, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Nonce:       "stale-workspace-nonce",
+		Filename:    "proof.txt",
+		ContentType: "text/plain",
+		ByteSize:    5,
+		StoragePath: "/tmp/proof.txt",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.db.ExecContext(ctx, `DELETE FROM workspace_members WHERE workspace_id = ? AND user_id = ?`, workspace.ID, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := st.GetUploadByNonce(ctx, owner.ID, created.Nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if found.ID != created.ID || found.WorkspaceID != workspace.ID {
+		t.Fatalf("unexpected upload lookup after membership removal: %#v", found)
+	}
+}
+
 func TestReservedUploadRechecksModerationOnFinalize(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -319,6 +319,7 @@ type UploadQuotaReservation struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	ByteSize    int64  `json:"byte_size"`
 	CreatedAt   string `json:"created_at"`
 	ExpiresAt   string `json:"expires_at"`

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -304,6 +304,7 @@ type Upload struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1205,7 +1205,7 @@ func (q *Queries) GetThreadState(ctx context.Context, rootMessageID string) (Thr
 }
 
 const getUpload = `-- name: GetUpload :one
-SELECT id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads
 WHERE id = ?1
 `
@@ -1214,6 +1214,7 @@ type GetUploadRow struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`
@@ -1231,6 +1232,53 @@ func (q *Queries) GetUpload(ctx context.Context, id string) (GetUploadRow, error
 		&i.ID,
 		&i.WorkspaceID,
 		&i.OwnerID,
+		&i.ClientNonce,
+		&i.Filename,
+		&i.ContentType,
+		&i.ByteSize,
+		&i.Width,
+		&i.Height,
+		&i.DurationMs,
+		&i.StoragePath,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getUploadByOwnerNonce = `-- name: GetUploadByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
+FROM uploads
+WHERE owner_id = ?1 AND client_nonce = ?2
+`
+
+type GetUploadByOwnerNonceParams struct {
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+type GetUploadByOwnerNonceRow struct {
+	ID          string `json:"id"`
+	WorkspaceID string `json:"workspace_id"`
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	ByteSize    int64  `json:"byte_size"`
+	Width       int64  `json:"width"`
+	Height      int64  `json:"height"`
+	DurationMs  int64  `json:"duration_ms"`
+	StoragePath string `json:"storage_path"`
+	CreatedAt   string `json:"created_at"`
+}
+
+func (q *Queries) GetUploadByOwnerNonce(ctx context.Context, arg GetUploadByOwnerNonceParams) (GetUploadByOwnerNonceRow, error) {
+	row := q.db.QueryRowContext(ctx, getUploadByOwnerNonce, arg.OwnerID, arg.ClientNonce)
+	var i GetUploadByOwnerNonceRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.OwnerID,
+		&i.ClientNonce,
 		&i.Filename,
 		&i.ContentType,
 		&i.ByteSize,
@@ -2070,14 +2118,15 @@ func (q *Queries) InsertThreadState(ctx context.Context, rootMessageID string) e
 }
 
 const insertUpload = `-- name: InsertUpload :exec
-INSERT INTO uploads (id, workspace_id, owner_id, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+INSERT INTO uploads (id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
 `
 
 type InsertUploadParams struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`
@@ -2093,6 +2142,7 @@ func (q *Queries) InsertUpload(ctx context.Context, arg InsertUploadParams) erro
 		arg.ID,
 		arg.WorkspaceID,
 		arg.OwnerID,
+		arg.ClientNonce,
 		arg.Filename,
 		arg.ContentType,
 		arg.ByteSize,

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1292,7 +1292,7 @@ func (q *Queries) GetUploadByOwnerNonce(ctx context.Context, arg GetUploadByOwne
 }
 
 const getUploadQuotaReservation = `-- name: GetUploadQuotaReservation :one
-SELECT id, workspace_id, owner_id, byte_size, created_at, expires_at
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
 FROM upload_quota_reservations
 WHERE id = ?1
 `
@@ -1304,6 +1304,33 @@ func (q *Queries) GetUploadQuotaReservation(ctx context.Context, id string) (Upl
 		&i.ID,
 		&i.WorkspaceID,
 		&i.OwnerID,
+		&i.ClientNonce,
+		&i.ByteSize,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+	)
+	return i, err
+}
+
+const getUploadQuotaReservationByOwnerNonce = `-- name: GetUploadQuotaReservationByOwnerNonce :one
+SELECT id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at
+FROM upload_quota_reservations
+WHERE owner_id = ?1 AND client_nonce = ?2
+`
+
+type GetUploadQuotaReservationByOwnerNonceParams struct {
+	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+func (q *Queries) GetUploadQuotaReservationByOwnerNonce(ctx context.Context, arg GetUploadQuotaReservationByOwnerNonceParams) (UploadQuotaReservation, error) {
+	row := q.db.QueryRowContext(ctx, getUploadQuotaReservationByOwnerNonce, arg.OwnerID, arg.ClientNonce)
+	var i UploadQuotaReservation
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.OwnerID,
+		&i.ClientNonce,
 		&i.ByteSize,
 		&i.CreatedAt,
 		&i.ExpiresAt,
@@ -2156,14 +2183,15 @@ func (q *Queries) InsertUpload(ctx context.Context, arg InsertUploadParams) erro
 }
 
 const insertUploadQuotaReservation = `-- name: InsertUploadQuotaReservation :exec
-INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, byte_size, created_at, expires_at)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+INSERT INTO upload_quota_reservations (id, workspace_id, owner_id, client_nonce, byte_size, created_at, expires_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
 `
 
 type InsertUploadQuotaReservationParams struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	ClientNonce string `json:"client_nonce"`
 	ByteSize    int64  `json:"byte_size"`
 	CreatedAt   string `json:"created_at"`
 	ExpiresAt   string `json:"expires_at"`
@@ -2174,6 +2202,7 @@ func (q *Queries) InsertUploadQuotaReservation(ctx context.Context, arg InsertUp
 		arg.ID,
 		arg.WorkspaceID,
 		arg.OwnerID,
+		arg.ClientNonce,
 		arg.ByteSize,
 		arg.CreatedAt,
 		arg.ExpiresAt,

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -14,6 +14,10 @@ import (
 const uploadQuotaReservationTTL = 15 * time.Minute
 
 func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput) (store.Upload, error) {
+	nonce, err := normalizeClientNonce(input.Nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.Upload{}, err
@@ -26,6 +30,7 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 		ID:          newID("upl"),
 		WorkspaceID: input.WorkspaceID,
 		OwnerID:     input.OwnerID,
+		Nonce:       nonce,
 		Filename:    input.Filename,
 		ContentType: input.ContentType,
 		ByteSize:    input.ByteSize,
@@ -39,6 +44,7 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 		ID:          upload.ID,
 		WorkspaceID: upload.WorkspaceID,
 		OwnerID:     upload.OwnerID,
+		ClientNonce: upload.Nonce,
 		Filename:    upload.Filename,
 		ContentType: upload.ContentType,
 		ByteSize:    upload.ByteSize,
@@ -102,6 +108,10 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 }
 
 func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, input store.CreateUploadInput) (store.Upload, error) {
+	nonce, err := normalizeClientNonce(input.Nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.Upload{}, err
@@ -134,6 +144,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 		ID:          newID("upl"),
 		WorkspaceID: input.WorkspaceID,
 		OwnerID:     input.OwnerID,
+		Nonce:       nonce,
 		Filename:    input.Filename,
 		ContentType: input.ContentType,
 		ByteSize:    input.ByteSize,
@@ -147,6 +158,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 		ID:          upload.ID,
 		WorkspaceID: upload.WorkspaceID,
 		OwnerID:     upload.OwnerID,
+		ClientNonce: upload.Nonce,
 		Filename:    upload.Filename,
 		ContentType: upload.ContentType,
 		ByteSize:    upload.ByteSize,
@@ -274,6 +286,28 @@ func (s *Store) GetUpload(ctx context.Context, uploadID, userID string) (store.U
 	}
 	if !visible {
 		return store.Upload{}, errors.New("upload is not visible")
+	}
+	return upload, nil
+}
+
+func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (store.Upload, error) {
+	normalized, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.Upload{}, err
+	}
+	if normalized == "" {
+		return store.Upload{}, sql.ErrNoRows
+	}
+	row, err := s.q.GetUploadByOwnerNonce(ctx, storedb.GetUploadByOwnerNonceParams{
+		OwnerID:     ownerID,
+		ClientNonce: normalized,
+	})
+	if err != nil {
+		return store.Upload{}, err
+	}
+	upload := storeUploadFromGetUploadByOwnerNonce(row)
+	if err := s.requireMembership(ctx, upload.WorkspaceID, ownerID); err != nil {
+		return store.Upload{}, err
 	}
 	return upload, nil
 }

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -305,11 +305,7 @@ func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (st
 	if err != nil {
 		return store.Upload{}, err
 	}
-	upload := storeUploadFromGetUploadByOwnerNonce(row)
-	if err := s.requireMembership(ctx, upload.WorkspaceID, ownerID); err != nil {
-		return store.Upload{}, err
-	}
-	return upload, nil
+	return storeUploadFromGetUploadByOwnerNonce(row), nil
 }
 
 func (s *Store) UploadHasDirectMessageAttachment(ctx context.Context, uploadID string) (bool, error) {

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -59,7 +59,11 @@ func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput)
 	return upload, tx.Commit()
 }
 
-func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID string, byteSize int64) (store.UploadQuotaReservation, error) {
+func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
+	normalizedNonce, err := normalizeClientNonce(nonce)
+	if err != nil {
+		return store.UploadQuotaReservation{}, err
+	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
@@ -79,6 +83,32 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, userID); err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
+	if normalizedNonce != "" {
+		uploadRow, err := qtx.GetUploadByOwnerNonce(ctx, storedb.GetUploadByOwnerNonceParams{
+			OwnerID:     userID,
+			ClientNonce: normalizedNonce,
+		})
+		switch {
+		case err == nil && storeUploadFromGetUploadByOwnerNonce(uploadRow).WorkspaceID != workspaceID:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceConflict
+		case err == nil:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceInProgress
+		case !errors.Is(err, sql.ErrNoRows):
+			return store.UploadQuotaReservation{}, err
+		}
+		existing, err := qtx.GetUploadQuotaReservationByOwnerNonce(ctx, storedb.GetUploadQuotaReservationByOwnerNonceParams{
+			OwnerID:     userID,
+			ClientNonce: normalizedNonce,
+		})
+		switch {
+		case err == nil && existing.WorkspaceID != workspaceID:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceConflict
+		case err == nil:
+			return store.UploadQuotaReservation{}, store.ErrUploadNonceInProgress
+		case !errors.Is(err, sql.ErrNoRows):
+			return store.UploadQuotaReservation{}, err
+		}
+	}
 	quota, err := uploadQuotaTx(ctx, tx, workspaceID, userID)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
@@ -90,6 +120,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 		ID:          newID("uqr"),
 		WorkspaceID: workspaceID,
 		OwnerID:     userID,
+		Nonce:       normalizedNonce,
 		ByteSize:    min(byteSize, quota.RemainingBytes),
 		CreatedAt:   uploadReservationTime(reservationNow),
 		ExpiresAt:   uploadReservationTime(reservationNow.Add(uploadQuotaReservationTTL)),
@@ -98,6 +129,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID stri
 		ID:          reservation.ID,
 		WorkspaceID: reservation.WorkspaceID,
 		OwnerID:     reservation.OwnerID,
+		ClientNonce: reservation.Nonce,
 		ByteSize:    reservation.ByteSize,
 		CreatedAt:   reservation.CreatedAt,
 		ExpiresAt:   reservation.ExpiresAt,
@@ -125,7 +157,7 @@ func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, 
 	if err != nil {
 		return store.Upload{}, err
 	}
-	if reservation.WorkspaceID != input.WorkspaceID || reservation.OwnerID != input.OwnerID {
+	if reservation.WorkspaceID != input.WorkspaceID || reservation.OwnerID != input.OwnerID || reservation.ClientNonce != nonce {
 		return store.Upload{}, errors.New("upload quota reservation does not match upload")
 	}
 	if err := requireMembershipTx(ctx, tx, input.WorkspaceID, input.OwnerID); err != nil {

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -71,6 +71,8 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, non
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
 	reservationNow := time.Now().UTC()
+	// Reclaim expired nonce claims before lookup so a crashed uploader cannot
+	// strand its nonce after the reservation TTL.
 	if err := qtx.DeleteExpiredUploadQuotaReservations(ctx, uploadReservationTime(reservationNow)); err != nil {
 		return store.UploadQuotaReservation{}, err
 	}

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -861,6 +861,7 @@ type Store interface {
 	CreateTopic(ctx context.Context, input CreateTopicInput) (Topic, error)
 	ListMessages(ctx context.Context, channelID, userID string, page MessagePageRequest) (MessagePage, error)
 	GetMessage(ctx context.Context, messageID, userID string) (Message, error)
+	GetMessageByNonce(ctx context.Context, authorID, nonce string) (Message, error)
 	EnsureThreadRouteID(ctx context.Context, userID, rootMessageID string) (Message, error)
 	CreateMessage(ctx context.Context, input CreateMessageInput) (Message, Event, error)
 	UpdateMessage(ctx context.Context, input UpdateMessageInput) (Message, Event, error)

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -35,6 +35,10 @@ var ErrPostRateLimited = errors.New("waiting room post limit reached")
 // budget in a workspace.
 var ErrUploadQuotaExceeded = errors.New("upload quota exceeded")
 
+// ErrUploadNonceConflict is returned when a client reuses an upload nonce in
+// another workspace.
+var ErrUploadNonceConflict = errors.New("upload nonce was already used in another workspace")
+
 var (
 	ErrOAuthTransactionInvalid  = errors.New("invalid or expired oauth transaction")
 	ErrOAuthCapacityExceeded    = errors.New("too many pending oauth requests")
@@ -569,6 +573,7 @@ type Upload struct {
 	ID          string `json:"id"`
 	WorkspaceID string `json:"workspace_id"`
 	OwnerID     string `json:"owner_id"`
+	Nonce       string `json:"nonce,omitempty"`
 	Filename    string `json:"filename"`
 	ContentType string `json:"content_type"`
 	ByteSize    int64  `json:"byte_size"`
@@ -592,6 +597,7 @@ type PendingUploadCleanup struct {
 type CreateUploadInput struct {
 	WorkspaceID string
 	OwnerID     string
+	Nonce       string
 	Filename    string
 	ContentType string
 	ByteSize    int64
@@ -862,6 +868,7 @@ type Store interface {
 	ListEventsAfter(ctx context.Context, workspaceID, userID, cursor string, limit int) ([]Event, error)
 	CreateUpload(ctx context.Context, input CreateUploadInput) (Upload, error)
 	GetUpload(ctx context.Context, uploadID, userID string) (Upload, error)
+	GetUploadByNonce(ctx context.Context, ownerID, nonce string) (Upload, error)
 	UploadHasDirectMessageAttachment(ctx context.Context, uploadID string) (bool, error)
 	UploadHasOtherDirectMessageAttachment(ctx context.Context, uploadID, messageID string) (bool, error)
 	AttachUpload(ctx context.Context, input AttachUploadInput) (Event, error)

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -39,6 +39,10 @@ var ErrUploadQuotaExceeded = errors.New("upload quota exceeded")
 // another workspace.
 var ErrUploadNonceConflict = errors.New("upload nonce was already used in another workspace")
 
+// ErrUploadNonceInProgress is returned while another request owns the same
+// upload nonce claim and has not committed or released it yet.
+var ErrUploadNonceInProgress = errors.New("upload nonce is already in progress")
+
 var (
 	ErrOAuthTransactionInvalid  = errors.New("invalid or expired oauth transaction")
 	ErrOAuthCapacityExceeded    = errors.New("too many pending oauth requests")
@@ -627,6 +631,7 @@ type UploadQuotaReservation struct {
 	ID          string
 	WorkspaceID string
 	OwnerID     string
+	Nonce       string
 	ByteSize    int64
 	CreatedAt   string
 	ExpiresAt   string
@@ -831,7 +836,7 @@ type Store interface {
 	UserHasNonGuestMembership(ctx context.Context, userID string) (bool, error)
 	UploadQuota(ctx context.Context, workspaceID, userID string) (UploadQuota, error)
 	CanCreateUpload(ctx context.Context, workspaceID, userID string, byteSize int64) error
-	ReserveUploadQuota(ctx context.Context, workspaceID, userID string, byteSize int64) (UploadQuotaReservation, error)
+	ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (UploadQuotaReservation, error)
 	CreateReservedUpload(ctx context.Context, reservationID string, input CreateUploadInput) (Upload, error)
 	ReleaseUploadQuotaReservation(ctx context.Context, reservationID, userID string) error
 	FirstUser(ctx context.Context) (User, error)

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -51,7 +51,7 @@ The value is not stored on message rows or exported as a metrics label.
 | Reactions     | `/api/messages/{id}/reactions` | [reactions](../features/reactions.md) |
 | Realtime      | `/api/realtime/{ws,events,ephemeral}` | [realtime](../features/realtime.md) |
 | Search        | `/api/search` | [search](../features/search.md) |
-| Uploads       | `/api/uploads`, `/api/messages/{id}/attachments` | [uploads](../features/uploads.md) |
+| Uploads       | `/api/uploads`, `/api/uploads/by-nonce`, `/api/messages/{id}/attachments` | [uploads](../features/uploads.md) |
 | DMs           | `/api/dms`, `/api/dms/{id}`, `/api/dms/{id}/open`, `/api/dms/{id}/messages` | [dms](../features/dms.md) |
 | Integrations  | `/api/hooks/mattermost/{channel}` | [integrations](../features/integrations.md) |
 | Operations    | `/healthz`, `/readyz`, opt-in `/metrics` | [deployment](../deployment.md) |

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -45,7 +45,7 @@ The value is not stored on message rows or exported as a metrics label.
 | Connected accounts | `/api/workspaces/{id}/connected-accounts`, `/api/connected-accounts/{id}/revoke` | [integrations](../features/integrations.md) |
 | Topics        | `/api/workspaces/{id}/topics` | [messages](../features/messages.md) |
 | Channels      | `/api/workspaces/{id}/channels`, `/api/channels/{id}` | [workspaces](../features/workspaces.md) |
-| Messages      | `/api/channels/{id}/messages`, `/api/messages/{id}` | [messages](../features/messages.md) |
+| Messages      | `/api/channels/{id}/messages`, `/api/messages/by-nonce`, `/api/messages/{id}` | [messages](../features/messages.md) |
 | Threads       | `/api/messages/{id}/thread`, `/api/messages/{id}/thread/replies` | [threads](../features/threads.md) |
 | Replies       | `quoted_message_id` on any message-create endpoint | [replies](../features/replies.md) |
 | Reactions     | `/api/messages/{id}/reactions` | [reactions](../features/reactions.md) |

--- a/docs/features/messages.md
+++ b/docs/features/messages.md
@@ -19,6 +19,7 @@ on the same row via `quoted_message_id` and friends, documented in
 GET    /api/channels/{channel_id}/messages?after_seq=&before_seq=&around_seq=&limit=
 POST   /api/channels/{channel_id}/messages
 POST   /api/channels/{channel_id}/read
+GET    /api/messages/by-nonce?workspace_id=...&nonce=...
 GET    /api/messages/{message_id}
 PATCH  /api/messages/{message_id}
 DELETE /api/messages/{message_id}
@@ -36,6 +37,11 @@ DELETE /api/messages/{message_id}
   Empty bodies are rejected. `nonce` is an optional client idempotency key;
   replaying the same nonce with the same body, quote, and topic returns the
   existing message with HTTP 200 instead of creating a duplicate.
+- `GET /api/messages/by-nonce` lets the authenticated author reconcile a
+  durable create after an interrupted request. It returns the matching message,
+  including attachments, or a capability-marked 404 when no message exists.
+  The `X-ClickClack-Message-Nonce: supported` response header distinguishes
+  that result from an older server that does not implement the endpoint.
 - `POST /read` accepts `{seq}` and updates the caller's monotonic read pointer
   for the channel. The server caps `seq` to the channel's current last root
   message sequence.

--- a/docs/features/uploads.md
+++ b/docs/features/uploads.md
@@ -31,7 +31,8 @@ POST /api/messages/{message_id}/attachments        # { upload_id }
   first request returns `201`; later requests from the same uploader return the
   original upload with `200` without reading or storing the multipart body.
   The nonce lookup endpoint returns the same metadata without downloading the
-  file. Reusing the nonce for another workspace returns `409`.
+  file and includes `X-ClickClack-Upload-Nonce: supported`, including on a
+  `404` lookup miss. Reusing the nonce for another workspace returns `409`.
 - Guests cannot upload or attach files while they are still in the waiting
   room. Timed-out and blocked users are also upload-restricted.
 

--- a/docs/features/uploads.md
+++ b/docs/features/uploads.md
@@ -14,7 +14,8 @@ authenticated workspace members and serves common safe preview types inline.
 ## Endpoints
 
 ```http
-POST /api/uploads?workspace_id=...                 # multipart: file; form workspace_id also supported
+POST /api/uploads?workspace_id=...&nonce=...       # multipart: file; nonce is optional
+GET  /api/uploads/by-nonce?workspace_id=...&nonce=...
 GET  /api/uploads/{upload_id}                      # streams the file
 POST /api/messages/{message_id}/attachments        # { upload_id }
 ```
@@ -25,6 +26,12 @@ POST /api/messages/{message_id}/attachments        # { upload_id }
   not used as the storage key.
 - `Content-Type` falls back to `application/octet-stream` when the client
   doesn't send one.
+- Clients that may retry an upload can send a nonce of up to 128 characters.
+  The `workspace_id` query parameter is required when a nonce is present. The
+  first request returns `201`; later requests from the same uploader return the
+  original upload with `200` without reading or storing the multipart body.
+  The nonce lookup endpoint returns the same metadata without downloading the
+  file. Reusing the nonce for another workspace returns `409`.
 - Guests cannot upload or attach files while they are still in the waiting
   room. Timed-out and blocked users are also upload-restricted.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -77,7 +77,7 @@ See [features/auth.md](features/auth.md).
 | `messages`    | `get`, `update`, `delete` |
 | `threads`     | `get`, `reply` |
 | `search(workspaceId, q)` | full-text search |
-| `uploads`     | `create(workspaceId, file)`, `attach(messageId, uploadId)` |
+| `uploads`     | `create(workspaceId, file, filename?, { nonce? })`, `findByNonce(workspaceId, nonce)`, `attach(messageId, uploadId)` |
 | `dms`         | `list`, `create`, `get`, `close`, `open`, `messages`, `sendMessage`, `markRead` |
 | `events`      | `publishEphemeral`, `subscribe` |
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -74,7 +74,7 @@ See [features/auth.md](features/auth.md).
 | `auditLog`     | `list` |
 | `connectedAccounts` | `list`, `create`, `revoke` |
 | `channels`    | `list`, `create`, `update`, `messages`, `sendMessage`, `markRead` |
-| `messages`    | `get`, `update`, `delete` |
+| `messages`    | `get`, `findByNonce(workspaceId, nonce)`, `update`, `delete` |
 | `threads`     | `get`, `reply` |
 | `search(workspaceId, q)` | full-text search |
 | `uploads`     | `create(workspaceId, file, filename?, { nonce? })`, `findByNonce(workspaceId, nonce)`, `attach(messageId, uploadId)` |

--- a/infra/migrations/sqlite/0025_upload_client_nonce.sql
+++ b/infra/migrations/sqlite/0025_upload_client_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE uploads ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_uploads_owner_client_nonce
+  ON uploads(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/infra/migrations/sqlite/0026_upload_reservation_nonce.sql
+++ b/infra/migrations/sqlite/0026_upload_reservation_nonce.sql
@@ -1,0 +1,5 @@
+ALTER TABLE upload_quota_reservations ADD COLUMN client_nonce TEXT NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_upload_quota_reservations_owner_client_nonce
+  ON upload_quota_reservations(owner_id, client_nonce)
+  WHERE client_nonce <> '';

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -854,6 +854,44 @@ paths:
       responses:
         "200":
           description: Updated channel read receipt
+  /api/messages/by-nonce:
+    get:
+      operationId: getMessageByNonce
+      parameters:
+        - name: workspace_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: nonce
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 128
+      responses:
+        "200":
+          description: Message created by the authenticated owner with this nonce
+          headers:
+            X-ClickClack-Message-Nonce:
+              description: Indicates that durable message nonce lookup is supported.
+              schema:
+                type: string
+                enum: [supported]
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+        "404":
+          description: No message exists for this owner and nonce
+          headers:
+            X-ClickClack-Message-Nonce:
+              description: Indicates that durable message nonce lookup is supported.
+              schema:
+                type: string
+                enum: [supported]
+        "409":
+          description: The nonce belongs to a message in another workspace
   /api/messages/{message_id}:
     get:
       operationId: getMessage
@@ -2119,6 +2157,12 @@ components:
           $ref: "#/components/schemas/ThreadState"
         nonce:
           type: string
+    MessageResponse:
+      type: object
+      required: [message]
+      properties:
+        message:
+          $ref: "#/components/schemas/Message"
     Upload:
       type: object
       required: [id, workspace_id, owner_id, filename, content_type, byte_size, created_at]

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -1033,6 +1033,12 @@ paths:
           description: Optional workspace id for multipart clients that cannot send fields before the file part. If omitted, workspace_id must be included as a form field before file.
           schema:
             type: string
+        - name: nonce
+          in: query
+          description: Optional idempotency nonce. Requires workspace_id in the query. Replays return the original upload without reading the multipart body.
+          schema:
+            type: string
+            maxLength: 128
       requestBody:
         required: true
         content:
@@ -1057,8 +1063,58 @@ paths:
                   type: integer
                   minimum: 0
       responses:
+        "200":
+          description: Existing upload replayed by nonce
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
         "201":
           description: Created upload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
+        "409":
+          description: The nonce belongs to an upload in another workspace
+  /api/uploads/by-nonce:
+    get:
+      operationId: getUploadByNonce
+      parameters:
+        - name: workspace_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: nonce
+          in: query
+          required: true
+          schema:
+            type: string
+            maxLength: 128
+      responses:
+        "200":
+          description: Upload metadata
+          headers:
+            X-ClickClack-Upload-Nonce:
+              description: Indicates that durable upload nonce lookup is supported.
+              schema:
+                type: string
+                enum: [supported]
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UploadResponse"
+        "404":
+          description: No upload exists for this nonce
+          headers:
+            X-ClickClack-Upload-Nonce:
+              description: Indicates that durable upload nonce lookup is supported.
+              schema:
+                type: string
+                enum: [supported]
+        "409":
+          description: The nonce belongs to an upload in another workspace
   /api/uploads/{upload_id}:
     get:
       operationId: getUpload
@@ -2063,6 +2119,43 @@ components:
           $ref: "#/components/schemas/ThreadState"
         nonce:
           type: string
+    Upload:
+      type: object
+      required: [id, workspace_id, owner_id, filename, content_type, byte_size, created_at]
+      properties:
+        id:
+          type: string
+        workspace_id:
+          type: string
+        owner_id:
+          type: string
+        nonce:
+          type: string
+        filename:
+          type: string
+        content_type:
+          type: string
+        byte_size:
+          type: integer
+          format: int64
+        width:
+          type: integer
+          minimum: 0
+        height:
+          type: integer
+          minimum: 0
+        duration_ms:
+          type: integer
+          minimum: 0
+        created_at:
+          type: string
+          format: date-time
+    UploadResponse:
+      type: object
+      required: [upload]
+      properties:
+        upload:
+          $ref: "#/components/schemas/Upload"
     RouteTarget:
       type: object
       required: [workspace_id, workspace_route_id, target_type, target_id, target_route_id, canonical_path]

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -615,6 +615,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/messages/by-nonce": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getMessageByNonce"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/messages/{message_id}": {
     parameters: {
       query?: never;
@@ -1396,6 +1412,9 @@ export interface components {
       quoted_author?: components["schemas"]["User"];
       thread_state?: components["schemas"]["ThreadState"];
       nonce?: string;
+    };
+    MessageResponse: {
+      message: components["schemas"]["Message"];
     };
     Upload: {
       id: string;
@@ -2935,6 +2954,47 @@ export interface operations {
     responses: {
       /** @description Updated channel read receipt */
       200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getMessageByNonce: {
+    parameters: {
+      query: {
+        workspace_id: string;
+        nonce: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Message created by the authenticated owner with this nonce */
+      200: {
+        headers: {
+          /** @description Indicates that durable message nonce lookup is supported. */
+          "X-ClickClack-Message-Nonce"?: "supported";
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["MessageResponse"];
+        };
+      };
+      /** @description No message exists for this owner and nonce */
+      404: {
+        headers: {
+          /** @description Indicates that durable message nonce lookup is supported. */
+          "X-ClickClack-Message-Nonce"?: "supported";
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description The nonce belongs to a message in another workspace */
+      409: {
         headers: {
           [name: string]: unknown;
         };

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -791,6 +791,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/uploads/by-nonce": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get: operations["getUploadByNonce"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/uploads/{upload_id}": {
     parameters: {
       query?: never;
@@ -1380,6 +1396,24 @@ export interface components {
       quoted_author?: components["schemas"]["User"];
       thread_state?: components["schemas"]["ThreadState"];
       nonce?: string;
+    };
+    Upload: {
+      id: string;
+      workspace_id: string;
+      owner_id: string;
+      nonce?: string;
+      filename: string;
+      content_type: string;
+      /** Format: int64 */
+      byte_size: number;
+      width?: number;
+      height?: number;
+      duration_ms?: number;
+      /** Format: date-time */
+      created_at: string;
+    };
+    UploadResponse: {
+      upload: components["schemas"]["Upload"];
     };
     RouteTarget: {
       workspace_id: string;
@@ -3193,6 +3227,8 @@ export interface operations {
       query?: {
         /** @description Optional workspace id for multipart clients that cannot send fields before the file part. If omitted, workspace_id must be included as a form field before file. */
         workspace_id?: string;
+        /** @description Optional idempotency nonce. Requires workspace_id in the query. Replays return the original upload without reading the multipart body. */
+        nonce?: string;
       };
       header?: never;
       path?: never;
@@ -3212,8 +3248,67 @@ export interface operations {
       };
     };
     responses: {
+      /** @description Existing upload replayed by nonce */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UploadResponse"];
+        };
+      };
       /** @description Created upload */
       201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UploadResponse"];
+        };
+      };
+      /** @description The nonce belongs to an upload in another workspace */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getUploadByNonce: {
+    parameters: {
+      query: {
+        workspace_id: string;
+        nonce: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Upload metadata */
+      200: {
+        headers: {
+          /** @description Indicates that durable upload nonce lookup is supported. */
+          "X-ClickClack-Upload-Nonce"?: "supported";
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UploadResponse"];
+        };
+      };
+      /** @description No upload exists for this nonce */
+      404: {
+        headers: {
+          /** @description Indicates that durable upload nonce lookup is supported. */
+          "X-ClickClack-Upload-Nonce"?: "supported";
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description The nonce belongs to an upload in another workspace */
+      409: {
         headers: {
           [name: string]: unknown;
         };

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -708,6 +708,19 @@ export class ClickClackClient {
       const data = await this.request<{ message: Message }>(`/api/messages/${messageId}`);
       return data.message;
     },
+    findByNonce: async (workspaceId: string, nonce: string): Promise<Message | undefined> => {
+      const params = new URLSearchParams({ workspace_id: workspaceId, nonce });
+      const response = await this.fetchResponse(`/api/messages/by-nonce?${params.toString()}`);
+      if (
+        response.status === 404 &&
+        response.headers.get("X-ClickClack-Message-Nonce") === "supported"
+      ) {
+        await response.text();
+        return undefined;
+      }
+      const data = await this.readResponse<{ message: Message }>(response);
+      return data.message;
+    },
     update: async (messageId: string, input: { body: string }): Promise<Message> => {
       const data = await this.request<{ message: Message }>(`/api/messages/${messageId}`, {
         method: "PATCH",

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -209,6 +209,7 @@ export type Upload = {
   id: string;
   workspace_id: string;
   owner_id: string;
+  nonce?: string;
   filename: string;
   content_type: string;
   byte_size: number;
@@ -752,14 +753,29 @@ export class ClickClackClient {
       workspaceId: string,
       file: File | Blob,
       filename = "upload.bin",
+      options: { nonce?: string } = {},
     ): Promise<Upload> => {
       const form = new FormData();
       form.set("file", file, filename);
       const params = new URLSearchParams({ workspace_id: workspaceId });
+      if (options.nonce) params.set("nonce", options.nonce);
       const data = await this.request<{ upload: Upload }>(`/api/uploads?${params.toString()}`, {
         method: "POST",
         body: form,
       });
+      return data.upload;
+    },
+    findByNonce: async (workspaceId: string, nonce: string): Promise<Upload | undefined> => {
+      const params = new URLSearchParams({ workspace_id: workspaceId, nonce });
+      const response = await this.fetchResponse(`/api/uploads/by-nonce?${params.toString()}`);
+      if (
+        response.status === 404 &&
+        response.headers.get("X-ClickClack-Upload-Nonce") === "supported"
+      ) {
+        await response.text();
+        return undefined;
+      }
+      const data = await this.readResponse<{ upload: Upload }>(response);
       return data.upload;
     },
     attach: async (messageId: string, uploadId: string): Promise<void> => {
@@ -865,7 +881,7 @@ export class ClickClackClient {
     },
   };
 
-  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  private async fetchResponse(path: string, init: RequestInit = {}): Promise<Response> {
     const headers = new Headers(init.headers);
     const method = (init.method ?? "GET").toUpperCase();
     headers.set("Accept", "application/json");
@@ -875,7 +891,10 @@ export class ClickClackClient {
       headers.set("X-ClickClack-CSRF", "1");
     if (this.token) headers.set("Authorization", `Bearer ${this.token}`);
     if (this.userId) headers.set("X-ClickClack-User", this.userId);
-    const response = await this.fetcher(`${this.baseUrl}${path}`, { ...init, headers });
+    return this.fetcher(`${this.baseUrl}${path}`, { ...init, headers });
+  }
+
+  private async readResponse<T>(response: Response): Promise<T> {
     if (!response.ok) {
       throw new Error(await response.text());
     }
@@ -884,6 +903,10 @@ export class ClickClackClient {
     }
     const text = await response.text();
     return text ? (JSON.parse(text) as T) : (undefined as T);
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    return this.readResponse<T>(await this.fetchResponse(path, init));
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where retrying an interrupted upload or message send could create duplicate records, consume upload quota more than once, or leave clients unable to determine whether the original request succeeded.

It also prevents nonce recovery lookups from escaping the requesting user, workspace, or direct-message conversation scope.

## Why This Change Was Made

This adds optional owner-scoped idempotency nonces for uploads and messages, with atomic reservation and finalization in PostgreSQL and SQLite.

The API exposes scoped nonce lookup endpoints so clients can safely recover interrupted operations. Database migrations, generated queries, OpenAPI, the TypeScript SDK, and documentation are updated together. Requests that do not provide a nonce retain their existing behavior.

## User Impact

Clients can safely retry uploads and message creation without producing duplicate content or double-counting quota.

Interrupted media delivery can recover the original upload and message, including after expired reservations, while workspace, owner, and DM isolation remain enforced.

## Evidence

Current-main verification:

- `go test ./apps/api/internal/httpapi ./apps/api/internal/store/sqlite ./apps/api/internal/store/postgres`
- `pnpm --filter @clickclack/sdk-ts build`
- `pnpm fmt:go:check`
- `pnpm exec oxfmt --check packages/sdk-ts/src/generated/openapi.d.ts packages/sdk-ts/src/index.ts`

Remote AWS verification covered:

- Live PostgreSQL locking, reservation, replay, and finalization
- SQLite migration and replay behavior
- HTTP API authorization and nonce scoping
- OpenAPI and generated TypeScript SDK consistency
- SDK runtime smoke testing
- Expired reservation recovery
- Full affected Go package suites

The branch contains 17 focused commits and is rebased onto current ClickClack `main`.
