### PR TITLE
feat: add claim-time bot setup codes

### DIFF
--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -800,6 +800,68 @@ func (s *Server) createBotTokenForWorkspace(w http.ResponseWriter, r *http.Reque
 	writeResultStatus(w, http.StatusCreated, map[string]any{"bot_token": token}, err)
 }
 
+func (s *Server) createWorkspaceBotSetupCode(w http.ResponseWriter, r *http.Request) {
+	act, err := s.currentActor(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	if act.botTokenID != "" {
+		writeError(w, http.StatusForbidden, errors.New("bot tokens cannot create bot setup codes"))
+		return
+	}
+	var body struct {
+		Name   string   `json:"name"`
+		Scopes []string `json:"scopes"`
+	}
+	if err := readJSON(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	code, err := s.store.CreateBotSetupCode(r.Context(), store.CreateBotSetupCodeInput{
+		WorkspaceID: chi.URLParam(r, "workspace_id"),
+		BotUserID:   chi.URLParam(r, "bot_user_id"),
+		Name:        body.Name,
+		Scopes:      body.Scopes,
+		CreatedBy:   act.user.ID,
+	})
+	if err == nil {
+		s.recordAudit(r.Context(), code.WorkspaceID, act.user.ID, "bot_setup_code.created", "bot_setup_code", code.ID, map[string]any{
+			"bot_user_id": code.BotUserID,
+			"token_name":  code.TokenName,
+		})
+	}
+	writeResultStatus(w, http.StatusCreated, map[string]any{"setup_code": code}, err)
+}
+
+func (s *Server) claimBotSetupCode(w http.ResponseWriter, r *http.Request) {
+	if !s.setupCodeClaimLimiter.allow(clientIPKey(r)) {
+		writeError(w, http.StatusTooManyRequests, errors.New("too many setup code attempts, retry later"))
+		return
+	}
+	var body struct {
+		Code string `json:"code"`
+	}
+	if err := readJSON(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	claim, err := s.store.ClaimBotSetupCode(r.Context(), body.Code)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	s.recordAudit(r.Context(), claim.Workspace.ID, claim.BotToken.CreatedBy, "bot_setup_code.claimed", "bot_token", claim.BotToken.ID, map[string]any{
+		"bot_user_id": claim.Bot.ID,
+		"token_name":  claim.BotToken.Name,
+	})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"bot_token": claim.BotToken,
+		"bot":       claim.Bot,
+		"workspace": claim.Workspace,
+	})
+}
+
 func (s *Server) removeBotFromWorkspace(w http.ResponseWriter, r *http.Request) {
 	act, err := s.currentActor(r)
 	if err != nil {

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -851,14 +851,24 @@ func (s *Server) claimBotSetupCode(w http.ResponseWriter, r *http.Request) {
 		writeStoreError(w, err)
 		return
 	}
-	s.recordAudit(r.Context(), claim.Workspace.ID, claim.BotToken.CreatedBy, "bot_setup_code.claimed", "bot_token", claim.BotToken.ID, map[string]any{
+	s.recordAudit(r.Context(), claim.Workspace.ID, claim.Bot.ID, "bot_setup_code.claimed", "bot_token", claim.BotToken.ID, map[string]any{
 		"bot_user_id": claim.Bot.ID,
 		"token_name":  claim.BotToken.Name,
 	})
 	writeJSON(w, http.StatusOK, map[string]any{
-		"bot_token": claim.BotToken,
-		"bot":       claim.Bot,
-		"workspace": claim.Workspace,
+		"token": claim.BotToken.Token,
+		"bot": map[string]string{
+			"id":           claim.Bot.ID,
+			"handle":       claim.Bot.Handle,
+			"display_name": claim.Bot.DisplayName,
+		},
+		"workspace": map[string]string{
+			"id":       claim.Workspace.ID,
+			"route_id": claim.Workspace.RouteID,
+			"slug":     claim.Workspace.Slug,
+			"name":     claim.Workspace.Name,
+		},
+		"defaults": claim.Defaults,
 	})
 }
 

--- a/apps/api/internal/httpapi/ratelimit.go
+++ b/apps/api/internal/httpapi/ratelimit.go
@@ -1,0 +1,80 @@
+package httpapi
+
+import (
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const rateLimiterSweepThreshold = 4096
+
+// slidingWindowLimiter is a small in-memory per-key rate limiter for
+// unauthenticated endpoints. It is intentionally process-local: multi-node
+// deployments get a per-node budget, which is sufficient to blunt
+// brute-force attempts against high-entropy codes.
+type slidingWindowLimiter struct {
+	mu     sync.Mutex
+	limit  int
+	window time.Duration
+	nowFn  func() time.Time
+	hits   map[string][]time.Time
+}
+
+func newSlidingWindowLimiter(limit int, window time.Duration) *slidingWindowLimiter {
+	return &slidingWindowLimiter{
+		limit:  limit,
+		window: window,
+		nowFn:  time.Now,
+		hits:   map[string][]time.Time{},
+	}
+}
+
+func (l *slidingWindowLimiter) allow(key string) bool {
+	now := l.nowFn()
+	cutoff := now.Add(-l.window)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	kept := pruneAfter(l.hits[key], cutoff)
+	if len(kept) >= l.limit {
+		l.hits[key] = kept
+		return false
+	}
+	l.hits[key] = append(kept, now)
+	if len(l.hits) > rateLimiterSweepThreshold {
+		l.sweep(cutoff)
+	}
+	return true
+}
+
+func (l *slidingWindowLimiter) sweep(cutoff time.Time) {
+	for key, entries := range l.hits {
+		kept := pruneAfter(entries, cutoff)
+		if len(kept) == 0 {
+			delete(l.hits, key)
+			continue
+		}
+		l.hits[key] = kept
+	}
+}
+
+func pruneAfter(entries []time.Time, cutoff time.Time) []time.Time {
+	kept := entries[:0]
+	for _, t := range entries {
+		if t.After(cutoff) {
+			kept = append(kept, t)
+		}
+	}
+	return kept
+}
+
+// clientIPKey derives the rate-limit key from the transport peer address.
+// Forwarding headers are deliberately not trusted here: honoring them would
+// let clients rotate keys freely.
+func clientIPKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/apps/api/internal/httpapi/ratelimit.go
+++ b/apps/api/internal/httpapi/ratelimit.go
@@ -3,11 +3,12 @@ package httpapi
 import (
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
 
-const rateLimiterSweepThreshold = 4096
+const rateLimiterMaxKeys = 4096
 
 // slidingWindowLimiter is a small in-memory per-key rate limiter for
 // unauthenticated endpoints. It is intentionally process-local: multi-node
@@ -19,6 +20,7 @@ type slidingWindowLimiter struct {
 	window time.Duration
 	nowFn  func() time.Time
 	hits   map[string][]time.Time
+	nextGC time.Time
 }
 
 func newSlidingWindowLimiter(limit int, window time.Duration) *slidingWindowLimiter {
@@ -35,15 +37,25 @@ func (l *slidingWindowLimiter) allow(key string) bool {
 	cutoff := now.Add(-l.window)
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if l.nextGC.IsZero() || !now.Before(l.nextGC) {
+		l.sweep(cutoff)
+		l.nextGC = now.Add(l.window)
+	}
+	if _, exists := l.hits[key]; !exists && len(l.hits) >= rateLimiterMaxKeys {
+		// Keep memory bounded even when callers rotate through unbounded keys.
+		// Evicting one arbitrary key avoids an O(n) oldest-entry scan on every
+		// request after the cap is reached.
+		for evicted := range l.hits {
+			delete(l.hits, evicted)
+			break
+		}
+	}
 	kept := pruneAfter(l.hits[key], cutoff)
 	if len(kept) >= l.limit {
 		l.hits[key] = kept
 		return false
 	}
 	l.hits[key] = append(kept, now)
-	if len(l.hits) > rateLimiterSweepThreshold {
-		l.sweep(cutoff)
-	}
 	return true
 }
 
@@ -68,13 +80,41 @@ func pruneAfter(entries []time.Time, cutoff time.Time) []time.Time {
 	return kept
 }
 
-// clientIPKey derives the rate-limit key from the transport peer address.
-// Forwarding headers are deliberately not trusted here: honoring them would
-// let clients rotate keys freely.
+// clientIPKey derives the rate-limit key from the transport peer address. A
+// loopback reverse proxy may supply one matching client IP in X-Real-IP and
+// X-Forwarded-For; all other forwarding headers are ignored.
 func clientIPKey(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr
 	}
-	return host
+	remoteIP := net.ParseIP(host)
+	if remoteIP == nil {
+		return host
+	}
+	if remoteIP.IsLoopback() {
+		if forwardedIP := loopbackProxyClientIP(r); forwardedIP != "" {
+			return forwardedIP
+		}
+	}
+	return remoteIP.String()
+}
+
+func loopbackProxyClientIP(r *http.Request) string {
+	realValues := r.Header.Values("X-Real-IP")
+	forwardedValues := r.Header.Values("X-Forwarded-For")
+	if len(realValues) != 1 || len(forwardedValues) != 1 {
+		return ""
+	}
+	realValue := strings.TrimSpace(realValues[0])
+	forwardedValue := strings.TrimSpace(forwardedValues[0])
+	if strings.Contains(forwardedValue, ",") {
+		return ""
+	}
+	realIP := net.ParseIP(realValue)
+	forwardedIP := net.ParseIP(forwardedValue)
+	if realIP == nil || forwardedIP == nil || !realIP.Equal(forwardedIP) {
+		return ""
+	}
+	return realIP.String()
 }

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -26,16 +26,17 @@ import (
 )
 
 type Server struct {
-	store          store.Store
-	hub            *realtime.Hub
-	uploadDir      string
-	uploadStorage  uploadstore.Store
-	githubOAuth    GitHubOAuthConfig
-	cookies        authpolicy.CookieNames
-	disableDevAuth bool
-	pushNotifier   PushNotifier
-	metrics        *metricsRegistry
-	build          buildMetadata
+	store                 store.Store
+	hub                   *realtime.Hub
+	uploadDir             string
+	uploadStorage         uploadstore.Store
+	githubOAuth           GitHubOAuthConfig
+	cookies               authpolicy.CookieNames
+	disableDevAuth        bool
+	pushNotifier          PushNotifier
+	metrics               *metricsRegistry
+	build                 buildMetadata
+	setupCodeClaimLimiter *slidingWindowLimiter
 }
 
 const (
@@ -46,6 +47,10 @@ const (
 	httpRequestTimeout            = 30 * time.Second
 	idleTimeout                   = 120 * time.Second
 	uploadCleanupSweepLimit       = 100
+	// setupCodeClaimLimit/Window bound unauthenticated bot setup code
+	// claim attempts per client IP.
+	setupCodeClaimLimit  = 10
+	setupCodeClaimWindow = time.Minute
 )
 
 var errAmbiguousCookie = errors.New("multiple cookies with the same name are not allowed")
@@ -84,15 +89,16 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 		cookieNames = authpolicy.DefaultCookieNames()
 	}
 	return &Server{
-		store:          st,
-		hub:            hub,
-		uploadDir:      options.UploadDir,
-		uploadStorage:  uploadStorage,
-		githubOAuth:    options.GitHubOAuth.withDefaults(),
-		cookies:        cookieNames,
-		disableDevAuth: options.DisableDevAuth,
-		pushNotifier:   options.PushNotifier,
-		metrics:        metrics,
+		store:                 st,
+		hub:                   hub,
+		uploadDir:             options.UploadDir,
+		uploadStorage:         uploadStorage,
+		githubOAuth:           options.GitHubOAuth.withDefaults(),
+		cookies:               cookieNames,
+		disableDevAuth:        options.DisableDevAuth,
+		pushNotifier:          options.PushNotifier,
+		metrics:               metrics,
+		setupCodeClaimLimiter: newSlidingWindowLimiter(setupCodeClaimLimit, setupCodeClaimWindow),
 		build: buildMetadata{
 			Environment: options.Environment,
 			Version:     options.Version,
@@ -146,6 +152,8 @@ func (s *Server) Handler() http.Handler {
 		r.Delete("/workspaces/{workspace_id}/bots/{bot_user_id}/membership", s.removeBotFromWorkspace)
 		r.Get("/workspaces/{workspace_id}/bots/{bot_user_id}/tokens", s.listWorkspaceBotTokens)
 		r.Post("/workspaces/{workspace_id}/bots/{bot_user_id}/tokens", s.createWorkspaceBotToken)
+		r.Post("/workspaces/{workspace_id}/bots/{bot_user_id}/setup-codes", s.createWorkspaceBotSetupCode)
+		r.Post("/bot-setup-codes/claim", s.claimBotSetupCode)
 		r.Put("/bots/self/commands", s.setBotCommands)
 		r.Delete("/bots/{bot_user_id}", s.deleteBot)
 		r.Get("/bots/{bot_user_id}/tokens", s.listBotTokens)
@@ -1530,6 +1538,8 @@ func writeStoreError(w http.ResponseWriter, err error) {
 		writeError(w, http.StatusConflict, err)
 	case errors.Is(err, store.ErrSetupNonceConflict):
 		writeError(w, http.StatusConflict, err)
+	case errors.Is(err, store.ErrSetupCodeInvalid):
+		writeError(w, http.StatusNotFound, err)
 	case errors.Is(err, store.ErrModerationRestricted):
 		writeError(w, http.StatusForbidden, err)
 	case errors.Is(err, store.ErrNotWorkspaceManager):

--- a/apps/api/internal/httpapi/setup_codes_test.go
+++ b/apps/api/internal/httpapi/setup_codes_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openclaw/clickclack/apps/api/internal/realtime"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -187,4 +188,49 @@ func TestHTTPBotSetupCodeClaimRateLimit(t *testing.T) {
 		expectStatus(t, http.MethodPost, claimURL, strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusNotFound)
 	}
 	expectStatus(t, http.MethodPost, claimURL, strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusTooManyRequests)
+}
+
+func TestSetupCodeClaimLimiterBoundsStateAndResets(t *testing.T) {
+	now := time.Date(2026, time.July, 16, 12, 0, 0, 0, time.UTC)
+	limiter := newSlidingWindowLimiter(2, time.Minute)
+	limiter.nowFn = func() time.Time { return now }
+
+	if !limiter.allow("client") || !limiter.allow("client") || limiter.allow("client") {
+		t.Fatal("expected two attempts per window")
+	}
+	now = now.Add(time.Minute)
+	if !limiter.allow("client") {
+		t.Fatal("expected limiter to reset after the window")
+	}
+	for i := 0; i < rateLimiterMaxKeys+100; i++ {
+		if !limiter.allow(string(rune(i + 1))) {
+			t.Fatalf("new key %d was unexpectedly limited", i)
+		}
+	}
+	if len(limiter.hits) > rateLimiterMaxKeys {
+		t.Fatalf("limiter retained %d keys, max %d", len(limiter.hits), rateLimiterMaxKeys)
+	}
+}
+
+func TestSetupCodeClaimClientIPKey(t *testing.T) {
+	t.Parallel()
+	request := httptest.NewRequest(http.MethodPost, "/api/bot-setup-codes/claim", nil)
+	request.RemoteAddr = "127.0.0.1:1234"
+	request.Header.Set("X-Real-IP", "203.0.113.10")
+	request.Header.Set("X-Forwarded-For", "203.0.113.10")
+	if got := clientIPKey(request); got != "203.0.113.10" {
+		t.Fatalf("expected loopback proxy client IP, got %q", got)
+	}
+
+	request.Header.Set("X-Forwarded-For", "198.51.100.8")
+	if got := clientIPKey(request); got != "127.0.0.1" {
+		t.Fatalf("expected mismatched proxy headers to fall back to peer, got %q", got)
+	}
+
+	request.RemoteAddr = "192.0.2.5:4321"
+	request.Header.Set("X-Real-IP", "203.0.113.10")
+	request.Header.Set("X-Forwarded-For", "203.0.113.10")
+	if got := clientIPKey(request); got != "192.0.2.5" {
+		t.Fatalf("expected public peer to ignore forwarding headers, got %q", got)
+	}
 }

--- a/apps/api/internal/httpapi/setup_codes_test.go
+++ b/apps/api/internal/httpapi/setup_codes_test.go
@@ -2,6 +2,8 @@ package httpapi
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -95,21 +97,85 @@ func TestHTTPBotSetupCodeMintAndClaim(t *testing.T) {
 	}
 
 	// Claim is unauthenticated and returns the minted token plus context.
-	claim := postJSON[struct {
-		BotToken  store.BotToken  `json:"bot_token"`
-		Bot       store.User      `json:"bot"`
-		Workspace store.Workspace `json:"workspace"`
-	}](t, server.URL+"/api/bot-setup-codes/claim", map[string]any{"code": minted.SetupCode.Code})
-	if !strings.HasPrefix(claim.BotToken.Token, "ccb_") {
-		t.Fatalf("expected plaintext token in claim response, got %#v", claim.BotToken)
+	rawClaim := postJSON[map[string]json.RawMessage](t, server.URL+"/api/bot-setup-codes/claim", map[string]any{"code": minted.SetupCode.Code})
+	if _, ok := rawClaim["bot_token"]; ok {
+		t.Fatalf("claim response leaked internal bot token metadata: %#v", rawClaim)
+	}
+	var claim struct {
+		Token string `json:"token"`
+		Bot   struct {
+			ID          string `json:"id"`
+			Handle      string `json:"handle"`
+			DisplayName string `json:"display_name"`
+		} `json:"bot"`
+		Workspace struct {
+			ID      string `json:"id"`
+			RouteID string `json:"route_id"`
+			Slug    string `json:"slug"`
+			Name    string `json:"name"`
+		} `json:"workspace"`
+		Defaults struct {
+			DefaultTo string `json:"defaultTo"`
+		} `json:"defaults"`
+	}
+	encodedClaim, err := json.Marshal(rawClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(encodedClaim, &claim); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(claim.Token, "ccb_") {
+		t.Fatalf("expected plaintext token in claim response, got %#v", claim)
 	}
 	if claim.Bot.ID != bot.Bot.ID || claim.Workspace.ID != workspace.ID || claim.Workspace.RouteID == "" {
 		t.Fatalf("unexpected claim context: %#v", claim)
 	}
+	if claim.Defaults.DefaultTo != "channel:general" {
+		t.Fatalf("expected default channel suggestion, got %#v", claim.Defaults)
+	}
+
+	auditLog := getJSONAsUser[struct {
+		AuditLogEntries []store.AuditLogEntry `json:"audit_log_entries"`
+	}](t, owner.ID, server.URL+"/api/workspaces/"+workspace.ID+"/audit-log")
+	var foundClaim bool
+	for _, entry := range auditLog.AuditLogEntries {
+		if entry.Action != "bot_setup_code.claimed" {
+			continue
+		}
+		foundClaim = true
+		if entry.ActorUserID != bot.Bot.ID {
+			t.Fatalf("expected claimed token bot as audit actor, got %#v", entry)
+		}
+	}
+	if !foundClaim {
+		t.Fatalf("expected setup code claim audit entry, got %#v", auditLog.AuditLogEntries)
+	}
 
 	// Codes are single use, and unknown codes look identical.
-	expectStatus(t, http.MethodPost, server.URL+"/api/bot-setup-codes/claim", strings.NewReader(`{"code":"`+minted.SetupCode.Code+`"}`), http.StatusNotFound)
-	expectStatus(t, http.MethodPost, server.URL+"/api/bot-setup-codes/claim", strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusNotFound)
+	usedStatus, usedBody := setupCodeClaimError(t, server.URL, minted.SetupCode.Code)
+	unknownStatus, unknownBody := setupCodeClaimError(t, server.URL, "AAAA-BBBB-CCCC")
+	if usedStatus != http.StatusNotFound || unknownStatus != http.StatusNotFound || usedBody != unknownBody {
+		t.Fatalf("expected uniform not-found responses, used=(%d %q) unknown=(%d %q)", usedStatus, usedBody, unknownStatus, unknownBody)
+	}
+}
+
+func setupCodeClaimError(t *testing.T, serverURL, code string) (int, string) {
+	t.Helper()
+	resp, err := http.Post(
+		serverURL+"/api/bot-setup-codes/claim",
+		"application/json",
+		strings.NewReader(`{"code":"`+code+`"}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp.StatusCode, string(body)
 }
 
 func TestHTTPBotSetupCodeClaimRateLimit(t *testing.T) {

--- a/apps/api/internal/httpapi/setup_codes_test.go
+++ b/apps/api/internal/httpapi/setup_codes_test.go
@@ -1,0 +1,124 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func newSetupCodeTestServer(t *testing.T) (*httptest.Server, store.Store, store.Workspace, store.User, store.User) {
+	t.Helper()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "member-setup-codes@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	t.Cleanup(server.Close)
+	return server, st, workspace, owner, member
+}
+
+func TestHTTPBotSetupCodeMintAndClaim(t *testing.T) {
+	t.Parallel()
+	server, _, workspace, owner, member := newSetupCodeTestServer(t)
+
+	bot := postJSONAsUser[struct {
+		Bot store.User `json:"bot"`
+	}](t, owner.ID, server.URL+"/api/workspaces/"+workspace.ID+"/bots", map[string]any{
+		"display_name": "setup code bot",
+	})
+
+	mintURL := server.URL + "/api/workspaces/" + workspace.ID + "/bots/" + bot.Bot.ID + "/setup-codes"
+
+	// Mint requires manager rights (dev-auth test servers resolve
+	// anonymous local requests, so 401 is covered by authz_test patterns).
+	expectStatusAsUser(t, member.ID, http.MethodPost, mintURL, strings.NewReader(`{"name":"gateway"}`), http.StatusForbidden)
+
+	minted := postJSONAsUser[struct {
+		SetupCode store.BotSetupCode `json:"setup_code"`
+	}](t, owner.ID, mintURL, map[string]any{
+		"name":   "gateway",
+		"scopes": []string{"bot:write"},
+	})
+	if minted.SetupCode.Code == "" || strings.Count(minted.SetupCode.Code, "-") != 2 {
+		t.Fatalf("expected plaintext code in mint response, got %#v", minted.SetupCode)
+	}
+	if minted.SetupCode.ExpiresAt == "" {
+		t.Fatalf("expected expiry in mint response, got %#v", minted.SetupCode)
+	}
+
+	// Bot tokens cannot mint setup codes.
+	tokenResp := postJSONAsUser[struct {
+		BotToken store.BotToken `json:"bot_token"`
+	}](t, owner.ID, server.URL+"/api/workspaces/"+workspace.ID+"/bots/"+bot.Bot.ID+"/tokens", map[string]any{"name": "for authz check"})
+	req, err := http.NewRequest(http.MethodPost, mintURL, strings.NewReader(`{"name":"gateway"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tokenResp.BotToken.Token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected bot token mint to be forbidden, got %s", resp.Status)
+	}
+
+	// Claim is unauthenticated and returns the minted token plus context.
+	claim := postJSON[struct {
+		BotToken  store.BotToken  `json:"bot_token"`
+		Bot       store.User      `json:"bot"`
+		Workspace store.Workspace `json:"workspace"`
+	}](t, server.URL+"/api/bot-setup-codes/claim", map[string]any{"code": minted.SetupCode.Code})
+	if !strings.HasPrefix(claim.BotToken.Token, "ccb_") {
+		t.Fatalf("expected plaintext token in claim response, got %#v", claim.BotToken)
+	}
+	if claim.Bot.ID != bot.Bot.ID || claim.Workspace.ID != workspace.ID || claim.Workspace.RouteID == "" {
+		t.Fatalf("unexpected claim context: %#v", claim)
+	}
+
+	// Codes are single use, and unknown codes look identical.
+	expectStatus(t, http.MethodPost, server.URL+"/api/bot-setup-codes/claim", strings.NewReader(`{"code":"`+minted.SetupCode.Code+`"}`), http.StatusNotFound)
+	expectStatus(t, http.MethodPost, server.URL+"/api/bot-setup-codes/claim", strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusNotFound)
+}
+
+func TestHTTPBotSetupCodeClaimRateLimit(t *testing.T) {
+	t.Parallel()
+	server, _, _, _, _ := newSetupCodeTestServer(t)
+
+	claimURL := server.URL + "/api/bot-setup-codes/claim"
+	for i := 0; i < setupCodeClaimLimit; i++ {
+		expectStatus(t, http.MethodPost, claimURL, strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusNotFound)
+	}
+	expectStatus(t, http.MethodPost, claimURL, strings.NewReader(`{"code":"AAAA-BBBB-CCCC"}`), http.StatusTooManyRequests)
+}

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -644,6 +644,9 @@ func (s *Store) RemoveBotFromWorkspace(ctx context.Context, workspaceID, botUser
 	if err := requireWorkspaceManagerTx(ctx, tx, workspaceID, requesterID); err != nil {
 		return err
 	}
+	if err := lockBotLifecycleTx(ctx, tx, botUserID); err != nil {
+		return err
+	}
 	qtx := s.q.WithTx(tx)
 	if _, err := qtx.LockBotWorkspaceMembership(ctx, storedb.LockBotWorkspaceMembershipParams{
 		WorkspaceID: workspaceID,

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -673,6 +673,12 @@ func (s *Store) RemoveBotFromWorkspace(ctx context.Context, workspaceID, botUser
 		WHERE bot_user_id = $2 AND workspace_id = $3`, revokedAt, botUserID, workspaceID); err != nil {
 		return err
 	}
+	if _, err := qtx.DeleteBotSetupCodesForWorkspaceBot(ctx, storedb.DeleteBotSetupCodesForWorkspaceBotParams{
+		WorkspaceID: workspaceID,
+		BotUserID:   botUserID,
+	}); err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 
@@ -753,6 +759,9 @@ func (s *Store) deleteBotTx(ctx context.Context, tx *sql.Tx, botUserID, requeste
 		return store.DeletedBot{}, botDeletionCounts{}, err
 	}
 	counts.botTokens = int(tokenCount)
+	if _, err := qtx.DeleteBotSetupCodesForBot(ctx, bot.ID); err != nil {
+		return store.DeletedBot{}, botDeletionCounts{}, err
+	}
 	commandCount, err := qtx.RevokeAllBotSlashCommands(ctx, storedb.RevokeAllBotSlashCommandsParams{
 		RevokedAt: sqlText(deletedAt),
 		BotUserID: bot.ID,

--- a/apps/api/internal/store/postgres/migrations/0027_bot_setup_codes.sql
+++ b/apps/api/internal/store/postgres/migrations/0027_bot_setup_codes.sql
@@ -13,3 +13,5 @@ CREATE TABLE bot_setup_codes (
 );
 
 CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);
+CREATE INDEX idx_bot_setup_codes_bot ON bot_setup_codes(bot_user_id);
+CREATE INDEX idx_bot_setup_codes_pending_expiry ON bot_setup_codes(expires_at) WHERE claimed_at IS NULL;

--- a/apps/api/internal/store/postgres/migrations/0027_bot_setup_codes.sql
+++ b/apps/api/internal/store/postgres/migrations/0027_bot_setup_codes.sql
@@ -1,0 +1,15 @@
+CREATE TABLE bot_setup_codes (
+  id TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  bot_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_name TEXT NOT NULL,
+  scopes_json TEXT NOT NULL,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  claimed_at TEXT,
+  claimed_token_id TEXT REFERENCES bot_tokens(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);

--- a/apps/api/internal/store/postgres/mutations.go
+++ b/apps/api/internal/store/postgres/mutations.go
@@ -114,10 +114,15 @@ func (s *Store) DeleteWorkspace(ctx context.Context, workspaceID, actorUserID st
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
-	candidateBotIDs, err := qtx.ListWorkspaceActiveServiceBotIDs(ctx, workspaceID)
+	serviceBotIDs, err := qtx.ListWorkspaceActiveServiceBotIDs(ctx, workspaceID)
 	if err != nil {
 		return nil, err
 	}
+	memberBotIDs, err := qtx.ListWorkspaceActiveBotMemberIDs(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	candidateBotIDs := mergeBotWorkspaceIDs(serviceBotIDs, memberBotIDs)
 	for _, botUserID := range candidateBotIDs {
 		if err := lockBotLifecycleTx(ctx, tx, botUserID); err != nil {
 			return nil, err

--- a/apps/api/internal/store/postgres/setup_codes.go
+++ b/apps/api/internal/store/postgres/setup_codes.go
@@ -159,12 +159,32 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
-	row, err := qtx.GetBotSetupCodeByHash(ctx, hashBotSetupCode(normalized))
+	codeHash := hashBotSetupCode(normalized)
+	candidate, err := qtx.GetBotSetupCodeByHash(ctx, codeHash)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	if err != nil {
 		return store.BotSetupCodeClaim{}, err
+	}
+	// Take the lifecycle lock before locking the code row. Bot removal and
+	// deletion use the same order, preventing a code-row/lifecycle deadlock.
+	bot, err := lockActiveBotTx(ctx, tx, candidate.BotUserID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	row, err := qtx.LockBotSetupCodeByHash(ctx, codeHash)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if row.BotUserID != bot.ID {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	if row.ClaimedAt.Valid {
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
@@ -172,13 +192,6 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 	expiresAt, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
 	if err != nil || !time.Now().UTC().Before(expiresAt) {
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
-	}
-	bot, err := lockActiveBotTx(ctx, tx, row.BotUserID)
-	if errors.Is(err, sql.ErrNoRows) {
-		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
-	}
-	if err != nil {
-		return store.BotSetupCodeClaim{}, err
 	}
 	workspaceID, err := botWorkspaceForTokenTx(ctx, tx, bot.ID, row.WorkspaceID)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/apps/api/internal/store/postgres/setup_codes.go
+++ b/apps/api/internal/store/postgres/setup_codes.go
@@ -1,0 +1,252 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/postgres/storedb"
+)
+
+// botSetupCodeTTL bounds how long a pending setup code can be claimed.
+const botSetupCodeTTL = 10 * time.Minute
+
+// setupCodeAlphabet is crockford-style base32 without the ambiguous
+// I, L, O, and U. 12 characters give 60 bits of entropy, which is
+// required because the claim endpoint is unauthenticated.
+const setupCodeAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+const setupCodeLength = 12
+
+func newBotSetupCode() (string, error) {
+	var raw [setupCodeLength]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	for i, b := range raw {
+		if i > 0 && i%4 == 0 {
+			out.WriteByte('-')
+		}
+		// 256 is a multiple of 32, so masking has no modulo bias.
+		out.WriteByte(setupCodeAlphabet[b&31])
+	}
+	return out.String(), nil
+}
+
+func normalizeBotSetupCode(code string) (string, error) {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	code = strings.ReplaceAll(code, "-", "")
+	code = strings.ReplaceAll(code, " ", "")
+	if len(code) != setupCodeLength {
+		return "", store.ErrSetupCodeInvalid
+	}
+	for i := 0; i < len(code); i++ {
+		if !strings.ContainsRune(setupCodeAlphabet, rune(code[i])) {
+			return "", store.ErrSetupCodeInvalid
+		}
+	}
+	return code, nil
+}
+
+func hashBotSetupCode(normalizedCode string) string {
+	sum := sha256.Sum256([]byte("bot-setup-code:" + normalizedCode))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Store) CreateBotSetupCode(ctx context.Context, input store.CreateBotSetupCodeInput) (store.BotSetupCode, error) {
+	botUserID := strings.TrimSpace(input.BotUserID)
+	if botUserID == "" {
+		return store.BotSetupCode{}, errors.New("bot_user_id is required")
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	if workspaceID == "" {
+		return store.BotSetupCode{}, errors.New("workspace_id is required")
+	}
+	createdBy := strings.TrimSpace(input.CreatedBy)
+	if createdBy == "" {
+		return store.BotSetupCode{}, errors.New("created_by is required")
+	}
+	tokenName := strings.TrimSpace(input.Name)
+	if tokenName == "" {
+		tokenName = "default"
+	}
+	scopes, err := normalizeBotScopes(input.Scopes)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	code, err := newBotSetupCode()
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	defer tx.Rollback()
+	bot, err := lockActiveBotTx(ctx, tx, botUserID)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if _, err := botWorkspaceForTokenTx(ctx, tx, bot.ID, workspaceID); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if err := requireBotTokenManagerTx(ctx, tx, workspaceID, bot, createdBy); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	qtx := s.q.WithTx(tx)
+	createdAt := now()
+	if _, err := qtx.DeleteExpiredBotSetupCodes(ctx, createdAt); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	// Re-minting replaces any pending code for the same token grant.
+	if _, err := qtx.DeleteUnclaimedBotSetupCodesForTokenName(ctx, storedb.DeleteUnclaimedBotSetupCodesForTokenNameParams{
+		WorkspaceID: workspaceID,
+		BotUserID:   bot.ID,
+		TokenName:   tokenName,
+	}); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	setup := store.BotSetupCode{
+		ID:          newID("bsc"),
+		BotUserID:   bot.ID,
+		WorkspaceID: workspaceID,
+		TokenName:   tokenName,
+		Scopes:      scopes,
+		CreatedBy:   createdBy,
+		CreatedAt:   createdAt,
+		ExpiresAt:   time.Now().UTC().Add(botSetupCodeTTL).Format(time.RFC3339Nano),
+	}
+	if err := qtx.InsertBotSetupCode(ctx, storedb.InsertBotSetupCodeParams{
+		ID:          setup.ID,
+		CodeHash:    hashBotSetupCode(strings.ReplaceAll(code, "-", "")),
+		WorkspaceID: setup.WorkspaceID,
+		BotUserID:   setup.BotUserID,
+		TokenName:   setup.TokenName,
+		ScopesJson:  string(scopesJSON),
+		CreatedBy:   sqlOptionalText(setup.CreatedBy),
+		CreatedAt:   setup.CreatedAt,
+		ExpiresAt:   setup.ExpiresAt,
+	}); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	setup.Code = code
+	return setup, nil
+}
+
+func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSetupCodeClaim, error) {
+	normalized, err := normalizeBotSetupCode(code)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetBotSetupCodeByHash(ctx, hashBotSetupCode(normalized))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if row.ClaimedAt.Valid {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
+	if err != nil || time.Now().UTC().After(expiresAt) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	bot, err := lockActiveBotTx(ctx, tx, row.BotUserID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	workspaceID, err := botWorkspaceForTokenTx(ctx, tx, bot.ID, row.WorkspaceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	var scopes []string
+	if err := json.Unmarshal([]byte(row.ScopesJson), &scopes); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	token := newID("ccb")
+	botToken := store.BotToken{
+		ID:          newID("btok"),
+		Token:       token,
+		BotUserID:   bot.ID,
+		WorkspaceID: workspaceID,
+		OwnerUserID: bot.OwnerUserID,
+		Name:        row.TokenName,
+		Scopes:      scopes,
+		CreatedBy:   stringFromNull(row.CreatedBy),
+		CreatedAt:   now(),
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO bot_tokens (id, token_hash, bot_user_id, workspace_id, owner_user_id, name, scopes_json, created_by, setup_nonce, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		botToken.ID,
+		hashBotToken(token),
+		botToken.BotUserID,
+		botToken.WorkspaceID,
+		sqlOptionalText(botToken.OwnerUserID),
+		botToken.Name,
+		row.ScopesJson,
+		sqlOptionalText(botToken.CreatedBy),
+		"",
+		botToken.CreatedAt,
+	); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	claimed, err := qtx.MarkBotSetupCodeClaimed(ctx, storedb.MarkBotSetupCodeClaimedParams{
+		ClaimedAt:      sqlText(botToken.CreatedAt),
+		ClaimedTokenID: sqlText(botToken.ID),
+		ID:             row.ID,
+	})
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if claimed != 1 {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	wsRow, err := qtx.GetWorkspaceForSetupClaim(ctx, workspaceID)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	return store.BotSetupCodeClaim{
+		BotToken: botToken,
+		Bot:      bot,
+		Workspace: store.Workspace{
+			ID:        wsRow.ID,
+			RouteID:   stringFromNull(wsRow.RouteID),
+			Name:      wsRow.Name,
+			Slug:      wsRow.Slug,
+			IconURL:   wsRow.IconUrl,
+			CreatedAt: wsRow.CreatedAt,
+		},
+	}, nil
+}

--- a/apps/api/internal/store/postgres/setup_codes.go
+++ b/apps/api/internal/store/postgres/setup_codes.go
@@ -170,7 +170,7 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	expiresAt, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
-	if err != nil || time.Now().UTC().After(expiresAt) {
+	if err != nil || !time.Now().UTC().Before(expiresAt) {
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	bot, err := lockActiveBotTx(ctx, tx, row.BotUserID)
@@ -234,10 +234,14 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 	if err != nil {
 		return store.BotSetupCodeClaim{}, err
 	}
+	defaultChannel, err := qtx.GetDefaultChannelForSetupClaim(ctx, workspaceID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return store.BotSetupCodeClaim{}, err
 	}
-	return store.BotSetupCodeClaim{
+	claim := store.BotSetupCodeClaim{
 		BotToken: botToken,
 		Bot:      bot,
 		Workspace: store.Workspace{
@@ -248,5 +252,9 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 			IconURL:   wsRow.IconUrl,
 			CreatedAt: wsRow.CreatedAt,
 		},
-	}, nil
+	}
+	if defaultChannel != "" {
+		claim.Defaults.DefaultTo = "channel:" + defaultChannel
+	}
+	return claim, nil
 }

--- a/apps/api/internal/store/postgres/setup_codes_test.go
+++ b/apps/api/internal/store/postgres/setup_codes_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -75,6 +76,9 @@ func TestPostgresBotSetupCodes(t *testing.T) {
 	if claim.BotToken.Token == "" || claim.Bot.ID != bot.ID || claim.Workspace.ID != workspace.ID {
 		t.Fatalf("unexpected claim result: %#v", claim)
 	}
+	if claim.Defaults.DefaultTo != "channel:general" {
+		t.Fatalf("expected general channel suggestion, got %#v", claim.Defaults)
+	}
 	auth, err := st.GetBotTokenAuth(ctx, claim.BotToken.Token)
 	if err != nil {
 		t.Fatal(err)
@@ -85,6 +89,45 @@ func TestPostgresBotSetupCodes(t *testing.T) {
 
 	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
 		t.Fatalf("expected second claim to fail uniformly, got %v", err)
+	}
+
+	concurrent, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "concurrent",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, claimErr := st.ClaimBotSetupCode(ctx, concurrent.Code)
+			results <- claimErr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	var successes, invalid int
+	for claimErr := range results {
+		switch {
+		case claimErr == nil:
+			successes++
+		case errors.Is(claimErr, store.ErrSetupCodeInvalid):
+			invalid++
+		default:
+			t.Fatalf("unexpected concurrent claim error: %v", claimErr)
+		}
+	}
+	if successes != 1 || invalid != 1 {
+		t.Fatalf("expected one success and one uniform rejection, got success=%d invalid=%d", successes, invalid)
 	}
 
 	expiredCode, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "expiring", CreatedBy: owner.ID})

--- a/apps/api/internal/store/postgres/setup_codes_test.go
+++ b/apps/api/internal/store/postgres/setup_codes_test.go
@@ -267,3 +267,66 @@ func TestPostgresRemoveBotFromWorkspaceUsesLifecycleLock(t *testing.T) {
 		t.Fatal("bot removal did not resume after lifecycle lock release")
 	}
 }
+
+func TestPostgresWorkspaceDeletionUsesUserBotLifecycleLock(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Workspace Owner", "postgres-setup-workspace-delete-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		OwnerUserID: owner.ID,
+		DisplayName: "Owned Setup Bot",
+		Handle:      "postgres-owned-setup-delete-bot",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "workspace-delete",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocker := mustBeginPostgresTx(t, ctx, st.db)
+	if err := lockBotLifecycleTx(ctx, blocker, bot.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		_, deleteErr := st.DeleteWorkspace(ctx, workspace.ID, owner.ID)
+		deleteResult <- deleteErr
+	}()
+	waitForBlockedBotLifecycleOperations(t, ctx, st.db, 1)
+	if err := blocker.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-deleteResult:
+		if err != nil {
+			t.Fatalf("workspace deletion failed after lifecycle lock release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("workspace deletion did not resume after lifecycle lock release")
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("workspace deletion left its user-owned bot setup code claimable: %v", err)
+	}
+}

--- a/apps/api/internal/store/postgres/setup_codes_test.go
+++ b/apps/api/internal/store/postgres/setup_codes_test.go
@@ -1,0 +1,112 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestPostgresBotSetupCodes(t *testing.T) {
+	dsn := os.Getenv("CLICKCLACK_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CLICKCLACK_POSTGRES_TEST_DSN to run Postgres integration smoke")
+	}
+	ctx := context.Background()
+	st, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	suffix := time.Now().UTC().Format("20060102150405.000000000")
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Setup Code Owner", Email: "pg-setup-owner-" + suffix + "@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Setup Codes " + suffix}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Setup Code Member", Email: "pg-setup-member-" + suffix + "@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Setup Code Bot", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		CreatedBy:   member.ID,
+	}); !errors.Is(err, store.ErrNotWorkspaceManager) {
+		t.Fatalf("expected member mint to require manager, got %v", err)
+	}
+
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "gateway",
+		Scopes:      []string{"messages:write"},
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(setup.Code) != 14 || strings.Count(setup.Code, "-") != 2 {
+		t.Fatalf("expected XXXX-XXXX-XXXX code, got %q", setup.Code)
+	}
+
+	claim, err := st.ClaimBotSetupCode(ctx, strings.ToLower(setup.Code))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.BotToken.Token == "" || claim.Bot.ID != bot.ID || claim.Workspace.ID != workspace.ID {
+		t.Fatalf("unexpected claim result: %#v", claim)
+	}
+	auth, err := st.GetBotTokenAuth(ctx, claim.BotToken.Token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.User.ID != bot.ID || auth.WorkspaceID != workspace.ID {
+		t.Fatalf("expected minted token to authenticate, got %#v", auth)
+	}
+
+	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected second claim to fail uniformly, got %v", err)
+	}
+
+	expiredCode, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "expiring", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expired := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+	if _, err := st.db.ExecContext(ctx, `UPDATE bot_setup_codes SET expires_at = $1 WHERE id = $2`, expired, expiredCode.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, expiredCode.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected expired claim to fail uniformly, got %v", err)
+	}
+
+	pending, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "pending", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RemoveBotFromWorkspace(ctx, workspace.ID, bot.ID, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, pending.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected claim after removal to fail uniformly, got %v", err)
+	}
+}

--- a/apps/api/internal/store/postgres/setup_codes_test.go
+++ b/apps/api/internal/store/postgres/setup_codes_test.go
@@ -35,6 +35,14 @@ func TestPostgresBotSetupCodes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if _, _, err := st.CreateChannel(ctx, store.CreateChannelInput{
+		WorkspaceID: workspace.ID,
+		UserID:      owner.ID,
+		Name:        "general",
+		Kind:        "public",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Setup Code Member", Email: "pg-setup-member-" + suffix + "@example.com"})
 	if err != nil {
 		t.Fatal(err)

--- a/apps/api/internal/store/postgres/setup_codes_test.go
+++ b/apps/api/internal/store/postgres/setup_codes_test.go
@@ -153,3 +153,117 @@ func TestPostgresBotSetupCodes(t *testing.T) {
 		t.Fatalf("expected claim after removal to fail uniformly, got %v", err)
 	}
 }
+
+func TestPostgresBotSetupCodeClaimLocksLifecycleBeforeCodeRow(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Setup Owner", "postgres-setup-lock-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		DisplayName: "Setup Lock Bot",
+		Handle:      "postgres-setup-lock-bot",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "lock-order",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocker := mustBeginPostgresTx(t, ctx, st.db)
+	if err := lockBotLifecycleTx(ctx, blocker, bot.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	claimResult := make(chan error, 1)
+	go func() {
+		_, claimErr := st.ClaimBotSetupCode(ctx, setup.Code)
+		claimResult <- claimErr
+	}()
+	waitForBlockedBotLifecycleOperations(t, ctx, st.db, 1)
+
+	lockCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	if _, err := st.q.WithTx(blocker).LockBotSetupCodeByHash(lockCtx, hashBotSetupCode(strings.ReplaceAll(setup.Code, "-", ""))); err != nil {
+		t.Fatalf("claim locked the setup-code row before the bot lifecycle lock: %v", err)
+	}
+	if err := blocker.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-claimResult:
+		if err != nil {
+			t.Fatalf("claim failed after lifecycle lock release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("claim did not resume after lifecycle lock release")
+	}
+}
+
+func TestPostgresRemoveBotFromWorkspaceUsesLifecycleLock(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Removal Owner", "postgres-setup-remove-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		DisplayName: "Removal Lock Bot",
+		Handle:      "postgres-setup-remove-lock-bot",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blocker := mustBeginPostgresTx(t, ctx, st.db)
+	if err := lockBotLifecycleTx(ctx, blocker, bot.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	removeResult := make(chan error, 1)
+	go func() {
+		removeResult <- st.RemoveBotFromWorkspace(ctx, workspace.ID, bot.ID, owner.ID)
+	}()
+	waitForBlockedBotLifecycleOperations(t, ctx, st.db, 1)
+	if err := blocker.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case err := <-removeResult:
+		if err != nil {
+			t.Fatalf("bot removal failed after lifecycle lock release: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("bot removal did not resume after lifecycle lock release")
+	}
+}

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -367,6 +367,17 @@ WHERE u.kind = 'bot'
   )
 ORDER BY u.id;
 
+-- name: ListWorkspaceActiveBotMemberIDs :many
+SELECT u.id
+FROM users u
+JOIN workspace_members wm ON wm.user_id = u.id
+WHERE wm.workspace_id = sqlc.arg(workspace_id)
+  AND u.kind = 'bot'
+  AND NOT EXISTS (
+    SELECT 1 FROM bot_tombstones tombstone WHERE tombstone.bot_user_id = u.id
+  )
+ORDER BY u.id;
+
 -- name: InsertPendingUploadCleanup :one
 INSERT INTO pending_upload_cleanups (id, workspace_id, storage_path, created_at, updated_at)
 VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(storage_path), sqlc.arg(created_at), sqlc.arg(updated_at))

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -1458,6 +1458,11 @@ VALUES (sqlc.arg(id), sqlc.arg(code_hash), sqlc.arg(workspace_id), sqlc.arg(bot_
 -- name: GetBotSetupCodeByHash :one
 SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
 FROM bot_setup_codes
+WHERE code_hash = sqlc.arg(code_hash);
+
+-- name: LockBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
 WHERE code_hash = sqlc.arg(code_hash)
 FOR UPDATE;
 

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -1450,3 +1450,45 @@ JOIN workspace_members wm
  AND wm.role = 'bot'
 WHERE bc.workspace_id = sqlc.arg(workspace_id)
 ORDER BY u.handle, bc.command;
+
+-- name: InsertBotSetupCode :exec
+INSERT INTO bot_setup_codes (id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at)
+VALUES (sqlc.arg(id), sqlc.arg(code_hash), sqlc.arg(workspace_id), sqlc.arg(bot_user_id), sqlc.arg(token_name), sqlc.arg(scopes_json), sqlc.arg(created_by), sqlc.arg(created_at), sqlc.arg(expires_at));
+
+-- name: GetBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
+WHERE code_hash = sqlc.arg(code_hash)
+FOR UPDATE;
+
+-- name: MarkBotSetupCodeClaimed :execrows
+UPDATE bot_setup_codes
+SET claimed_at = sqlc.arg(claimed_at), claimed_token_id = sqlc.arg(claimed_token_id)
+WHERE id = sqlc.arg(id) AND claimed_at IS NULL;
+
+-- name: DeleteUnclaimedBotSetupCodesForTokenName :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND bot_user_id = sqlc.arg(bot_user_id)
+  AND token_name = sqlc.arg(token_name)
+  AND claimed_at IS NULL;
+
+-- name: DeleteBotSetupCodesForWorkspaceBot :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND bot_user_id = sqlc.arg(bot_user_id)
+  AND claimed_at IS NULL;
+
+-- name: DeleteBotSetupCodesForBot :execrows
+DELETE FROM bot_setup_codes
+WHERE bot_user_id = sqlc.arg(bot_user_id)
+  AND claimed_at IS NULL;
+
+-- name: DeleteExpiredBotSetupCodes :execrows
+DELETE FROM bot_setup_codes
+WHERE claimed_at IS NULL AND expires_at <= sqlc.arg(now);
+
+-- name: GetWorkspaceForSetupClaim :one
+SELECT id, route_id, name, slug, icon_url, created_at
+FROM workspaces
+WHERE id = sqlc.arg(workspace_id);

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -1492,3 +1492,11 @@ WHERE claimed_at IS NULL AND expires_at <= sqlc.arg(now);
 SELECT id, route_id, name, slug, icon_url, created_at
 FROM workspaces
 WHERE id = sqlc.arg(workspace_id);
+
+-- name: GetDefaultChannelForSetupClaim :one
+SELECT name
+FROM channels
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND archived_at IS NULL
+ORDER BY CASE WHEN name = 'general' THEN 0 ELSE 1 END, created_at, id
+LIMIT 1;

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -533,3 +533,5 @@ CREATE TABLE bot_setup_codes (
 );
 
 CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);
+CREATE INDEX idx_bot_setup_codes_bot ON bot_setup_codes(bot_user_id);
+CREATE INDEX idx_bot_setup_codes_pending_expiry ON bot_setup_codes(expires_at) WHERE claimed_at IS NULL;

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -517,3 +517,19 @@ CREATE TABLE desktop_oauth_grants (
 
 CREATE INDEX idx_desktop_oauth_grants_expiry
   ON desktop_oauth_grants(expires_at_unix);
+
+CREATE TABLE bot_setup_codes (
+  id TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  bot_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_name TEXT NOT NULL,
+  scopes_json TEXT NOT NULL,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  claimed_at TEXT,
+  claimed_token_id TEXT REFERENCES bot_tokens(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -54,6 +54,20 @@ type BotCommand struct {
 	UpdatedAt   string `json:"updated_at"`
 }
 
+type BotSetupCode struct {
+	ID             string         `json:"id"`
+	CodeHash       string         `json:"code_hash"`
+	WorkspaceID    string         `json:"workspace_id"`
+	BotUserID      string         `json:"bot_user_id"`
+	TokenName      string         `json:"token_name"`
+	ScopesJson     string         `json:"scopes_json"`
+	CreatedBy      sql.NullString `json:"created_by"`
+	CreatedAt      string         `json:"created_at"`
+	ExpiresAt      string         `json:"expires_at"`
+	ClaimedAt      sql.NullString `json:"claimed_at"`
+	ClaimedTokenID sql.NullString `json:"claimed_token_id"`
+}
+
 type BotToken struct {
 	ID          string         `json:"id"`
 	TokenHash   string         `json:"token_hash"`

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -382,6 +382,40 @@ func (q *Queries) DeleteBotCommandsForBot(ctx context.Context, arg DeleteBotComm
 	return err
 }
 
+const deleteBotSetupCodesForBot = `-- name: DeleteBotSetupCodesForBot :execrows
+DELETE FROM bot_setup_codes
+WHERE bot_user_id = $1
+  AND claimed_at IS NULL
+`
+
+func (q *Queries) DeleteBotSetupCodesForBot(ctx context.Context, botUserID string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteBotSetupCodesForBot, botUserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteBotSetupCodesForWorkspaceBot = `-- name: DeleteBotSetupCodesForWorkspaceBot :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = $1
+  AND bot_user_id = $2
+  AND claimed_at IS NULL
+`
+
+type DeleteBotSetupCodesForWorkspaceBotParams struct {
+	WorkspaceID string `json:"workspace_id"`
+	BotUserID   string `json:"bot_user_id"`
+}
+
+func (q *Queries) DeleteBotSetupCodesForWorkspaceBot(ctx context.Context, arg DeleteBotSetupCodesForWorkspaceBotParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteBotSetupCodesForWorkspaceBot, arg.WorkspaceID, arg.BotUserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteDesktopOAuthGrant = `-- name: DeleteDesktopOAuthGrant :execrows
 DELETE FROM desktop_oauth_grants
 WHERE id = $1 AND grant_hash = $2
@@ -394,6 +428,19 @@ type DeleteDesktopOAuthGrantParams struct {
 
 func (q *Queries) DeleteDesktopOAuthGrant(ctx context.Context, arg DeleteDesktopOAuthGrantParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteDesktopOAuthGrant, arg.ID, arg.GrantHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredBotSetupCodes = `-- name: DeleteExpiredBotSetupCodes :execrows
+DELETE FROM bot_setup_codes
+WHERE claimed_at IS NULL AND expires_at <= $1
+`
+
+func (q *Queries) DeleteExpiredBotSetupCodes(ctx context.Context, now string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredBotSetupCodes, now)
 	if err != nil {
 		return 0, err
 	}
@@ -483,6 +530,28 @@ WHERE id = $1
 func (q *Queries) DeletePendingUploadCleanup(ctx context.Context, id string) error {
 	_, err := q.db.ExecContext(ctx, deletePendingUploadCleanup, id)
 	return err
+}
+
+const deleteUnclaimedBotSetupCodesForTokenName = `-- name: DeleteUnclaimedBotSetupCodesForTokenName :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = $1
+  AND bot_user_id = $2
+  AND token_name = $3
+  AND claimed_at IS NULL
+`
+
+type DeleteUnclaimedBotSetupCodesForTokenNameParams struct {
+	WorkspaceID string `json:"workspace_id"`
+	BotUserID   string `json:"bot_user_id"`
+	TokenName   string `json:"token_name"`
+}
+
+func (q *Queries) DeleteUnclaimedBotSetupCodesForTokenName(ctx context.Context, arg DeleteUnclaimedBotSetupCodesForTokenNameParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteUnclaimedBotSetupCodesForTokenName, arg.WorkspaceID, arg.BotUserID, arg.TokenName)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const deleteUploadQuotaReservation = `-- name: DeleteUploadQuotaReservation :execrows
@@ -795,6 +864,32 @@ func (q *Queries) GetActiveBotForDeletion(ctx context.Context, botUserID string)
 		&i.Handle,
 		&i.AvatarUrl,
 		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getBotSetupCodeByHash = `-- name: GetBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
+WHERE code_hash = $1
+FOR UPDATE
+`
+
+func (q *Queries) GetBotSetupCodeByHash(ctx context.Context, codeHash string) (BotSetupCode, error) {
+	row := q.db.QueryRowContext(ctx, getBotSetupCodeByHash, codeHash)
+	var i BotSetupCode
+	err := row.Scan(
+		&i.ID,
+		&i.CodeHash,
+		&i.WorkspaceID,
+		&i.BotUserID,
+		&i.TokenName,
+		&i.ScopesJson,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ClaimedAt,
+		&i.ClaimedTokenID,
 	)
 	return i, err
 }
@@ -1650,6 +1745,35 @@ func (q *Queries) GetWorkspaceByRouteID(ctx context.Context, routeID sql.NullStr
 	return i, err
 }
 
+const getWorkspaceForSetupClaim = `-- name: GetWorkspaceForSetupClaim :one
+SELECT id, route_id, name, slug, icon_url, created_at
+FROM workspaces
+WHERE id = $1
+`
+
+type GetWorkspaceForSetupClaimRow struct {
+	ID        string         `json:"id"`
+	RouteID   sql.NullString `json:"route_id"`
+	Name      string         `json:"name"`
+	Slug      string         `json:"slug"`
+	IconUrl   string         `json:"icon_url"`
+	CreatedAt string         `json:"created_at"`
+}
+
+func (q *Queries) GetWorkspaceForSetupClaim(ctx context.Context, workspaceID string) (GetWorkspaceForSetupClaimRow, error) {
+	row := q.db.QueryRowContext(ctx, getWorkspaceForSetupClaim, workspaceID)
+	var i GetWorkspaceForSetupClaimRow
+	err := row.Scan(
+		&i.ID,
+		&i.RouteID,
+		&i.Name,
+		&i.Slug,
+		&i.IconUrl,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const hideDirectConversation = `-- name: HideDirectConversation :exec
 INSERT INTO direct_conversation_hidden (conversation_id, user_id, hidden_at)
 VALUES ($1, $2, $3)
@@ -1698,6 +1822,38 @@ func (q *Queries) InsertBotCommand(ctx context.Context, arg InsertBotCommandPara
 		arg.ArgsHint,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+	)
+	return err
+}
+
+const insertBotSetupCode = `-- name: InsertBotSetupCode :exec
+INSERT INTO bot_setup_codes (id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`
+
+type InsertBotSetupCodeParams struct {
+	ID          string         `json:"id"`
+	CodeHash    string         `json:"code_hash"`
+	WorkspaceID string         `json:"workspace_id"`
+	BotUserID   string         `json:"bot_user_id"`
+	TokenName   string         `json:"token_name"`
+	ScopesJson  string         `json:"scopes_json"`
+	CreatedBy   sql.NullString `json:"created_by"`
+	CreatedAt   string         `json:"created_at"`
+	ExpiresAt   string         `json:"expires_at"`
+}
+
+func (q *Queries) InsertBotSetupCode(ctx context.Context, arg InsertBotSetupCodeParams) error {
+	_, err := q.db.ExecContext(ctx, insertBotSetupCode,
+		arg.ID,
+		arg.CodeHash,
+		arg.WorkspaceID,
+		arg.BotUserID,
+		arg.TokenName,
+		arg.ScopesJson,
+		arg.CreatedBy,
+		arg.CreatedAt,
+		arg.ExpiresAt,
 	)
 	return err
 }
@@ -3874,6 +4030,26 @@ SELECT id FROM workspaces WHERE id = $1 FOR UPDATE
 func (q *Queries) LockWorkspaceForUpdate(ctx context.Context, workspaceID string) error {
 	_, err := q.db.ExecContext(ctx, lockWorkspaceForUpdate, workspaceID)
 	return err
+}
+
+const markBotSetupCodeClaimed = `-- name: MarkBotSetupCodeClaimed :execrows
+UPDATE bot_setup_codes
+SET claimed_at = $1, claimed_token_id = $2
+WHERE id = $3 AND claimed_at IS NULL
+`
+
+type MarkBotSetupCodeClaimedParams struct {
+	ClaimedAt      sql.NullString `json:"claimed_at"`
+	ClaimedTokenID sql.NullString `json:"claimed_token_id"`
+	ID             string         `json:"id"`
+}
+
+func (q *Queries) MarkBotSetupCodeClaimed(ctx context.Context, arg MarkBotSetupCodeClaimedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markBotSetupCodeClaimed, arg.ClaimedAt, arg.ClaimedTokenID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const markMagicLinkUsed = `-- name: MarkMagicLinkUsed :execrows

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -872,7 +872,6 @@ const getBotSetupCodeByHash = `-- name: GetBotSetupCodeByHash :one
 SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
 FROM bot_setup_codes
 WHERE code_hash = $1
-FOR UPDATE
 `
 
 func (q *Queries) GetBotSetupCodeByHash(ctx context.Context, codeHash string) (BotSetupCode, error) {
@@ -4016,6 +4015,32 @@ func (q *Queries) LockBotCommandSet(ctx context.Context, arg LockBotCommandSetPa
 	var user_id string
 	err := row.Scan(&user_id)
 	return user_id, err
+}
+
+const lockBotSetupCodeByHash = `-- name: LockBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
+WHERE code_hash = $1
+FOR UPDATE
+`
+
+func (q *Queries) LockBotSetupCodeByHash(ctx context.Context, codeHash string) (BotSetupCode, error) {
+	row := q.db.QueryRowContext(ctx, lockBotSetupCodeByHash, codeHash)
+	var i BotSetupCode
+	err := row.Scan(
+		&i.ID,
+		&i.CodeHash,
+		&i.WorkspaceID,
+		&i.BotUserID,
+		&i.TokenName,
+		&i.ScopesJson,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ClaimedAt,
+		&i.ClaimedTokenID,
+	)
+	return i, err
 }
 
 const lockBotWorkspaceMembership = `-- name: LockBotWorkspaceMembership :one

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1055,6 +1055,22 @@ func (q *Queries) GetChannelWorkspace(ctx context.Context, id string) (string, e
 	return workspace_id, err
 }
 
+const getDefaultChannelForSetupClaim = `-- name: GetDefaultChannelForSetupClaim :one
+SELECT name
+FROM channels
+WHERE workspace_id = $1
+  AND archived_at IS NULL
+ORDER BY CASE WHEN name = 'general' THEN 0 ELSE 1 END, created_at, id
+LIMIT 1
+`
+
+func (q *Queries) GetDefaultChannelForSetupClaim(ctx context.Context, workspaceID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, getDefaultChannelForSetupClaim, workspaceID)
+	var name string
+	err := row.Scan(&name)
+	return name, err
+}
+
 const getDesktopOAuthGrantForConsume = `-- name: GetDesktopOAuthGrantForConsume :one
 SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
 FROM desktop_oauth_grants

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -3465,6 +3465,41 @@ func (q *Queries) ListThreadStates(ctx context.Context, rootMessageIds []string)
 	return items, nil
 }
 
+const listWorkspaceActiveBotMemberIDs = `-- name: ListWorkspaceActiveBotMemberIDs :many
+SELECT u.id
+FROM users u
+JOIN workspace_members wm ON wm.user_id = u.id
+WHERE wm.workspace_id = $1
+  AND u.kind = 'bot'
+  AND NOT EXISTS (
+    SELECT 1 FROM bot_tombstones tombstone WHERE tombstone.bot_user_id = u.id
+  )
+ORDER BY u.id
+`
+
+func (q *Queries) ListWorkspaceActiveBotMemberIDs(ctx context.Context, workspaceID string) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, listWorkspaceActiveBotMemberIDs, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWorkspaceActiveServiceBotIDs = `-- name: ListWorkspaceActiveServiceBotIDs :many
 SELECT DISTINCT u.id
 FROM users u

--- a/apps/api/internal/store/sqlite/bots.go
+++ b/apps/api/internal/store/sqlite/bots.go
@@ -625,6 +625,12 @@ func (s *Store) RemoveBotFromWorkspace(ctx context.Context, workspaceID, botUser
 		WHERE bot_user_id = ? AND workspace_id = ?`, revokedAt, botUserID, workspaceID); err != nil {
 		return err
 	}
+	if _, err := qtx.DeleteBotSetupCodesForWorkspaceBot(ctx, storedb.DeleteBotSetupCodesForWorkspaceBotParams{
+		WorkspaceID: workspaceID,
+		BotUserID:   botUserID,
+	}); err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 
@@ -702,6 +708,9 @@ func (s *Store) deleteBotTx(ctx context.Context, tx *sql.Tx, botUserID, requeste
 		return store.DeletedBot{}, botDeletionCounts{}, err
 	}
 	counts.botTokens = int(tokenCount)
+	if _, err := qtx.DeleteBotSetupCodesForBot(ctx, bot.ID); err != nil {
+		return store.DeletedBot{}, botDeletionCounts{}, err
+	}
 	commandCount, err := qtx.RevokeAllBotSlashCommands(ctx, storedb.RevokeAllBotSlashCommandsParams{
 		RevokedAt: sqlText(deletedAt),
 		BotUserID: bot.ID,

--- a/apps/api/internal/store/sqlite/migrations/0034_bot_setup_codes.sql
+++ b/apps/api/internal/store/sqlite/migrations/0034_bot_setup_codes.sql
@@ -13,3 +13,5 @@ CREATE TABLE bot_setup_codes (
 );
 
 CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);
+CREATE INDEX idx_bot_setup_codes_bot ON bot_setup_codes(bot_user_id);
+CREATE INDEX idx_bot_setup_codes_pending_expiry ON bot_setup_codes(expires_at) WHERE claimed_at IS NULL;

--- a/apps/api/internal/store/sqlite/migrations/0034_bot_setup_codes.sql
+++ b/apps/api/internal/store/sqlite/migrations/0034_bot_setup_codes.sql
@@ -1,0 +1,15 @@
+CREATE TABLE bot_setup_codes (
+  id TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  bot_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_name TEXT NOT NULL,
+  scopes_json TEXT NOT NULL,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  claimed_at TEXT,
+  claimed_token_id TEXT REFERENCES bot_tokens(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);

--- a/apps/api/internal/store/sqlite/setup_codes.go
+++ b/apps/api/internal/store/sqlite/setup_codes.go
@@ -1,0 +1,258 @@
+package sqlite
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
+)
+
+// botSetupCodeTTL bounds how long a pending setup code can be claimed.
+const botSetupCodeTTL = 10 * time.Minute
+
+// setupCodeAlphabet is crockford-style base32 without the ambiguous
+// I, L, O, and U. 12 characters give 60 bits of entropy, which is
+// required because the claim endpoint is unauthenticated.
+const setupCodeAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+const setupCodeLength = 12
+
+func newBotSetupCode() (string, error) {
+	var raw [setupCodeLength]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	var out strings.Builder
+	for i, b := range raw {
+		if i > 0 && i%4 == 0 {
+			out.WriteByte('-')
+		}
+		// 256 is a multiple of 32, so masking has no modulo bias.
+		out.WriteByte(setupCodeAlphabet[b&31])
+	}
+	return out.String(), nil
+}
+
+func normalizeBotSetupCode(code string) (string, error) {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	code = strings.ReplaceAll(code, "-", "")
+	code = strings.ReplaceAll(code, " ", "")
+	if len(code) != setupCodeLength {
+		return "", store.ErrSetupCodeInvalid
+	}
+	for i := 0; i < len(code); i++ {
+		if !strings.ContainsRune(setupCodeAlphabet, rune(code[i])) {
+			return "", store.ErrSetupCodeInvalid
+		}
+	}
+	return code, nil
+}
+
+func hashBotSetupCode(normalizedCode string) string {
+	sum := sha256.Sum256([]byte("bot-setup-code:" + normalizedCode))
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Store) CreateBotSetupCode(ctx context.Context, input store.CreateBotSetupCodeInput) (store.BotSetupCode, error) {
+	botUserID := strings.TrimSpace(input.BotUserID)
+	if botUserID == "" {
+		return store.BotSetupCode{}, errors.New("bot_user_id is required")
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	if workspaceID == "" {
+		return store.BotSetupCode{}, errors.New("workspace_id is required")
+	}
+	createdBy := strings.TrimSpace(input.CreatedBy)
+	if createdBy == "" {
+		return store.BotSetupCode{}, errors.New("created_by is required")
+	}
+	tokenName := strings.TrimSpace(input.Name)
+	if tokenName == "" {
+		tokenName = "default"
+	}
+	scopes, err := normalizeBotScopes(input.Scopes)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	code, err := newBotSetupCode()
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	defer tx.Rollback()
+	bot, err := scanUser(tx.QueryRowContext(ctx, `SELECT id, kind, owner_user_id, display_name, handle, avatar_url, created_at FROM users WHERE id = ?`, botUserID))
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if bot.Kind != "bot" {
+		return store.BotSetupCode{}, errors.New("bot_user_id must refer to a bot")
+	}
+	if _, err := botWorkspaceForTokenTx(ctx, tx, bot.ID, workspaceID); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if err := requireBotTokenManagerTx(ctx, tx, workspaceID, bot, createdBy); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	qtx := s.q.WithTx(tx)
+	createdAt := now()
+	if _, err := qtx.DeleteExpiredBotSetupCodes(ctx, createdAt); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	// Re-minting replaces any pending code for the same token grant.
+	if _, err := qtx.DeleteUnclaimedBotSetupCodesForTokenName(ctx, storedb.DeleteUnclaimedBotSetupCodesForTokenNameParams{
+		WorkspaceID: workspaceID,
+		BotUserID:   bot.ID,
+		TokenName:   tokenName,
+	}); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	scopesJSON, err := json.Marshal(scopes)
+	if err != nil {
+		return store.BotSetupCode{}, err
+	}
+	setup := store.BotSetupCode{
+		ID:          newID("bsc"),
+		BotUserID:   bot.ID,
+		WorkspaceID: workspaceID,
+		TokenName:   tokenName,
+		Scopes:      scopes,
+		CreatedBy:   createdBy,
+		CreatedAt:   createdAt,
+		ExpiresAt:   time.Now().UTC().Add(botSetupCodeTTL).Format(time.RFC3339Nano),
+	}
+	if err := qtx.InsertBotSetupCode(ctx, storedb.InsertBotSetupCodeParams{
+		ID:          setup.ID,
+		CodeHash:    hashBotSetupCode(strings.ReplaceAll(code, "-", "")),
+		WorkspaceID: setup.WorkspaceID,
+		BotUserID:   setup.BotUserID,
+		TokenName:   setup.TokenName,
+		ScopesJson:  string(scopesJSON),
+		CreatedBy:   sqlOptionalText(setup.CreatedBy),
+		CreatedAt:   setup.CreatedAt,
+		ExpiresAt:   setup.ExpiresAt,
+	}); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.BotSetupCode{}, err
+	}
+	setup.Code = code
+	return setup, nil
+}
+
+func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSetupCodeClaim, error) {
+	normalized, err := normalizeBotSetupCode(code)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	defer tx.Rollback()
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetBotSetupCodeByHash(ctx, hashBotSetupCode(normalized))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if row.ClaimedAt.Valid {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	expiresAt, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
+	if err != nil || time.Now().UTC().After(expiresAt) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	bot, err := scanUser(tx.QueryRowContext(ctx, `SELECT id, kind, owner_user_id, display_name, handle, avatar_url, created_at FROM users WHERE id = ?`, row.BotUserID))
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if bot.Kind != "bot" {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	workspaceID, err := botWorkspaceForTokenTx(ctx, tx, bot.ID, row.WorkspaceID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	var scopes []string
+	if err := json.Unmarshal([]byte(row.ScopesJson), &scopes); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	token := newID("ccb")
+	botToken := store.BotToken{
+		ID:          newID("btok"),
+		Token:       token,
+		BotUserID:   bot.ID,
+		WorkspaceID: workspaceID,
+		OwnerUserID: bot.OwnerUserID,
+		Name:        row.TokenName,
+		Scopes:      scopes,
+		CreatedBy:   stringFromNull(row.CreatedBy),
+		CreatedAt:   now(),
+	}
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO bot_tokens (id, token_hash, bot_user_id, workspace_id, owner_user_id, name, scopes_json, created_by, setup_nonce, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		botToken.ID,
+		hashBotToken(token),
+		botToken.BotUserID,
+		botToken.WorkspaceID,
+		sqlOptionalText(botToken.OwnerUserID),
+		botToken.Name,
+		row.ScopesJson,
+		sqlOptionalText(botToken.CreatedBy),
+		"",
+		botToken.CreatedAt,
+	); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	claimed, err := qtx.MarkBotSetupCodeClaimed(ctx, storedb.MarkBotSetupCodeClaimedParams{
+		ClaimedAt:      sqlText(botToken.CreatedAt),
+		ClaimedTokenID: sqlText(botToken.ID),
+		ID:             row.ID,
+	})
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if claimed != 1 {
+		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
+	}
+	wsRow, err := qtx.GetWorkspaceForSetupClaim(ctx, workspaceID)
+	if err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.BotSetupCodeClaim{}, err
+	}
+	return store.BotSetupCodeClaim{
+		BotToken: botToken,
+		Bot:      bot,
+		Workspace: store.Workspace{
+			ID:        wsRow.ID,
+			RouteID:   stringFromNull(wsRow.RouteID),
+			Name:      wsRow.Name,
+			Slug:      wsRow.Slug,
+			IconURL:   wsRow.IconUrl,
+			CreatedAt: wsRow.CreatedAt,
+		},
+	}, nil
+}

--- a/apps/api/internal/store/sqlite/setup_codes.go
+++ b/apps/api/internal/store/sqlite/setup_codes.go
@@ -173,7 +173,7 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	expiresAt, err := time.Parse(time.RFC3339Nano, row.ExpiresAt)
-	if err != nil || time.Now().UTC().After(expiresAt) {
+	if err != nil || !time.Now().UTC().Before(expiresAt) {
 		return store.BotSetupCodeClaim{}, store.ErrSetupCodeInvalid
 	}
 	bot, err := scanUser(tx.QueryRowContext(ctx, `SELECT id, kind, owner_user_id, display_name, handle, avatar_url, created_at FROM users WHERE id = ?`, row.BotUserID))
@@ -240,10 +240,14 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 	if err != nil {
 		return store.BotSetupCodeClaim{}, err
 	}
+	defaultChannel, err := qtx.GetDefaultChannelForSetupClaim(ctx, workspaceID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return store.BotSetupCodeClaim{}, err
+	}
 	if err := tx.Commit(); err != nil {
 		return store.BotSetupCodeClaim{}, err
 	}
-	return store.BotSetupCodeClaim{
+	claim := store.BotSetupCodeClaim{
 		BotToken: botToken,
 		Bot:      bot,
 		Workspace: store.Workspace{
@@ -254,5 +258,9 @@ func (s *Store) ClaimBotSetupCode(ctx context.Context, code string) (store.BotSe
 			IconURL:   wsRow.IconUrl,
 			CreatedAt: wsRow.CreatedAt,
 		},
-	}, nil
+	}
+	if defaultChannel != "" {
+		claim.Defaults.DefaultTo = "channel:" + defaultChannel
+	}
+	return claim, nil
 }

--- a/apps/api/internal/store/sqlite/setup_codes_test.go
+++ b/apps/api/internal/store/sqlite/setup_codes_test.go
@@ -1,0 +1,287 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func setupCodeFixture(t *testing.T) (*Store, store.Workspace, store.User, store.User) {
+	t.Helper()
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "member-setup-codes@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	return st, workspace, owner, member
+}
+
+func TestBotSetupCodeMintAndClaim(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, member := setupCodeFixture(t)
+
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		DisplayName: "Service Bot",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "gateway",
+		CreatedBy:   member.ID,
+	}); !errors.Is(err, store.ErrNotWorkspaceManager) {
+		t.Fatalf("expected member mint to require manager, got %v", err)
+	}
+
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "gateway",
+		Scopes:      []string{"messages:write"},
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(setup.Code) != 14 || strings.Count(setup.Code, "-") != 2 {
+		t.Fatalf("expected XXXX-XXXX-XXXX code, got %q", setup.Code)
+	}
+	if setup.ExpiresAt == "" || setupCodePlaintextAtRest(t, st, setup.Code) {
+		t.Fatalf("unexpected setup code state: %#v", setup)
+	}
+
+	// No new token exists until claim (CreateBot minted the initial one).
+	tokens, err := st.ListBotTokensForWorkspace(ctx, workspace.ID, bot.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseline := len(tokens)
+
+	// Claim is normalization-tolerant: lowercase without separators.
+	claim, err := st.ClaimBotSetupCode(ctx, strings.ToLower(strings.ReplaceAll(setup.Code, "-", "")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokens, err = st.ListBotTokensForWorkspace(ctx, workspace.ID, bot.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tokens) != baseline+1 {
+		t.Fatalf("expected claim to mint exactly one token, got %d -> %d", baseline, len(tokens))
+	}
+	if claim.BotToken.Token == "" || !strings.HasPrefix(claim.BotToken.Token, "ccb_") {
+		t.Fatalf("expected plaintext token in claim, got %#v", claim.BotToken)
+	}
+	if claim.Bot.ID != bot.ID || claim.Workspace.ID != workspace.ID {
+		t.Fatalf("unexpected claim context: %#v", claim)
+	}
+	if claim.BotToken.Name != "gateway" || len(claim.BotToken.Scopes) != 1 || claim.BotToken.Scopes[0] != "messages:write" {
+		t.Fatalf("expected captured name/scopes, got %#v", claim.BotToken)
+	}
+	auth, err := st.GetBotTokenAuth(ctx, claim.BotToken.Token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if auth.User.ID != bot.ID || auth.WorkspaceID != workspace.ID {
+		t.Fatalf("expected minted token to authenticate, got %#v", auth)
+	}
+
+	// Single use.
+	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected second claim to fail uniformly, got %v", err)
+	}
+}
+
+// setupCodePlaintextAtRest reports whether the plaintext code leaked into
+// the code_hash column.
+func setupCodePlaintextAtRest(t *testing.T, st *Store, code string) bool {
+	t.Helper()
+	var count int
+	normalized := strings.ReplaceAll(code, "-", "")
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM bot_setup_codes WHERE code_hash = ? OR code_hash = ?`, code, normalized).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	return count != 0
+}
+
+func TestBotSetupCodeExpiryAndInvalidInputs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, _ := setupCodeFixture(t)
+
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Expiring Bot", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if setup.TokenName != "default" {
+		t.Fatalf("expected default token name, got %q", setup.TokenName)
+	}
+	expired := time.Now().UTC().Add(-time.Minute).Format(time.RFC3339Nano)
+	if _, err := st.db.ExecContext(ctx, `UPDATE bot_setup_codes SET expires_at = ? WHERE id = ?`, expired, setup.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected expired claim to fail uniformly, got %v", err)
+	}
+
+	for _, invalid := range []string{"", "short", "!!!!-!!!!-!!!!", strings.Repeat("A", 13)} {
+		if _, err := st.ClaimBotSetupCode(ctx, invalid); !errors.Is(err, store.ErrSetupCodeInvalid) {
+			t.Fatalf("expected invalid code %q to fail uniformly, got %v", invalid, err)
+		}
+	}
+
+	// A fresh mint lazily purges the expired row.
+	if _, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "other", CreatedBy: owner.ID}); err != nil {
+		t.Fatal(err)
+	}
+	var remaining int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM bot_setup_codes WHERE id = ?`, setup.ID).Scan(&remaining); err != nil {
+		t.Fatal(err)
+	}
+	if remaining != 0 {
+		t.Fatal("expected expired setup code to be purged on next mint")
+	}
+}
+
+func TestBotSetupCodeRemintReplacesPending(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, _ := setupCodeFixture(t)
+
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Remint Bot", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "gateway", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: bot.ID, Name: "gateway", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, first.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected replaced code to be unclaimable, got %v", err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, second.Code); err != nil {
+		t.Fatalf("expected replacement code to claim, got %v", err)
+	}
+}
+
+func TestBotSetupCodeLifecycleCascades(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, _ := setupCodeFixture(t)
+
+	removed, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Removed Bot", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	removedCode, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: removed.ID, CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RemoveBotFromWorkspace(ctx, workspace.ID, removed.ID, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, removedCode.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected claim after removal to fail uniformly, got %v", err)
+	}
+	var count int
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM bot_setup_codes WHERE bot_user_id = ?`, removed.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("expected pending codes to be deleted on workspace removal")
+	}
+
+	deleted, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Deleted Bot", CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deletedCode, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{WorkspaceID: workspace.ID, BotUserID: deleted.ID, CreatedBy: owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DeleteBot(ctx, deleted.ID, owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.ClaimBotSetupCode(ctx, deletedCode.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
+		t.Fatalf("expected claim after bot deletion to fail uniformly, got %v", err)
+	}
+	if err := st.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM bot_setup_codes WHERE bot_user_id = ?`, deleted.ID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatal("expected pending codes to be deleted with the bot")
+	}
+}
+
+func TestBotSetupCodeUserOwnedBotAuthorization(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, member := setupCodeFixture(t)
+
+	userBot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		OwnerUserID: member.ID,
+		DisplayName: "Member Bot",
+		CreatedBy:   member.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   userBot.ID,
+		CreatedBy:   owner.ID,
+	}); !errors.Is(err, store.ErrBotOwnerRequired) {
+		t.Fatalf("expected non-owner mint on user-owned bot to fail, got %v", err)
+	}
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   userBot.ID,
+		CreatedBy:   member.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := st.ClaimBotSetupCode(ctx, setup.Code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if claim.BotToken.OwnerUserID != member.ID {
+		t.Fatalf("expected owner to carry into minted token, got %#v", claim.BotToken)
+	}
+}

--- a/apps/api/internal/store/sqlite/setup_codes_test.go
+++ b/apps/api/internal/store/sqlite/setup_codes_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,6 +99,9 @@ func TestBotSetupCodeMintAndClaim(t *testing.T) {
 	if claim.Bot.ID != bot.ID || claim.Workspace.ID != workspace.ID {
 		t.Fatalf("unexpected claim context: %#v", claim)
 	}
+	if claim.Defaults.DefaultTo != "channel:general" {
+		t.Fatalf("expected general channel suggestion, got %#v", claim.Defaults)
+	}
 	if claim.BotToken.Name != "gateway" || len(claim.BotToken.Scopes) != 1 || claim.BotToken.Scopes[0] != "messages:write" {
 		t.Fatalf("expected captured name/scopes, got %#v", claim.BotToken)
 	}
@@ -112,6 +116,71 @@ func TestBotSetupCodeMintAndClaim(t *testing.T) {
 	// Single use.
 	if _, err := st.ClaimBotSetupCode(ctx, setup.Code); !errors.Is(err, store.ErrSetupCodeInvalid) {
 		t.Fatalf("expected second claim to fail uniformly, got %v", err)
+	}
+}
+
+func TestBotSetupCodeConcurrentClaimMintsOnce(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st, workspace, owner, _ := setupCodeFixture(t)
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		DisplayName: "Concurrent Claim Bot",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	setup, err := st.CreateBotSetupCode(ctx, store.CreateBotSetupCodeInput{
+		WorkspaceID: workspace.ID,
+		BotUserID:   bot.ID,
+		Name:        "concurrent",
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.ListBotTokensForWorkspace(ctx, workspace.ID, bot.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, claimErr := st.ClaimBotSetupCode(ctx, setup.Code)
+			results <- claimErr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var successes, invalid int
+	for claimErr := range results {
+		switch {
+		case claimErr == nil:
+			successes++
+		case errors.Is(claimErr, store.ErrSetupCodeInvalid):
+			invalid++
+		default:
+			t.Fatalf("unexpected concurrent claim error: %v", claimErr)
+		}
+	}
+	if successes != 1 || invalid != 1 {
+		t.Fatalf("expected one success and one uniform rejection, got success=%d invalid=%d", successes, invalid)
+	}
+	after, err := st.ListBotTokensForWorkspace(ctx, workspace.ID, bot.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after) != len(before)+1 {
+		t.Fatalf("expected exactly one minted token, got %d -> %d", len(before), len(after))
 	}
 }
 

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -1456,3 +1456,11 @@ WHERE claimed_at IS NULL AND expires_at <= sqlc.arg(now);
 SELECT id, route_id, name, slug, icon_url, created_at
 FROM workspaces
 WHERE id = sqlc.arg(workspace_id);
+
+-- name: GetDefaultChannelForSetupClaim :one
+SELECT name
+FROM channels
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND archived_at IS NULL
+ORDER BY CASE WHEN name = 'general' THEN 0 ELSE 1 END, created_at, id
+LIMIT 1;

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -1415,3 +1415,44 @@ JOIN workspace_members wm
  AND wm.role = 'bot'
 WHERE bc.workspace_id = sqlc.arg(workspace_id)
 ORDER BY u.handle, bc.command;
+
+-- name: InsertBotSetupCode :exec
+INSERT INTO bot_setup_codes (id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at)
+VALUES (sqlc.arg(id), sqlc.arg(code_hash), sqlc.arg(workspace_id), sqlc.arg(bot_user_id), sqlc.arg(token_name), sqlc.arg(scopes_json), sqlc.arg(created_by), sqlc.arg(created_at), sqlc.arg(expires_at));
+
+-- name: GetBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
+WHERE code_hash = sqlc.arg(code_hash);
+
+-- name: MarkBotSetupCodeClaimed :execrows
+UPDATE bot_setup_codes
+SET claimed_at = sqlc.arg(claimed_at), claimed_token_id = sqlc.arg(claimed_token_id)
+WHERE id = sqlc.arg(id) AND claimed_at IS NULL;
+
+-- name: DeleteUnclaimedBotSetupCodesForTokenName :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND bot_user_id = sqlc.arg(bot_user_id)
+  AND token_name = sqlc.arg(token_name)
+  AND claimed_at IS NULL;
+
+-- name: DeleteBotSetupCodesForWorkspaceBot :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND bot_user_id = sqlc.arg(bot_user_id)
+  AND claimed_at IS NULL;
+
+-- name: DeleteBotSetupCodesForBot :execrows
+DELETE FROM bot_setup_codes
+WHERE bot_user_id = sqlc.arg(bot_user_id)
+  AND claimed_at IS NULL;
+
+-- name: DeleteExpiredBotSetupCodes :execrows
+DELETE FROM bot_setup_codes
+WHERE claimed_at IS NULL AND expires_at <= sqlc.arg(now);
+
+-- name: GetWorkspaceForSetupClaim :one
+SELECT id, route_id, name, slug, icon_url, created_at
+FROM workspaces
+WHERE id = sqlc.arg(workspace_id);

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -509,3 +509,19 @@ CREATE TABLE desktop_oauth_grants (
 
 CREATE INDEX idx_desktop_oauth_grants_expiry
   ON desktop_oauth_grants(expires_at_unix);
+
+CREATE TABLE bot_setup_codes (
+  id TEXT PRIMARY KEY,
+  code_hash TEXT NOT NULL UNIQUE,
+  workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  bot_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_name TEXT NOT NULL,
+  scopes_json TEXT NOT NULL,
+  created_by TEXT REFERENCES users(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  claimed_at TEXT,
+  claimed_token_id TEXT REFERENCES bot_tokens(id) ON DELETE SET NULL
+);
+
+CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -525,3 +525,5 @@ CREATE TABLE bot_setup_codes (
 );
 
 CREATE INDEX idx_bot_setup_codes_workspace_bot ON bot_setup_codes(workspace_id, bot_user_id);
+CREATE INDEX idx_bot_setup_codes_bot ON bot_setup_codes(bot_user_id);
+CREATE INDEX idx_bot_setup_codes_pending_expiry ON bot_setup_codes(expires_at) WHERE claimed_at IS NULL;

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -54,6 +54,20 @@ type BotCommand struct {
 	UpdatedAt   string `json:"updated_at"`
 }
 
+type BotSetupCode struct {
+	ID             string         `json:"id"`
+	CodeHash       string         `json:"code_hash"`
+	WorkspaceID    string         `json:"workspace_id"`
+	BotUserID      string         `json:"bot_user_id"`
+	TokenName      string         `json:"token_name"`
+	ScopesJson     string         `json:"scopes_json"`
+	CreatedBy      sql.NullString `json:"created_by"`
+	CreatedAt      string         `json:"created_at"`
+	ExpiresAt      string         `json:"expires_at"`
+	ClaimedAt      sql.NullString `json:"claimed_at"`
+	ClaimedTokenID sql.NullString `json:"claimed_token_id"`
+}
+
 type BotToken struct {
 	ID          string         `json:"id"`
 	TokenHash   string         `json:"token_hash"`

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1050,6 +1050,22 @@ func (q *Queries) GetChannelWorkspace(ctx context.Context, id string) (string, e
 	return workspace_id, err
 }
 
+const getDefaultChannelForSetupClaim = `-- name: GetDefaultChannelForSetupClaim :one
+SELECT name
+FROM channels
+WHERE workspace_id = ?1
+  AND archived_at IS NULL
+ORDER BY CASE WHEN name = 'general' THEN 0 ELSE 1 END, created_at, id
+LIMIT 1
+`
+
+func (q *Queries) GetDefaultChannelForSetupClaim(ctx context.Context, workspaceID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, getDefaultChannelForSetupClaim, workspaceID)
+	var name string
+	err := row.Scan(&name)
+	return name, err
+}
+
 const getDesktopOAuthGrantForConsume = `-- name: GetDesktopOAuthGrantForConsume :one
 SELECT id, grant_hash, user_id, desktop_challenge, created_at_unix, expires_at_unix
 FROM desktop_oauth_grants

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -379,6 +379,40 @@ func (q *Queries) DeleteBotCommandsForBot(ctx context.Context, arg DeleteBotComm
 	return err
 }
 
+const deleteBotSetupCodesForBot = `-- name: DeleteBotSetupCodesForBot :execrows
+DELETE FROM bot_setup_codes
+WHERE bot_user_id = ?1
+  AND claimed_at IS NULL
+`
+
+func (q *Queries) DeleteBotSetupCodesForBot(ctx context.Context, botUserID string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteBotSetupCodesForBot, botUserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteBotSetupCodesForWorkspaceBot = `-- name: DeleteBotSetupCodesForWorkspaceBot :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = ?1
+  AND bot_user_id = ?2
+  AND claimed_at IS NULL
+`
+
+type DeleteBotSetupCodesForWorkspaceBotParams struct {
+	WorkspaceID string `json:"workspace_id"`
+	BotUserID   string `json:"bot_user_id"`
+}
+
+func (q *Queries) DeleteBotSetupCodesForWorkspaceBot(ctx context.Context, arg DeleteBotSetupCodesForWorkspaceBotParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteBotSetupCodesForWorkspaceBot, arg.WorkspaceID, arg.BotUserID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const deleteDesktopOAuthGrant = `-- name: DeleteDesktopOAuthGrant :execrows
 DELETE FROM desktop_oauth_grants
 WHERE id = ?1 AND grant_hash = ?2
@@ -391,6 +425,19 @@ type DeleteDesktopOAuthGrantParams struct {
 
 func (q *Queries) DeleteDesktopOAuthGrant(ctx context.Context, arg DeleteDesktopOAuthGrantParams) (int64, error) {
 	result, err := q.db.ExecContext(ctx, deleteDesktopOAuthGrant, arg.ID, arg.GrantHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const deleteExpiredBotSetupCodes = `-- name: DeleteExpiredBotSetupCodes :execrows
+DELETE FROM bot_setup_codes
+WHERE claimed_at IS NULL AND expires_at <= ?1
+`
+
+func (q *Queries) DeleteExpiredBotSetupCodes(ctx context.Context, now string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteExpiredBotSetupCodes, now)
 	if err != nil {
 		return 0, err
 	}
@@ -480,6 +527,28 @@ WHERE id = ?1
 func (q *Queries) DeletePendingUploadCleanup(ctx context.Context, id string) error {
 	_, err := q.db.ExecContext(ctx, deletePendingUploadCleanup, id)
 	return err
+}
+
+const deleteUnclaimedBotSetupCodesForTokenName = `-- name: DeleteUnclaimedBotSetupCodesForTokenName :execrows
+DELETE FROM bot_setup_codes
+WHERE workspace_id = ?1
+  AND bot_user_id = ?2
+  AND token_name = ?3
+  AND claimed_at IS NULL
+`
+
+type DeleteUnclaimedBotSetupCodesForTokenNameParams struct {
+	WorkspaceID string `json:"workspace_id"`
+	BotUserID   string `json:"bot_user_id"`
+	TokenName   string `json:"token_name"`
+}
+
+func (q *Queries) DeleteUnclaimedBotSetupCodesForTokenName(ctx context.Context, arg DeleteUnclaimedBotSetupCodesForTokenNameParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, deleteUnclaimedBotSetupCodesForTokenName, arg.WorkspaceID, arg.BotUserID, arg.TokenName)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const deleteUploadQuotaReservation = `-- name: DeleteUploadQuotaReservation :execrows
@@ -791,6 +860,31 @@ func (q *Queries) GetActiveBotForDeletion(ctx context.Context, botUserID string)
 		&i.Handle,
 		&i.AvatarUrl,
 		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getBotSetupCodeByHash = `-- name: GetBotSetupCodeByHash :one
+SELECT id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at, claimed_at, claimed_token_id
+FROM bot_setup_codes
+WHERE code_hash = ?1
+`
+
+func (q *Queries) GetBotSetupCodeByHash(ctx context.Context, codeHash string) (BotSetupCode, error) {
+	row := q.db.QueryRowContext(ctx, getBotSetupCodeByHash, codeHash)
+	var i BotSetupCode
+	err := row.Scan(
+		&i.ID,
+		&i.CodeHash,
+		&i.WorkspaceID,
+		&i.BotUserID,
+		&i.TokenName,
+		&i.ScopesJson,
+		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ClaimedAt,
+		&i.ClaimedTokenID,
 	)
 	return i, err
 }
@@ -1644,6 +1738,35 @@ func (q *Queries) GetWorkspaceByRouteID(ctx context.Context, routeID sql.NullStr
 	return i, err
 }
 
+const getWorkspaceForSetupClaim = `-- name: GetWorkspaceForSetupClaim :one
+SELECT id, route_id, name, slug, icon_url, created_at
+FROM workspaces
+WHERE id = ?1
+`
+
+type GetWorkspaceForSetupClaimRow struct {
+	ID        string         `json:"id"`
+	RouteID   sql.NullString `json:"route_id"`
+	Name      string         `json:"name"`
+	Slug      string         `json:"slug"`
+	IconUrl   string         `json:"icon_url"`
+	CreatedAt string         `json:"created_at"`
+}
+
+func (q *Queries) GetWorkspaceForSetupClaim(ctx context.Context, workspaceID string) (GetWorkspaceForSetupClaimRow, error) {
+	row := q.db.QueryRowContext(ctx, getWorkspaceForSetupClaim, workspaceID)
+	var i GetWorkspaceForSetupClaimRow
+	err := row.Scan(
+		&i.ID,
+		&i.RouteID,
+		&i.Name,
+		&i.Slug,
+		&i.IconUrl,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const hideDirectConversation = `-- name: HideDirectConversation :exec
 INSERT INTO direct_conversation_hidden (conversation_id, user_id, hidden_at)
 VALUES (?1, ?2, ?3)
@@ -1692,6 +1815,38 @@ func (q *Queries) InsertBotCommand(ctx context.Context, arg InsertBotCommandPara
 		arg.ArgsHint,
 		arg.CreatedAt,
 		arg.UpdatedAt,
+	)
+	return err
+}
+
+const insertBotSetupCode = `-- name: InsertBotSetupCode :exec
+INSERT INTO bot_setup_codes (id, code_hash, workspace_id, bot_user_id, token_name, scopes_json, created_by, created_at, expires_at)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+`
+
+type InsertBotSetupCodeParams struct {
+	ID          string         `json:"id"`
+	CodeHash    string         `json:"code_hash"`
+	WorkspaceID string         `json:"workspace_id"`
+	BotUserID   string         `json:"bot_user_id"`
+	TokenName   string         `json:"token_name"`
+	ScopesJson  string         `json:"scopes_json"`
+	CreatedBy   sql.NullString `json:"created_by"`
+	CreatedAt   string         `json:"created_at"`
+	ExpiresAt   string         `json:"expires_at"`
+}
+
+func (q *Queries) InsertBotSetupCode(ctx context.Context, arg InsertBotSetupCodeParams) error {
+	_, err := q.db.ExecContext(ctx, insertBotSetupCode,
+		arg.ID,
+		arg.CodeHash,
+		arg.WorkspaceID,
+		arg.BotUserID,
+		arg.TokenName,
+		arg.ScopesJson,
+		arg.CreatedBy,
+		arg.CreatedAt,
+		arg.ExpiresAt,
 	)
 	return err
 }
@@ -3865,6 +4020,26 @@ func (q *Queries) LockBotWorkspaceMembership(ctx context.Context, arg LockBotWor
 	var user_id string
 	err := row.Scan(&user_id)
 	return user_id, err
+}
+
+const markBotSetupCodeClaimed = `-- name: MarkBotSetupCodeClaimed :execrows
+UPDATE bot_setup_codes
+SET claimed_at = ?1, claimed_token_id = ?2
+WHERE id = ?3 AND claimed_at IS NULL
+`
+
+type MarkBotSetupCodeClaimedParams struct {
+	ClaimedAt      sql.NullString `json:"claimed_at"`
+	ClaimedTokenID sql.NullString `json:"claimed_token_id"`
+	ID             string         `json:"id"`
+}
+
+func (q *Queries) MarkBotSetupCodeClaimed(ctx context.Context, arg MarkBotSetupCodeClaimedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markBotSetupCodeClaimed, arg.ClaimedAt, arg.ClaimedTokenID, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const markMagicLinkUsed = `-- name: MarkMagicLinkUsed :execrows

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -43,6 +43,12 @@ var ErrDirectConversationNoActivePeer = errors.New("direct conversation has no a
 // daily post budget.
 var ErrPostRateLimited = errors.New("waiting room post limit reached")
 
+// ErrSetupCodeInvalid is returned for any unusable bot setup code — unknown,
+// expired, already claimed, or pointing at a bot that is no longer eligible.
+// The single error keeps claim responses uniform so callers cannot probe
+// which condition failed.
+var ErrSetupCodeInvalid = errors.New("setup code is invalid or expired")
+
 // ErrUploadQuotaExceeded is returned when a user has exhausted their upload
 // budget in a workspace.
 var ErrUploadQuotaExceeded = errors.New("upload quota exceeded")
@@ -372,6 +378,38 @@ type CreateBotTokenInput struct {
 	Scopes      []string
 	SetupNonce  string
 	CreatedBy   string
+}
+
+// BotSetupCode is a pending bot-token grant. Creating one does not mint a
+// token; the token is minted when the code is claimed. Code carries the
+// plaintext only in the mint response — at rest only the hash is stored.
+type BotSetupCode struct {
+	ID          string   `json:"id"`
+	BotUserID   string   `json:"bot_user_id"`
+	WorkspaceID string   `json:"workspace_id"`
+	TokenName   string   `json:"token_name"`
+	Scopes      []string `json:"scopes"`
+	CreatedBy   string   `json:"created_by,omitempty"`
+	CreatedAt   string   `json:"created_at"`
+	ExpiresAt   string   `json:"expires_at"`
+	Code        string   `json:"code,omitempty"`
+}
+
+type CreateBotSetupCodeInput struct {
+	WorkspaceID string
+	BotUserID   string
+	Name        string
+	Scopes      []string
+	CreatedBy   string
+}
+
+// BotSetupCodeClaim is the result of claiming a setup code: the freshly
+// minted token (plaintext included once) plus the context an installer
+// needs to write its configuration.
+type BotSetupCodeClaim struct {
+	BotToken  BotToken  `json:"bot_token"`
+	Bot       User      `json:"bot"`
+	Workspace Workspace `json:"workspace"`
 }
 
 type AppInstallation struct {
@@ -916,6 +954,8 @@ type Store interface {
 	CreateBot(ctx context.Context, input CreateBotInput) (User, BotToken, error)
 	ListBots(ctx context.Context, workspaceID, requesterID string) ([]BotWithTokens, error)
 	CreateBotToken(ctx context.Context, input CreateBotTokenInput) (BotToken, error)
+	CreateBotSetupCode(ctx context.Context, input CreateBotSetupCodeInput) (BotSetupCode, error)
+	ClaimBotSetupCode(ctx context.Context, code string) (BotSetupCodeClaim, error)
 	ListBotTokens(ctx context.Context, botUserID, requesterID string) ([]BotToken, error)
 	ListBotTokensForWorkspace(ctx context.Context, workspaceID, botUserID, requesterID string) ([]BotToken, error)
 	RevokeBotToken(ctx context.Context, tokenID, requesterID string) (BotToken, error)

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -410,6 +410,9 @@ type BotSetupCodeClaim struct {
 	BotToken  BotToken  `json:"bot_token"`
 	Bot       User      `json:"bot"`
 	Workspace Workspace `json:"workspace"`
+	Defaults  struct {
+		DefaultTo string `json:"defaultTo,omitempty"`
+	} `json:"defaults"`
 }
 
 type AppInstallation struct {

--- a/deploy/nginx/clickclack.conf.example
+++ b/deploy/nginx/clickclack.conf.example
@@ -31,6 +31,7 @@ http {
   # published address ranges before enabling these limits.
   limit_req_zone $binary_remote_addr zone=clickclack_oauth_start:64m rate=1r/s;
   limit_req_zone $binary_remote_addr zone=clickclack_oauth_consume:64m rate=5r/s;
+  limit_req_zone $binary_remote_addr zone=clickclack_setup_claim:16m rate=10r/m;
 
   upstream clickclack_api {
     server 127.0.0.1:8080;
@@ -93,6 +94,11 @@ http {
 
     location = /api/auth/github/callback {
       error_log /dev/null crit;
+      proxy_pass http://clickclack_api;
+    }
+
+    location = /api/bot-setup-codes/claim {
+      limit_req zone=clickclack_setup_claim burst=3 nodelay;
       proxy_pass http://clickclack_api;
     }
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -37,7 +37,7 @@ The value is not stored on message rows or exported as a metrics label.
 | Profile       | `/api/me`, `/api/me/bots` | [profiles](../features/profiles.md) |
 | Workspaces    | `/api/workspaces`, `/api/workspaces/{id}`, `/api/workspaces/{id}/members` | [workspaces](../features/workspaces.md) |
 | Moderation    | `/api/workspaces/{id}/moderation/members` | [moderation](../features/moderation.md) |
-| Bots          | `/api/workspaces/{id}/{bots,bot-commands}`, `/api/workspaces/{id}/bots/{bot_id}/{tokens,membership}`, `/api/bots/{id}`, `/api/bots/{id}/tokens`, `/api/bots/self/commands`, `/api/bot-tokens/{id}/revoke` | [bots](../features/bots.md) |
+| Bots          | `/api/workspaces/{id}/{bots,bot-commands}`, `/api/workspaces/{id}/bots/{bot_id}/{tokens,membership,setup-codes}`, `/api/bots/{id}`, `/api/bots/{id}/tokens`, `/api/bots/self/commands`, `/api/bot-tokens/{id}/revoke`, `/api/bot-setup-codes/claim` | [bots](../features/bots.md) |
 | Event types   | `/api/event-types` | [integrations](../features/integrations.md) |
 | App installs  | `/api/workspaces/{id}/app-installations`, `/api/app-installations/{id}/revoke` | [integrations](../features/integrations.md) |
 | Slash commands | `/api/workspaces/{id}/slash-commands`, `/api/slash-commands/{id}/{revoke,rotate-secret}`, `/api/hooks/slash/{channel}` | [integrations](../features/integrations.md) |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -176,9 +176,12 @@ an origin when configured.
 Terminate TLS only at infrastructure you trust, redirect HTTP to HTTPS, and
 send HSTS from the public HTTPS origin after confirming every subdomain covered
 by the policy is HTTPS-ready. ClickClack intentionally does not trust arbitrary
-`X-Forwarded-For` values for security decisions. Do not add a naive
-application-level IP limiter or derive a security limit from forwarded headers
-without a proven trusted-client identity contract for every proxy path.
+`X-Forwarded-For` values for security decisions. The setup-code claim limiter
+uses the transport peer by default. It accepts a forwarded client IP only when
+the peer is loopback and `X-Real-IP` matches a single-IP `X-Forwarded-For`,
+which is the contract used by the bundled Nginx example. Other proxy topologies
+must enforce their own edge limit or expose a separately verified client
+identity; arbitrary forwarding headers remain ignored.
 
 ### Optional self-hosted Nginx example
 
@@ -188,7 +191,8 @@ deployment. It is not ClickClack's hosted production configuration and does not
 describe or configure the hosted edge.
 
 The example includes TLS, WebSocket proxying, a 64 MiB request limit,
-query-free access logs, explicit forwarding headers, and OAuth rate limits.
+query-free access logs, explicit forwarding headers, and OAuth plus setup-code
+claim rate limits.
 Replace its hostname and certificate paths, confirm the upstream address, run
 `nginx -t`, and reload only after the syntax check succeeds. Its OAuth start
 bucket allows one request per second with a burst of eight, while desktop

--- a/docs/features/bots.md
+++ b/docs/features/bots.md
@@ -228,6 +228,8 @@ HTTP API:
 - `DELETE /api/workspaces/{workspace_id}/bots/{bot_user_id}/membership`
 - `GET /api/workspaces/{workspace_id}/bots/{bot_user_id}/tokens`
 - `POST /api/workspaces/{workspace_id}/bots/{bot_user_id}/tokens`
+- `POST /api/workspaces/{workspace_id}/bots/{bot_user_id}/setup-codes`
+- `POST /api/bot-setup-codes/claim`
 - `DELETE /api/bots/{bot_user_id}`
 - `GET /api/bots/{bot_user_id}/tokens`
 - `POST /api/bots/{bot_user_id}/tokens`
@@ -249,6 +251,25 @@ returned by list calls. `GET /api/workspaces/{workspace_id}/bots` returns
 Raw token values are never returned by list calls. Rotation is create-new, move
 the runtime, then revoke-old through
 `POST /api/bot-tokens/{token_id}/revoke`.
+
+## Setup Codes
+
+Setup codes hand a token to an installer without the plaintext ever passing
+through a clipboard or shell history. A setup code is a pending token grant:
+`POST /api/workspaces/{workspace_id}/bots/{bot_user_id}/setup-codes` (same
+authorization as token creation, human session required) returns a one-time
+plaintext code (`XXXX-XXXX-XXXX`, 10-minute expiry) while storing only its
+hash. No bot token exists yet.
+
+The installer claims the code with the unauthenticated, rate-limited
+`POST /api/bot-setup-codes/claim` (`{"code": "XXXX-XXXX-XXXX"}`). The claim
+atomically consumes the code and mints the bot token at that moment,
+returning `{bot_token, bot, workspace}` with the one-time raw token and the
+context needed to write installer configuration. Codes are single use;
+unknown, expired, and already-claimed codes all answer with the same `404`.
+Re-minting a code for the same bot and token name replaces the pending code,
+and removing or deleting the bot invalidates its pending codes. An expired,
+unclaimed code never creates a token.
 
 ## Command Menus
 

--- a/docs/features/bots.md
+++ b/docs/features/bots.md
@@ -264,8 +264,9 @@ hash. No bot token exists yet.
 The installer claims the code with the unauthenticated, rate-limited
 `POST /api/bot-setup-codes/claim` (`{"code": "XXXX-XXXX-XXXX"}`). The claim
 atomically consumes the code and mints the bot token at that moment,
-returning `{bot_token, bot, workspace}` with the one-time raw token and the
-context needed to write installer configuration. Codes are single use;
+returning `{token, bot, workspace, defaults}` with the one-time raw token,
+minimal bot and workspace identity, and a suggested `defaultTo` channel when
+one exists. Codes are single use;
 unknown, expired, and already-claimed codes all answer with the same `404`.
 Re-minting a code for the same bot and token name replaces the pending code,
 and removing or deleting the bot invalidates its pending codes. An expired,

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -1967,14 +1967,45 @@ components:
           description: Setup code. Case-insensitive; separators are ignored.
     BotSetupCodeClaimResponse:
       type: object
-      required: [bot_token, bot, workspace]
+      required: [token, bot, workspace, defaults]
       properties:
-        bot_token:
-          $ref: "#/components/schemas/BotToken"
+        token:
+          type: string
+          description: One-time plaintext bot token minted by this claim.
         bot:
-          $ref: "#/components/schemas/User"
+          $ref: "#/components/schemas/BotSetupCodeClaimBot"
         workspace:
-          $ref: "#/components/schemas/Workspace"
+          $ref: "#/components/schemas/BotSetupCodeClaimWorkspace"
+        defaults:
+          $ref: "#/components/schemas/BotSetupCodeClaimDefaults"
+    BotSetupCodeClaimBot:
+      type: object
+      required: [id, handle, display_name]
+      properties:
+        id:
+          type: string
+        handle:
+          type: string
+        display_name:
+          type: string
+    BotSetupCodeClaimWorkspace:
+      type: object
+      required: [id, route_id, slug, name]
+      properties:
+        id:
+          type: string
+        route_id:
+          type: string
+        slug:
+          type: string
+        name:
+          type: string
+    BotSetupCodeClaimDefaults:
+      type: object
+      properties:
+        defaultTo:
+          type: string
+          description: Suggested OpenClaw outbound target, such as channel:general. Omitted when the workspace has no active channels.
     AppInstallation:
       type: object
       required: [id, workspace_id, app_slug, display_name, bot_user_id, config, created_at]

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -605,6 +605,53 @@ paths:
                 $ref: "#/components/schemas/BotTokenResponse"
         "403":
           description: Service bot tokens require a workspace manager. User-owned bot tokens require the bot owner.
+  /api/workspaces/{workspace_id}/bots/{bot_user_id}/setup-codes:
+    post:
+      operationId: createWorkspaceBotSetupCode
+      summary: Mint a short-lived single-use setup code that defers bot token creation to claim time
+      parameters:
+        - $ref: "#/components/parameters/workspace_id"
+        - name: bot_user_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateBotSetupCodeRequest"
+      responses:
+        "201":
+          description: Pending setup code. The plaintext code is returned once and only its hash is stored. No bot token exists until the code is claimed. Re-minting for the same bot and token name replaces any pending code.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotSetupCodeResponse"
+        "403":
+          description: Service bot setup codes require a workspace manager. User-owned bot setup codes require the bot owner. Bot tokens are rejected.
+  /api/bot-setup-codes/claim:
+    post:
+      operationId: claimBotSetupCode
+      summary: Claim a setup code, minting the bot token at claim time
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimBotSetupCodeRequest"
+      responses:
+        "200":
+          description: Setup code claimed. The minted one-time raw token and installer context are returned. Codes are single use.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BotSetupCodeClaimResponse"
+        "404":
+          description: Unknown, expired, or already claimed code. The response is deliberately uniform.
+        "429":
+          description: Too many claim attempts from this address.
   /api/bots/{bot_user_id}:
     delete:
       operationId: deleteBot
@@ -1867,6 +1914,67 @@ components:
           minLength: 16
           maxLength: 128
           description: Retry key for integration setup. Replays reuse the same token row while returning a fresh raw token.
+    CreateBotSetupCodeRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Token name captured at mint time. Defaults to "default".
+        scopes:
+          type: array
+          items:
+            type: string
+          description: Scopes captured and validated at mint time.
+    BotSetupCode:
+      type: object
+      required: [id, bot_user_id, workspace_id, token_name, scopes, created_at, expires_at]
+      properties:
+        id:
+          type: string
+        bot_user_id:
+          type: string
+        workspace_id:
+          type: string
+        token_name:
+          type: string
+        scopes:
+          type: array
+          items:
+            type: string
+        created_by:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        expires_at:
+          type: string
+          format: date-time
+        code:
+          type: string
+          description: One-time plaintext setup code (XXXX-XXXX-XXXX). Present only in the mint response; only a hash is stored.
+    BotSetupCodeResponse:
+      type: object
+      required: [setup_code]
+      properties:
+        setup_code:
+          $ref: "#/components/schemas/BotSetupCode"
+    ClaimBotSetupCodeRequest:
+      type: object
+      required: [code]
+      properties:
+        code:
+          type: string
+          description: Setup code. Case-insensitive; separators are ignored.
+    BotSetupCodeClaimResponse:
+      type: object
+      required: [bot_token, bot, workspace]
+      properties:
+        bot_token:
+          $ref: "#/components/schemas/BotToken"
+        bot:
+          $ref: "#/components/schemas/User"
+        workspace:
+          $ref: "#/components/schemas/Workspace"
     AppInstallation:
       type: object
       required: [id, workspace_id, app_slug, display_name, bot_user_id, config, created_at]

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -408,6 +408,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/workspaces/{workspace_id}/bots/{bot_user_id}/setup-codes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Mint a short-lived single-use setup code that defers bot token creation to claim time */
+    post: operations["createWorkspaceBotSetupCode"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/bot-setup-codes/claim": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Claim a setup code, minting the bot token at claim time */
+    post: operations["claimBotSetupCode"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/bots/{bot_user_id}": {
     parameters: {
       query?: never;
@@ -1214,6 +1248,38 @@ export interface components {
       scopes?: string[];
       /** @description Retry key for integration setup. Replays reuse the same token row while returning a fresh raw token. */
       setup_nonce?: string;
+    };
+    CreateBotSetupCodeRequest: {
+      /** @description Token name captured at mint time. Defaults to "default". */
+      name?: string;
+      /** @description Scopes captured and validated at mint time. */
+      scopes?: string[];
+    };
+    BotSetupCode: {
+      id: string;
+      bot_user_id: string;
+      workspace_id: string;
+      token_name: string;
+      scopes: string[];
+      created_by?: string;
+      /** Format: date-time */
+      created_at: string;
+      /** Format: date-time */
+      expires_at: string;
+      /** @description One-time plaintext setup code (XXXX-XXXX-XXXX). Present only in the mint response; only a hash is stored. */
+      code?: string;
+    };
+    BotSetupCodeResponse: {
+      setup_code: components["schemas"]["BotSetupCode"];
+    };
+    ClaimBotSetupCodeRequest: {
+      /** @description Setup code. Case-insensitive; separators are ignored. */
+      code: string;
+    };
+    BotSetupCodeClaimResponse: {
+      bot_token: components["schemas"]["BotToken"];
+      bot: components["schemas"]["User"];
+      workspace: components["schemas"]["Workspace"];
     };
     AppInstallation: {
       id: string;
@@ -2779,6 +2845,78 @@ export interface operations {
       };
     };
   };
+  createWorkspaceBotSetupCode: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspace_id: components["parameters"]["workspace_id"];
+        bot_user_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateBotSetupCodeRequest"];
+      };
+    };
+    responses: {
+      /** @description Pending setup code. The plaintext code is returned once and only its hash is stored. No bot token exists until the code is claimed. Re-minting for the same bot and token name replaces any pending code. */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["BotSetupCodeResponse"];
+        };
+      };
+      /** @description Service bot setup codes require a workspace manager. User-owned bot setup codes require the bot owner. Bot tokens are rejected. */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  claimBotSetupCode: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ClaimBotSetupCodeRequest"];
+      };
+    };
+    responses: {
+      /** @description Setup code claimed. The minted one-time raw token and installer context are returned. Codes are single use. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["BotSetupCodeClaimResponse"];
+        };
+      };
+      /** @description Unknown, expired, or already claimed code. The response is deliberately uniform. */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Too many claim attempts from this address. */
+      429: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   deleteBot: {
     parameters: {
       query?: never;
@@ -3835,7 +3973,7 @@ export interface operations {
         };
         content?: never;
       };
-      /** @description Required scope, workspace binding, or conversation access is missing */
+      /** @description Bot token lacks messages:read, the requested workspace binding, or dms:read for direct-conversation search. */
       403: {
         headers: {
           [name: string]: unknown;

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -1277,9 +1277,26 @@ export interface components {
       code: string;
     };
     BotSetupCodeClaimResponse: {
-      bot_token: components["schemas"]["BotToken"];
-      bot: components["schemas"]["User"];
-      workspace: components["schemas"]["Workspace"];
+      /** @description One-time plaintext bot token minted by this claim. */
+      token: string;
+      bot: components["schemas"]["BotSetupCodeClaimBot"];
+      workspace: components["schemas"]["BotSetupCodeClaimWorkspace"];
+      defaults: components["schemas"]["BotSetupCodeClaimDefaults"];
+    };
+    BotSetupCodeClaimBot: {
+      id: string;
+      handle: string;
+      display_name: string;
+    };
+    BotSetupCodeClaimWorkspace: {
+      id: string;
+      route_id: string;
+      slug: string;
+      name: string;
+    };
+    BotSetupCodeClaimDefaults: {
+      /** @description Suggested OpenClaw outbound target, such as channel:general. Omitted when the workspace has no active channels. */
+      defaultTo?: string;
     };
     AppInstallation: {
       id: string;

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -38,6 +38,25 @@ export type BotWithTokens = {
   tokens: BotToken[];
 };
 
+export type BotSetupCode = {
+  id: string;
+  bot_user_id: string;
+  workspace_id: string;
+  token_name: string;
+  scopes: string[];
+  created_by?: string;
+  created_at: string;
+  expires_at: string;
+  /** One-time plaintext setup code. Present only in the mint response. */
+  code?: string;
+};
+
+export type BotSetupCodeClaim = {
+  bot_token: BotToken;
+  bot: User;
+  workspace: Workspace;
+};
+
 export type BotCommandInput = {
   command: string;
   description: string;
@@ -602,6 +621,26 @@ export class ClickClackClient {
         },
       );
       return data.bot_token;
+    },
+    createSetupCode: async (
+      workspaceId: string,
+      botUserId: string,
+      input: { name?: string; scopes?: string[] } = {},
+    ): Promise<BotSetupCode> => {
+      const data = await this.request<{ setup_code: BotSetupCode }>(
+        `/api/workspaces/${workspaceId}/bots/${botUserId}/setup-codes`,
+        {
+          method: "POST",
+          body: JSON.stringify(input),
+        },
+      );
+      return data.setup_code;
+    },
+    claimSetupCode: async (code: string): Promise<BotSetupCodeClaim> => {
+      return this.request(`/api/bot-setup-codes/claim`, {
+        method: "POST",
+        body: JSON.stringify({ code }),
+      });
     },
   };
 

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -52,9 +52,21 @@ export type BotSetupCode = {
 };
 
 export type BotSetupCodeClaim = {
-  bot_token: BotToken;
-  bot: User;
-  workspace: Workspace;
+  token: string;
+  bot: {
+    id: string;
+    handle: string;
+    display_name: string;
+  };
+  workspace: {
+    id: string;
+    route_id: string;
+    slug: string;
+    name: string;
+  };
+  defaults: {
+    defaultTo?: string;
+  };
 };
 
 export type BotCommandInput = {


### PR DESCRIPTION
## Summary

- add short-lived, single-use bot setup codes that store only a hash and mint the bot token atomically at claim time
- add human-only setup-code minting, unauthenticated rate-limited claiming, audit entries, and lifecycle cleanup
- expose the contract through OpenAPI, the TypeScript SDK, deployment configuration, and operator documentation

## Review fixes

- return the minimal claim response with a stable default-channel suggestion
- bound the in-memory limiter and trust forwarded identity only through the documented loopback proxy contract
- serialize claims, bot removal, and workspace deletion through the PostgreSQL bot lifecycle lock order

## Verification

- `pnpm check`
- `pnpm coverage` (85.3% total)
- repeated SQLite and HTTP setup-code tests
- sqlc and OpenAPI regeneration with a clean tree
- AWS Crabbox `cbx_8edf89f811ef`: PostgreSQL setup-code and lifecycle concurrency tests passed; `nginx -t` passed
