### PR TITLE
feat: add integration history helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Proxied WebSocket upgrades in the Vite dev server so the local app connects to realtime instead of looping on "Reconnecting…".
 - Added a bounded read-only artifact pane for code, text, Markdown, PDF, and sandboxed HTML attachments, while keeping DOCX download-only and preserving thread routes when the pane closes. Thanks @jjjhenriksen.
 - Added an opt-in realtime tail cursor so fresh clients can skip retained history without racing new events, and applied read-receipt visibility before event pagination. Thanks @shakkernerd.
+- Added SDK helpers for paginated realtime recovery and bounded latest thread-history windows. Thanks @arcabotai for surfacing the integration needs.
 - Preserved validated request correlation IDs as optional metadata on durable message and thread-reply events across replay and realtime delivery, and added canary run/case evidence IDs without changing message storage or gateway traffic.
 - Added an isolated FakeCo small-VM deployment path with idempotent synthetic chat seed data, OpenClaw and ClawRouter SecretRef configuration, correlated health/readiness and metadata-only telemetry, a quoted-reply end-to-end canary, tests, and teardown guidance.
 

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1046,7 +1046,21 @@ func (s *Server) getThread(w http.ResponseWriter, r *http.Request) {
 	if _, ok := s.requireBotMessageResource(w, r, act, chi.URLParam(r, "message_id"), "dms:read"); !ok {
 		return
 	}
-	root, replies, state, err := s.store.GetThread(r.Context(), chi.URLParam(r, "message_id"), act.user.ID, queryInt(r, "limit", 100))
+	messageID := chi.URLParam(r, "message_id")
+	limit := queryInt(r, "limit", 100)
+	latest := strings.TrimSpace(r.URL.Query().Get("latest"))
+	if latest != "" && latest != "true" && latest != "false" {
+		writeError(w, http.StatusBadRequest, errors.New("latest must be true or false"))
+		return
+	}
+	var root store.Message
+	var replies []store.Message
+	var state store.ThreadState
+	if latest == "true" {
+		root, replies, state, err = s.store.GetThreadLatest(r.Context(), messageID, act.user.ID, limit)
+	} else {
+		root, replies, state, err = s.store.GetThread(r.Context(), messageID, act.user.ID, limit)
+	}
 	writeResult(w, map[string]any{"root": root, "replies": replies, "thread_state": state}, err)
 }
 

--- a/apps/api/internal/httpapi/thread_windows_test.go
+++ b/apps/api/internal/httpapi/thread_windows_test.go
@@ -1,0 +1,65 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestThreadLatestWindowHTTP(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Thread Owner", "thread-http-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: owner.ID, Body: "root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 1; index <= 5; index++ {
+		if _, _, _, err := st.CreateThreadReply(ctx, store.CreateThreadReplyInput{
+			RootMessageID: root.ID,
+			AuthorID:      owner.ID,
+			Body:          fmt.Sprintf("reply-%d", index),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	thread := getJSON[struct {
+		Replies     []store.Message   `json:"replies"`
+		ThreadState store.ThreadState `json:"thread_state"`
+	}](t, server.URL+"/api/messages/"+url.PathEscape(root.ID)+"/thread?latest=true&limit=2")
+	if thread.ThreadState.ReplyCount != 5 || len(thread.Replies) != 2 || thread.Replies[0].Body != "reply-4" || thread.Replies[1].Body != "reply-5" {
+		t.Fatalf("unexpected latest HTTP thread window: %#v", thread)
+	}
+	expectStatus(t, http.MethodGet, server.URL+"/api/messages/"+url.PathEscape(root.ID)+"/thread?latest=maybe", nil, http.StatusBadRequest)
+}

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -636,6 +637,14 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 }
 
 func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, limit int) (store.Message, []store.Message, store.ThreadState, error) {
+	return s.getThread(ctx, rootMessageID, userID, limit, false)
+}
+
+func (s *Store) GetThreadLatest(ctx context.Context, rootMessageID, userID string, limit int) (store.Message, []store.Message, store.ThreadState, error) {
+	return s.getThread(ctx, rootMessageID, userID, limit, true)
+}
+
+func (s *Store) getThread(ctx context.Context, rootMessageID, userID string, limit int, latest bool) (store.Message, []store.Message, store.ThreadState, error) {
 	if limit <= 0 || limit > 200 {
 		limit = 100
 	}
@@ -658,9 +667,13 @@ func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, lim
 		return store.Message{}, nil, store.ThreadState{}, err
 	}
 	root = roots[0]
+	order := "ASC"
+	if latest {
+		order = "DESC"
+	}
 	rows, err := s.db.QueryContext(ctx, messageSelect()+`
 		WHERE m.thread_root_id = $1 AND m.parent_message_id = $2
-		ORDER BY m.thread_seq
+		ORDER BY m.thread_seq `+order+`
 		LIMIT $3`, rootMessageID, rootMessageID, limit)
 	if err != nil {
 		return store.Message{}, nil, store.ThreadState{}, err
@@ -669,6 +682,9 @@ func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, lim
 	replies, err := scanMessages(rows)
 	if err != nil {
 		return store.Message{}, nil, store.ThreadState{}, err
+	}
+	if latest {
+		slices.Reverse(replies)
 	}
 	replies, err = s.hydrateAttachments(ctx, replies)
 	if err != nil {

--- a/apps/api/internal/store/postgres/thread_windows_test.go
+++ b/apps/api/internal/store/postgres/thread_windows_test.go
@@ -1,0 +1,50 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Thread Owner", "postgres-thread-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: owner.ID, Body: "root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 1; index <= 5; index++ {
+		if _, _, _, err := st.CreateThreadReply(ctx, store.CreateThreadReplyInput{
+			RootMessageID: root.ID,
+			AuthorID:      owner.ID,
+			Body:          fmt.Sprintf("reply-%d", index),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, latest, state, err := st.GetThreadLatest(ctx, root.ID, owner.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ReplyCount != 5 || len(latest) != 2 || latest[0].Body != "reply-4" || latest[1].Body != "reply-5" {
+		t.Fatalf("unexpected latest thread window: state=%#v replies=%#v", state, latest)
+	}
+}

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -650,6 +651,14 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 }
 
 func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, limit int) (store.Message, []store.Message, store.ThreadState, error) {
+	return s.getThread(ctx, rootMessageID, userID, limit, false)
+}
+
+func (s *Store) GetThreadLatest(ctx context.Context, rootMessageID, userID string, limit int) (store.Message, []store.Message, store.ThreadState, error) {
+	return s.getThread(ctx, rootMessageID, userID, limit, true)
+}
+
+func (s *Store) getThread(ctx context.Context, rootMessageID, userID string, limit int, latest bool) (store.Message, []store.Message, store.ThreadState, error) {
 	if limit <= 0 || limit > 200 {
 		limit = 100
 	}
@@ -672,9 +681,13 @@ func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, lim
 		return store.Message{}, nil, store.ThreadState{}, err
 	}
 	root = roots[0]
+	order := "ASC"
+	if latest {
+		order = "DESC"
+	}
 	rows, err := s.db.QueryContext(ctx, messageSelect()+`
 		WHERE m.thread_root_id = ? AND m.parent_message_id = ?
-		ORDER BY m.thread_seq
+		ORDER BY m.thread_seq `+order+`
 		LIMIT ?`, rootMessageID, rootMessageID, limit)
 	if err != nil {
 		return store.Message{}, nil, store.ThreadState{}, err
@@ -683,6 +696,9 @@ func (s *Store) GetThread(ctx context.Context, rootMessageID, userID string, lim
 	replies, err := scanMessages(rows)
 	if err != nil {
 		return store.Message{}, nil, store.ThreadState{}, err
+	}
+	if latest {
+		slices.Reverse(replies)
 	}
 	replies, err = s.hydrateAttachments(ctx, replies)
 	if err != nil {

--- a/apps/api/internal/store/sqlite/thread_windows_test.go
+++ b/apps/api/internal/store/sqlite/thread_windows_test.go
@@ -1,0 +1,55 @@
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, err := st.EnsureBootstrap(ctx, "Thread Owner", "thread-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: owner.ID, Body: "root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 1; index <= 5; index++ {
+		if _, _, _, err := st.CreateThreadReply(ctx, store.CreateThreadReplyInput{
+			RootMessageID: root.ID,
+			AuthorID:      owner.ID,
+			Body:          fmt.Sprintf("reply-%d", index),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	_, first, _, err := st.GetThread(ctx, root.ID, owner.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first[0].Body != "reply-1" || first[1].Body != "reply-2" {
+		t.Fatalf("expected earliest replies, got %#v", first)
+	}
+	_, latest, state, err := st.GetThreadLatest(ctx, root.ID, owner.ID, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.ReplyCount != 5 || len(latest) != 2 || latest[0].Body != "reply-4" || latest[1].Body != "reply-5" {
+		t.Fatalf("unexpected latest thread window: state=%#v replies=%#v", state, latest)
+	}
+}

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -1043,6 +1043,7 @@ type Store interface {
 	UpdateMessage(ctx context.Context, input UpdateMessageInput) (Message, Event, error)
 	DeleteMessage(ctx context.Context, input DeleteMessageInput) (Message, Event, error)
 	GetThread(ctx context.Context, rootMessageID, userID string, limit int) (Message, []Message, ThreadState, error)
+	GetThreadLatest(ctx context.Context, rootMessageID, userID string, limit int) (Message, []Message, ThreadState, error)
 	CreateThreadReply(ctx context.Context, input CreateThreadReplyInput) (Message, ThreadState, []Event, error)
 	AddReaction(ctx context.Context, input CreateReactionInput) (Event, error)
 	RemoveReaction(ctx context.Context, input CreateReactionInput) (Event, error)

--- a/docs/features/threads.md
+++ b/docs/features/threads.md
@@ -65,8 +65,10 @@ subscribers via the realtime hub.
 ## Ordering and pagination
 
 Replies are ordered by `thread_seq` ascending. `limit` is clamped to `1..200`
-(default 100). There's no `after_seq` parameter on the thread endpoint yet —
-clients fetch the head of the thread and use realtime events for new replies.
+(default 100). By default clients fetch the earliest replies. Passing
+`latest=true` returns the latest bounded window, still in ascending order. There
+is no general `after_seq` pagination parameter yet; clients use realtime events
+for new replies.
 
 ## What is intentionally missing
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -80,9 +80,23 @@ See [features/auth.md](features/auth.md).
 | `search(workspaceId, q, options?)` | paginated workspace, channel, or direct-message search |
 | `uploads`     | `create(workspaceId, file, filename?, { nonce? })`, `findByNonce(workspaceId, nonce)`, `attach(messageId, uploadId)` |
 | `dms`         | `list`, `create`, `get`, `close`, `open`, `messages`, `sendMessage`, `markRead` |
-| `events`      | `publishEphemeral`, `subscribe` |
+| `events`      | `list`, `publishEphemeral`, `subscribe` |
 
 ## Realtime subscription
+
+Capture the current tail or drain a bounded backlog through the same client:
+
+```ts
+const initial = await client.events.list({ workspaceId, includeTail: true });
+const page = await client.events.list({
+  workspaceId,
+  afterCursor: initial.tailCursor,
+  limit: 500,
+});
+```
+
+`tailCursor` is captured before the initial page query, so events created during
+startup remain eligible for the following WebSocket subscription.
 
 ```ts
 const socket = client.events.subscribe({

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -1153,6 +1153,20 @@ paths:
       operationId: getThread
       parameters:
         - $ref: "#/components/parameters/message_id"
+        - name: limit
+          in: query
+          description: Maximum number of replies to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 100
+        - name: latest
+          in: query
+          description: Return the latest bounded reply window in chronological order instead of the earliest window.
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: Thread root and replies

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -3771,7 +3771,12 @@ export interface operations {
   };
   getThread: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description Maximum number of replies to return. */
+        limit?: number;
+        /** @description Return the latest bounded reply window in chronological order instead of the earliest window. */
+        latest?: boolean;
+      };
       header?: never;
       path: {
         message_id: components["parameters"]["message_id"];

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -403,6 +403,24 @@ export type RealtimeEvent = {
   payload: RealtimeEventPayload;
 };
 
+export type RealtimeEventPage = {
+  events: RealtimeEvent[];
+  tailCursor?: string;
+};
+
+export type ThreadState = {
+  root_message_id: string;
+  reply_count: number;
+  last_reply_at?: string;
+  last_reply_author_ids: string[];
+};
+
+export type Thread = {
+  root: Message;
+  replies: Message[];
+  thread_state: ThreadState;
+};
+
 export type ClickClackClientOptions = {
   baseUrl: string;
   userId?: string;
@@ -956,8 +974,15 @@ export class ClickClackClient {
   };
 
   threads = {
-    get: async (messageId: string) => {
-      return this.request(`/api/messages/${messageId}/thread`);
+    get: async (
+      messageId: string,
+      options: { limit?: number; latest?: boolean } = {},
+    ): Promise<Thread> => {
+      const params = new URLSearchParams();
+      if (options.limit !== undefined) params.set("limit", String(options.limit));
+      if (options.latest !== undefined) params.set("latest", String(options.latest));
+      const query = params.size > 0 ? `?${params.toString()}` : "";
+      return this.request<Thread>(`/api/messages/${messageId}/thread${query}`);
     },
     reply: async (
       messageId: string,
@@ -1087,6 +1112,24 @@ export class ClickClackClient {
   };
 
   events = {
+    list: async (input: {
+      workspaceId: string;
+      afterCursor?: string;
+      limit?: number;
+      includeTail?: boolean;
+    }): Promise<RealtimeEventPage> => {
+      const params = new URLSearchParams({ workspace_id: input.workspaceId });
+      if (input.afterCursor) params.set("after_cursor", input.afterCursor);
+      if (input.limit !== undefined) params.set("limit", String(input.limit));
+      if (input.includeTail) params.set("include_tail", "true");
+      const data = await this.request<{ events: RealtimeEvent[]; tail_cursor?: string }>(
+        `/api/realtime/events?${params.toString()}`,
+      );
+      return {
+        events: data.events,
+        ...(data.tail_cursor !== undefined ? { tailCursor: data.tail_cursor } : {}),
+      };
+    },
     publishEphemeral: async (input: {
       workspaceId: string;
       channelId?: string;


### PR DESCRIPTION
## Summary

- expose bounded durable-event pagination through `client.events.list`
- add `latest=true` thread windows across SQLite, Postgres, HTTP, OpenAPI, and the TypeScript SDK
- keep latest thread replies in chronological order
- document both framework-neutral integration helpers

This extracts the reusable integration capabilities surfaced by https://github.com/openclaw/clickclack/pull/78. Thanks @arcabotai for identifying the need and for the original implementation direction.

## Proof

- focused SQLite, Postgres, HTTP, SDK build, and SDK typecheck — pass
- `pnpm check` — pass
- `pnpm coverage` — 85.3%
- `pnpm test:e2e` — 98 passed
- `pnpm audit --audit-level=high` — no known vulnerabilities
- `govulncheck ./...` — no vulnerabilities
- real built Go server plus real built TypeScript SDK — created five thread replies, fetched replies 4–5 with `latest=true&limit=2`, observed reply count 5, fetched a two-event durable page, and received the captured tail cursor
- AutoReview — clean, no accepted/actionable findings
- public model identifier gate — PASS
