### PR TITLE
fix: prevent sqlite write lock failures

### DIFF
--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -347,7 +347,7 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 }
 
 func (s *Store) requireDirectAccess(ctx context.Context, conversationID, userID string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}

--- a/apps/api/internal/store/sqlite/members.go
+++ b/apps/api/internal/store/sqlite/members.go
@@ -39,7 +39,7 @@ func (s *Store) ListWorkspaceMemberPage(ctx context.Context, workspaceID, actorU
 			cursor.RoleSort = store.WorkspaceMemberRoleSort(req.Role)
 		}
 	}
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return store.WorkspaceMemberPage{}, err
 	}

--- a/apps/api/internal/store/sqlite/moderation.go
+++ b/apps/api/internal/store/sqlite/moderation.go
@@ -95,7 +95,7 @@ func requireGuestChannelAccessTx(ctx context.Context, tx *sql.Tx, workspaceID, c
 }
 
 func (s *Store) requireGuestChannelAccess(ctx context.Context, workspaceID, channelID, userID string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (s *Store) requireGuestChannelAccess(ctx context.Context, workspaceID, chan
 }
 
 func (s *Store) CanPublishEphemeral(ctx context.Context, workspaceID, channelID, directConversationID, userID string) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func postsRemainingTx(ctx context.Context, q storedb.DBTX, workspaceID, userID, 
 }
 
 func (s *Store) ListWorkspaceMembers(ctx context.Context, workspaceID, actorUserID string) ([]store.MemberModeration, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -36,7 +36,7 @@ func Open(dbURL string) (*Store, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", path+"?_txlock=immediate")
 	if err != nil {
 		return nil, err
 	}

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -33,10 +35,14 @@ func Open(dbURL string) (*Store, error) {
 	if path == "" || path == dbURL {
 		path = dbURL
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
 		return nil, err
 	}
-	db, err := sql.Open("sqlite", path+"?_txlock=immediate")
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", sqliteDSN(absolutePath))
 	if err != nil {
 		return nil, err
 	}
@@ -44,17 +50,26 @@ func Open(dbURL string) (*Store, error) {
 	db.SetMaxIdleConns(1)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	for _, pragma := range []string{
-		"PRAGMA journal_mode=WAL",
-		"PRAGMA foreign_keys=ON",
-		"PRAGMA busy_timeout=5000",
-	} {
-		if _, err := db.ExecContext(ctx, pragma); err != nil {
-			_ = db.Close()
-			return nil, err
-		}
+	if err := db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, err
 	}
 	return &Store{db: db, q: storedb.New(db)}, nil
+}
+
+func sqliteDSN(absolutePath string) string {
+	uriPath := filepath.ToSlash(absolutePath)
+	if runtime.GOOS == "windows" && filepath.VolumeName(absolutePath) != "" && !strings.HasPrefix(uriPath, "/") {
+		uriPath = "/" + uriPath
+	}
+	dsn := url.URL{Scheme: "file", Path: uriPath}
+	query := url.Values{}
+	query.Set("_txlock", "immediate")
+	query.Add("_pragma", "busy_timeout(5000)")
+	query.Add("_pragma", "foreign_keys(1)")
+	query.Add("_pragma", "journal_mode(WAL)")
+	dsn.RawQuery = query.Encode()
+	return dsn.String()
 }
 
 func (s *Store) Close() error { return s.db.Close() }

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -743,6 +744,71 @@ func TestOpenRejectsBadDirectory(t *testing.T) {
 	}
 	if _, err := Open("sqlite://" + filepath.Join(path, "db.sqlite")); err == nil {
 		t.Fatal("expected bad directory error")
+	}
+}
+
+func TestOpenSupportsSQLitePathsWithURICharacters(t *testing.T) {
+	t.Parallel()
+	filename := "clickclack #%.db"
+	if runtime.GOOS != "windows" {
+		filename = "clickclack ?#%.db"
+	}
+	path := filepath.Join(t.TempDir(), filename)
+	st, err := Open("sqlite://" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected SQLite database at the configured path: %v", err)
+	}
+}
+
+func TestOpenConfiguresReplacementConnections(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, err := Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	st.db.SetMaxIdleConns(0)
+	for attempt := 1; attempt <= 2; attempt++ {
+		conn, err := st.db.Conn(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var busyTimeout int
+		var foreignKeys int
+		var journalMode string
+		if err := conn.QueryRowContext(ctx, "PRAGMA busy_timeout").Scan(&busyTimeout); err != nil {
+			_ = conn.Close()
+			t.Fatal(err)
+		}
+		if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys); err != nil {
+			_ = conn.Close()
+			t.Fatal(err)
+		}
+		if err := conn.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journalMode); err != nil {
+			_ = conn.Close()
+			t.Fatal(err)
+		}
+		if err := conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if busyTimeout != 5000 || foreignKeys != 1 || !strings.EqualFold(journalMode, "wal") {
+			t.Fatalf(
+				"replacement connection %d configuration: busy_timeout=%d foreign_keys=%d journal_mode=%q",
+				attempt,
+				busyTimeout,
+				foreignKeys,
+				journalMode,
+			)
+		}
 	}
 }
 

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -888,6 +888,63 @@ func TestAuthTokenHashMigrationBackfillsLegacyTokens(t *testing.T) {
 	}
 }
 
+func TestWriteTransactionsWaitAcrossStoreConnections(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "clickclack.db")
+	first, err := Open("sqlite://" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = first.Close() })
+	second, err := Open("sqlite://" + path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = second.Close() })
+
+	writer, err := first.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Rollback()
+
+	reader, err := second.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		t.Fatalf("read-only transaction should not wait for a writer reservation: %v", err)
+	}
+	if err := reader.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan error, 1)
+	go func() {
+		tx, err := second.db.BeginTx(ctx, nil)
+		if err == nil {
+			err = tx.Rollback()
+		}
+		started <- err
+	}()
+
+	select {
+	case err := <-started:
+		t.Fatalf("competing write transaction returned before the active writer released its lock: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := writer.Rollback(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-started:
+		if err != nil {
+			t.Fatalf("competing write transaction failed after the lock was released: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("competing write transaction did not start after the lock was released")
+	}
+}
+
 func newTestStore(t *testing.T) *Store {
 	t.Helper()
 	st, err := Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -238,7 +238,7 @@ func (s *Store) UploadQuota(ctx context.Context, workspaceID, userID string) (st
 }
 
 func (s *Store) CanCreateUpload(ctx context.Context, workspaceID, userID string, byteSize int64) error {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
 	if err != nil {
 		return err
 	}

--- a/tests/e2e/artifact-viewer.spec.ts
+++ b/tests/e2e/artifact-viewer.spec.ts
@@ -687,6 +687,10 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
   await page.goto("/app");
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   const viewer = page.getByRole("complementary", { name: "Artifact viewer" });
+  const closeViewer = async () => {
+    await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+    await expect(viewer).toHaveCount(0);
+  };
 
   await page.getByRole("button", { name: "Open forecast.xlsx" }).click();
   await expect(viewer.getByRole("region", { name: "Forecast worksheet" })).toContainText("125000");
@@ -695,23 +699,23 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
   }
   await viewer.getByRole("tab", { name: "Assumptions" }).click();
   await expect(viewer.getByRole("region", { name: "Assumptions worksheet" })).toContainText("0.18");
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open namespaced.xlsx" }).click();
   await expect(viewer.getByText("Deflated namespaced workbook")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open namespaced.pptx" }).click();
   await expect(viewer.getByText("Deflated namespaced slide")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open strict.xlsx" }).click();
   await expect(viewer.getByText("Strict workbook relationship")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open strict.pptx" }).click();
   await expect(viewer.getByText("Strict presentation relationship")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open dense.pptx" }).click();
   const denseSlide = viewer.getByLabel("Slide 1: Dense outline");
@@ -736,30 +740,30 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
       }),
     )
     .toBe(true);
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open phonetic.xlsx" }).click();
   await expect(viewer.getByText("Tokyo", { exact: true })).toBeVisible();
   await expect(viewer.getByText("Kyoto", { exact: true })).toBeVisible();
   await expect(viewer.getByText("とうきょう")).toHaveCount(0);
   await expect(viewer.getByText("きょうと")).toHaveCount(0);
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open mixed-sheets.xlsx" }).click();
   await expect(viewer.getByText("Visible worksheet data")).toBeVisible();
   await expect(viewer.getByText("3 non-worksheet sheets omitted")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open per-slide-limit.pptx" }).click();
   await expect(viewer.getByLabel("Slide 1: Oversized slide")).toBeVisible();
   await viewer.getByRole("button", { name: "Next" }).click();
   await expect(viewer.getByLabel("Slide 2: Later slide remains available")).toBeVisible();
   await expect(viewer.getByText("Some slide content was omitted by preview limits.")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open absolute.xlsx" }).click();
   await expect(viewer.getByText("Resolved from package root")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open many-sheets.xlsx" }).click();
   await expect(viewer.getByRole("alert")).toContainText("too many worksheets");
@@ -769,51 +773,51 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
       fullPage: true,
     });
   }
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open xml-element-flood.xlsx" }).click();
   await expect(viewer.getByRole("alert")).toContainText("too many XML elements");
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open cell-budget.xlsx" }).click();
   await viewer.getByRole("tab", { name: "Second" }).click();
   await expect(viewer.getByText("Preview is limited to 10,000 cells")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open omitted-references.xlsx" }).click();
   await expect(viewer.locator("tbody tr").nth(2)).toContainText("Derived A3");
   await expect(viewer.locator("tbody tr").nth(2)).toContainText("Derived B3");
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open shared-string-flood.xlsx" }).click();
   await expect(viewer.getByRole("alert")).toContainText("too many shared strings");
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open paragraph-flood.pptx" }).click();
   await expect(viewer.getByRole("alert")).toContainText("too many paragraphs");
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open media-heavy.pptx" }).click();
   await expect(viewer.getByText("Text-only preview survives media")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open hidden-content.xlsx" }).click();
   await expect(viewer.getByText("TRUE", { exact: true })).toBeVisible();
   await expect(viewer.getByText("1 hidden sheet omitted")).toBeVisible();
   await expect(viewer.getByText("Hidden workbook secret")).toHaveCount(0);
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open hidden-slide.pptx" }).click();
   await expect(viewer.getByText("Visible slide")).toBeVisible();
   await expect(viewer.getByText("1 hidden slide omitted.")).toBeVisible();
   await expect(viewer.getByText("Hidden slide secret")).toHaveCount(0);
   await expect(viewer.getByText("Text outline only.")).toBeVisible();
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open sparse.xlsx" }).click();
   await expect(viewer.getByText("Preview is limited to 10,000 cells")).toBeVisible();
   await expect(viewer.locator("tbody td")).toHaveCount(10_000);
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open long-cell.xlsx" }).click();
   await expect(viewer.getByText("Preview is limited to 10,000 cells")).toBeVisible();
@@ -825,7 +829,7 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
         .evaluate((cell) => cell.getBoundingClientRect().width),
     )
     .toBeLessThanOrEqual(160);
-  await viewer.getByRole("button", { name: "Close artifact viewer" }).click();
+  await closeViewer();
 
   await page.getByRole("button", { name: "Open launch.pptx" }).click();
   await expect(viewer.getByLabel("Slide 1: Launch plan")).toContainText("Three milestones");

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1410,7 +1410,13 @@ test("confirms message deletion in the app modal", async ({ page }) => {
   await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   await page.getByLabel("Message body").fill(body);
+  const messageCreated = page.waitForResponse(
+    (response) =>
+      response.url().endsWith(`/api/channels/${channel.id}/messages`) &&
+      response.request().method() === "POST",
+  );
   await page.getByRole("button", { name: "Send" }).click();
+  expect((await messageCreated).ok()).toBe(true);
 
   const row = page.locator(".message-row:not(.is-pending)", {
     has: page.locator(".markdown").filter({ hasText: body }),


### PR DESCRIPTION
## Summary

- configure SQLite lock handling and connection PRAGMAs on every pooled connection
- reserve the SQLite writer at transaction start while keeping read-only transactions non-blocking
- synchronize Playwright tests with actual viewer teardown and optimistic-message completion

## Verification

- `pnpm check`
- `go test -race ./apps/api/internal/store/sqlite`
- SQLite lock and connection regressions repeated 20 times
- Playwright: 76 tests with 2 workers pinned to 2 CPUs
- deadcode and coverage gates
- repeatable embedded build and docs build
- Windows amd64 SQLite test compilation