### PR TITLE
feat: Cloudflare Access trusted-proxy SSO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.2.1 - Unreleased
 
+- Added optional Cloudflare Access trusted-proxy SSO with pinned-team JWKS verification, automatic workspace provisioning, and normal ClickClack sessions.
 - Added externally managed channel identity and deep links, archive-aware and sectioned sidebar groups, archive event metadata, and a live standalone channel embed.
+||||||| parent of 16e3912 (feat(api): add Cloudflare Access SSO)
 - Fixed the thread reply composer send button sitting mid-row instead of flush right in thread panels and embeds.
 - Added a standalone, live-updating, cookie-authenticated thread embed with the shared thread composer and rendering, public route IDs, focused auth recovery, and an opt-in per-origin `/embed/*` frame policy.
 - Signed and notarized macOS desktop release bundles with the OpenClaw Foundation identity, hardened runtime, and strict sealed-artifact verification.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Added optional Cloudflare Access trusted-proxy SSO with pinned-team JWKS verification, automatic workspace provisioning, and normal ClickClack sessions.
 - Added externally managed channel identity and deep links, archive-aware and sectioned sidebar groups, archive event metadata, and a live standalone channel embed.
-||||||| parent of 16e3912 (feat(api): add Cloudflare Access SSO)
 - Fixed the thread reply composer send button sitting mid-row instead of flush right in thread panels and embeds.
 - Added a standalone, live-updating, cookie-authenticated thread embed with the shared thread composer and rendering, public route IDs, focused auth recovery, and an opt-in per-origin `/embed/*` frame policy.
 - Signed and notarized macOS desktop release bundles with the OpenClaw Foundation identity, hardened runtime, and strict sealed-artifact verification.

--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -88,6 +88,8 @@ func serve(args []string) error {
 	flags.Bool("dev-bootstrap", false, "create a local owner/workspace/channel if no user exists")
 	flags.Bool("metrics-enabled", false, "expose metadata-only Prometheus metrics at /metrics")
 	flags.String("embed-frame-ancestors", "", "comma-separated origins allowed to embed /embed/* pages")
+	flags.String("access-team-domain", "", "Cloudflare Access team HTTPS origin")
+	flags.String("access-aud", "", "Cloudflare Access application audience tag")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
@@ -146,6 +148,10 @@ func serve(args []string) error {
 			PublicURL:    cfg.PublicURL,
 			AllowedOrg:   cfg.GitHubAllowedOrg,
 			ModeratorOrg: cfg.GitHubModeratorOrg,
+		},
+		Access: httpapi.AccessConfig{
+			TeamDomain: cfg.AccessTeamDomain,
+			Audience:   cfg.AccessAUD,
 		},
 		PushNotifier:   pushNotifier,
 		MetricsEnabled: cfg.MetricsEnabled,
@@ -586,6 +592,10 @@ func applyFlagOverrides(flags *flag.FlagSet, cfg *config.Config) {
 			cfg.MetricsEnabled = f.Value.String() == "true"
 		case "embed-frame-ancestors":
 			cfg.EmbedFrameAncestors = config.ParseEmbedFrameAncestors(f.Value.String())
+		case "access-team-domain":
+			cfg.AccessTeamDomain = f.Value.String()
+		case "access-aud":
+			cfg.AccessAUD = f.Value.String()
 		}
 	})
 }

--- a/apps/api/cmd/clickclack/main_test.go
+++ b/apps/api/cmd/clickclack/main_test.go
@@ -72,6 +72,20 @@ func TestApplyFlagOverridesParsesEmbedFrameAncestors(t *testing.T) {
 	}
 }
 
+func TestApplyFlagOverridesSetsAccessConfig(t *testing.T) {
+	flags := flag.NewFlagSet("test", flag.ContinueOnError)
+	flags.String("access-team-domain", "", "")
+	flags.String("access-aud", "", "")
+	if err := flags.Parse([]string{"--access-team-domain", "https://openclaw.cloudflareaccess.com", "--access-aud", "test-aud"}); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Config{}
+	applyFlagOverrides(flags, &cfg)
+	if cfg.AccessTeamDomain != "https://openclaw.cloudflareaccess.com" || cfg.AccessAUD != "test-aud" {
+		t.Fatalf("unexpected Access flag config: %#v", cfg)
+	}
+}
+
 func TestFakeCoSeedRequiresExplicitEnvironment(t *testing.T) {
 	t.Setenv("CLICKCLACK_ENVIRONMENT", "")
 	err := admin([]string{"fakeco", "seed", "--data", t.TempDir()})

--- a/apps/api/internal/config/access.go
+++ b/apps/api/internal/config/access.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
+)
+
+func normalizeAccessConfig(c *Config) error {
+	teamDomain := strings.TrimSpace(c.AccessTeamDomain)
+	audience := strings.TrimSpace(c.AccessAUD)
+	if (teamDomain != "") != (audience != "") {
+		return errors.New("CLICKCLACK_ACCESS_TEAM_DOMAIN and CLICKCLACK_ACCESS_AUD must be configured together")
+	}
+	if teamDomain != "" {
+		canonicalTeamDomain, err := authpolicy.CanonicalPublicURL(teamDomain)
+		if err != nil {
+			return fmt.Errorf("CLICKCLACK_ACCESS_TEAM_DOMAIN: %w", err)
+		}
+		parsedTeamDomain, err := url.Parse(canonicalTeamDomain)
+		if err != nil || parsedTeamDomain.Scheme != "https" {
+			return errors.New("CLICKCLACK_ACCESS_TEAM_DOMAIN must be an HTTPS origin")
+		}
+		teamDomain = canonicalTeamDomain
+	}
+	c.AccessTeamDomain = teamDomain
+	c.AccessAUD = audience
+	return nil
+}

--- a/apps/api/internal/config/config.go
+++ b/apps/api/internal/config/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	GitHubClientSecret  string   `json:"github_client_secret"`
 	GitHubAllowedOrg    string   `json:"github_allowed_org"`
 	GitHubModeratorOrg  string   `json:"github_moderator_org"`
+	AccessTeamDomain    string   `json:"access_team_domain"`
+	AccessAUD           string   `json:"access_aud"`
 	PushoverAPIToken    string   `json:"pushover_api_token"`
 	R2AccountID         string   `json:"r2_account_id"`
 	R2AccessKeyID       string   `json:"r2_access_key_id"`
@@ -109,6 +111,12 @@ func Load(path string) (Config, error) {
 	if env := os.Getenv("CLICKCLACK_GITHUB_MODERATOR_ORG"); env != "" {
 		cfg.GitHubModeratorOrg = env
 	}
+	if env := os.Getenv("CLICKCLACK_ACCESS_TEAM_DOMAIN"); env != "" {
+		cfg.AccessTeamDomain = env
+	}
+	if env := os.Getenv("CLICKCLACK_ACCESS_AUD"); env != "" {
+		cfg.AccessAUD = env
+	}
 	if env := os.Getenv("CLICKCLACK_PUSHOVER_API_TOKEN"); env != "" {
 		cfg.PushoverAPIToken = env
 	}
@@ -134,6 +142,9 @@ func Load(path string) (Config, error) {
 }
 
 func (c *Config) ValidateServe() error {
+	if err := normalizeAccessConfig(c); err != nil {
+		return err
+	}
 	namespace, err := authpolicy.ParseCookieNamespace(c.CookieNamespace)
 	if err != nil {
 		return fmt.Errorf("CLICKCLACK_COOKIE_NAMESPACE: %w", err)

--- a/apps/api/internal/config/config_test.go
+++ b/apps/api/internal/config/config_test.go
@@ -164,6 +164,10 @@ func TestValidateServe(t *testing.T) {
 		{"missing client secret", Config{PublicURL: "https://chat.example.com", GitHubClientID: "client"}},
 		{"oauth without public url", Config{GitHubClientID: "client", GitHubClientSecret: "secret"}},
 		{"org without oauth", Config{GitHubAllowedOrg: "openclaw"}},
+		{"access domain only", Config{AccessTeamDomain: "https://openclaw.cloudflareaccess.com"}},
+		{"access audience only", Config{AccessAUD: "test-aud"}},
+		{"access domain must use https", Config{AccessTeamDomain: "http://openclaw.cloudflareaccess.com", AccessAUD: "test-aud"}},
+		{"access domain must be an origin", Config{AccessTeamDomain: "https://openclaw.cloudflareaccess.com/path", AccessAUD: "test-aud"}},
 		{"invalid embed ancestor", Config{EmbedFrameAncestors: []string{"https://control.example.com/path"}}},
 		{"wildcard embed ancestor", Config{EmbedFrameAncestors: []string{"https://*.example.com"}}},
 	} {
@@ -172,5 +176,41 @@ func TestValidateServe(t *testing.T) {
 				t.Fatal("expected validation error")
 			}
 		})
+	}
+}
+
+func TestValidateAccessConfig(t *testing.T) {
+	t.Parallel()
+	cfg := Config{AccessTeamDomain: " https://OpenClaw.cloudflareaccess.com:443/ ", AccessAUD: " test-access-aud "}
+	if err := cfg.ValidateServe(); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccessTeamDomain != "https://openclaw.cloudflareaccess.com" || cfg.AccessAUD != "test-access-aud" {
+		t.Fatalf("unexpected validated Access config: %#v", cfg)
+	}
+}
+
+func TestLoadAccessConfigFromEnvironmentAndJSON(t *testing.T) {
+	t.Setenv("CLICKCLACK_ACCESS_TEAM_DOMAIN", "https://env.cloudflareaccess.com")
+	t.Setenv("CLICKCLACK_ACCESS_AUD", "test-env-aud")
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"access_team_domain":"https://file.cloudflareaccess.com","access_aud":"test-file-aud"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccessTeamDomain != "https://env.cloudflareaccess.com" || cfg.AccessAUD != "test-env-aud" {
+		t.Fatalf("environment did not override Access JSON config: %#v", cfg)
+	}
+	t.Setenv("CLICKCLACK_ACCESS_TEAM_DOMAIN", "")
+	t.Setenv("CLICKCLACK_ACCESS_AUD", "")
+	cfg, err = Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AccessTeamDomain != "https://file.cloudflareaccess.com" || cfg.AccessAUD != "test-file-aud" {
+		t.Fatalf("Access JSON config was not loaded: %#v", cfg)
 	}
 }

--- a/apps/api/internal/httpapi/access.go
+++ b/apps/api/internal/httpapi/access.go
@@ -1,0 +1,276 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	accessAssertionHeader = "Cf-Access-Jwt-Assertion"
+	accessJWKSPath        = "/cdn-cgi/access/certs"
+	accessFetchTimeout    = 5 * time.Second
+	accessDefaultCacheTTL = time.Hour
+	accessMaxCacheTTL     = 24 * time.Hour
+	accessMaxJWKSBytes    = 1 << 20
+	accessClockLeeway     = 30 * time.Second
+)
+
+type AccessConfig struct {
+	TeamDomain string
+	Audience   string
+	HTTPClient *http.Client
+	Now        func() time.Time
+}
+
+type accessVerifier struct {
+	teamDomain string
+	audience   string
+	httpClient *http.Client
+	now        func() time.Time
+
+	mu      sync.Mutex
+	keys    map[string]*rsa.PublicKey
+	expires time.Time
+}
+
+type accessClaims struct {
+	Email      string `json:"email"`
+	Name       string `json:"name"`
+	CommonName string `json:"common_name"`
+	jwt.RegisteredClaims
+}
+
+type accessJWKS struct {
+	Keys []accessJWK `json:"keys"`
+}
+
+type accessJWK struct {
+	Kid string `json:"kid"`
+	Kty string `json:"kty"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+type accessResponseWriterContextKey struct{}
+
+func newAccessVerifier(config AccessConfig) *accessVerifier {
+	teamDomain := strings.TrimSpace(config.TeamDomain)
+	audience := strings.TrimSpace(config.Audience)
+	parsed, err := url.Parse(teamDomain)
+	if err != nil || audience == "" || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil ||
+		(parsed.Path != "" && parsed.Path != "/") || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return nil
+	}
+	teamDomain = strings.TrimSuffix(teamDomain, "/")
+	client := config.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if clientCopy.Timeout == 0 || clientCopy.Timeout > accessFetchTimeout {
+		clientCopy.Timeout = accessFetchTimeout
+	}
+	now := config.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &accessVerifier{
+		teamDomain: teamDomain,
+		audience:   audience,
+		httpClient: &clientCopy,
+		now:        now,
+	}
+}
+
+func bindAccessResponseWriter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), accessResponseWriterContextKey{}, w)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func accessResponseWriter(r *http.Request) (http.ResponseWriter, bool) {
+	w, ok := r.Context().Value(accessResponseWriterContextKey{}).(http.ResponseWriter)
+	return w, ok
+}
+
+func (s *Server) accessActor(r *http.Request, assertion string) (actor, error) {
+	claims, err := s.access.verify(r.Context(), assertion)
+	if err != nil {
+		return actor{}, err
+	}
+	displayName := firstNonEmpty(strings.TrimSpace(claims.Name), strings.TrimSpace(claims.CommonName), claims.Email)
+	user, err := s.store.GetOrCreateUserByEmail(r.Context(), "cloudflare-access", claims.Email, displayName)
+	if err != nil {
+		return actor{}, err
+	}
+	if _, err := s.store.EnsureDefaultWorkspaceMember(r.Context(), user.ID); err != nil {
+		return actor{}, err
+	}
+	session, err := s.store.CreateSession(r.Context(), user.ID)
+	if err != nil {
+		return actor{}, err
+	}
+	w, ok := accessResponseWriter(r)
+	if ok {
+		s.setSessionCookie(w, r, session)
+	}
+	return actor{user: user}, nil
+}
+
+func (v *accessVerifier) verify(ctx context.Context, assertion string) (accessClaims, error) {
+	claims := accessClaims{}
+	token, err := jwt.ParseWithClaims(strings.TrimSpace(assertion), &claims, v.keyFunc(ctx),
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+		jwt.WithIssuer(v.teamDomain),
+		jwt.WithAudience(v.audience),
+		jwt.WithExpirationRequired(),
+		jwt.WithIssuedAt(),
+		jwt.WithLeeway(accessClockLeeway),
+		jwt.WithTimeFunc(v.now),
+	)
+	if err != nil || !token.Valid {
+		return accessClaims{}, errors.New("invalid access assertion")
+	}
+	claims.Email = strings.ToLower(strings.TrimSpace(claims.Email))
+	if claims.IssuedAt == nil || claims.Email == "" {
+		return accessClaims{}, errors.New("invalid access assertion")
+	}
+	return claims, nil
+}
+
+func (v *accessVerifier) keyFunc(ctx context.Context) jwt.Keyfunc {
+	return func(token *jwt.Token) (any, error) {
+		kid, ok := token.Header["kid"].(string)
+		if !ok || strings.TrimSpace(kid) == "" {
+			return nil, errors.New("access assertion key ID missing")
+		}
+		return v.key(ctx, kid)
+	}
+}
+
+func (v *accessVerifier) key(ctx context.Context, kid string) (*rsa.PublicKey, error) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	now := v.now()
+	if now.Before(v.expires) {
+		if key := v.keys[kid]; key != nil {
+			return key, nil
+		}
+	}
+	keys, expires, err := v.fetchKeys(ctx, now)
+	if err != nil {
+		return nil, err
+	}
+	v.keys = keys
+	v.expires = expires
+	key := keys[kid]
+	if key == nil {
+		return nil, errors.New("access assertion key not found")
+	}
+	return key, nil
+}
+
+func (v *accessVerifier) fetchKeys(ctx context.Context, now time.Time) (map[string]*rsa.PublicKey, time.Time, error) {
+	ctx, cancel := context.WithTimeout(ctx, accessFetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, v.teamDomain+accessJWKSPath, nil)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, time.Time{}, fmt.Errorf("access key endpoint returned HTTP %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, accessMaxJWKSBytes+1))
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	if len(body) > accessMaxJWKSBytes {
+		return nil, time.Time{}, errors.New("access key response is too large")
+	}
+	var set accessJWKS
+	if err := json.Unmarshal(body, &set); err != nil {
+		return nil, time.Time{}, err
+	}
+	keys := make(map[string]*rsa.PublicKey, len(set.Keys))
+	for _, encoded := range set.Keys {
+		key, err := encoded.rsaPublicKey()
+		if err != nil {
+			continue
+		}
+		if _, duplicate := keys[encoded.Kid]; duplicate {
+			return nil, time.Time{}, errors.New("access key endpoint returned a duplicate key ID")
+		}
+		keys[encoded.Kid] = key
+	}
+	if len(keys) == 0 {
+		return nil, time.Time{}, errors.New("access key endpoint returned no usable RSA keys")
+	}
+	return keys, accessCacheExpiry(resp.Header, now), nil
+}
+
+func (j accessJWK) rsaPublicKey() (*rsa.PublicKey, error) {
+	if strings.TrimSpace(j.Kid) == "" || j.Kty != "RSA" || (j.Alg != "" && j.Alg != "RS256") || (j.Use != "" && j.Use != "sig") {
+		return nil, errors.New("unsupported access key")
+	}
+	modulus, err := base64.RawURLEncoding.DecodeString(j.N)
+	if err != nil || len(modulus) == 0 {
+		return nil, errors.New("invalid access key modulus")
+	}
+	exponentBytes, err := base64.RawURLEncoding.DecodeString(j.E)
+	if err != nil || len(exponentBytes) == 0 || len(exponentBytes) > 4 {
+		return nil, errors.New("invalid access key exponent")
+	}
+	exponent := new(big.Int).SetBytes(exponentBytes)
+	if !exponent.IsInt64() || exponent.Int64() < 3 || exponent.Int64() > int64(^uint(0)>>1) || exponent.Int64()%2 == 0 {
+		return nil, errors.New("invalid access key exponent")
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(modulus), E: int(exponent.Int64())}, nil
+}
+
+func accessCacheExpiry(header http.Header, now time.Time) time.Time {
+	for _, directive := range strings.Split(header.Get("Cache-Control"), ",") {
+		name, value, ok := strings.Cut(strings.TrimSpace(directive), "=")
+		if !ok || !strings.EqualFold(name, "max-age") {
+			continue
+		}
+		seconds, err := strconv.ParseInt(strings.Trim(value, "\""), 10, 64)
+		if err == nil && seconds >= 0 {
+			ttl := accessMaxCacheTTL
+			if seconds > int64(accessMaxCacheTTL/time.Second) {
+				return now.Add(ttl)
+			}
+			ttl = time.Duration(seconds) * time.Second
+			return now.Add(ttl)
+		}
+	}
+	if expires, err := http.ParseTime(header.Get("Expires")); err == nil && expires.After(now) {
+		if expires.After(now.Add(accessMaxCacheTTL)) {
+			return now.Add(accessMaxCacheTTL)
+		}
+		return expires
+	}
+	return now.Add(accessDefaultCacheTTL)
+}

--- a/apps/api/internal/httpapi/access.go
+++ b/apps/api/internal/httpapi/access.go
@@ -27,6 +27,7 @@ const (
 	accessMaxCacheTTL     = 24 * time.Hour
 	accessMaxJWKSBytes    = 1 << 20
 	accessClockLeeway     = 30 * time.Second
+	accessUnknownKidFloor = 30 * time.Second
 )
 
 type AccessConfig struct {
@@ -42,9 +43,10 @@ type accessVerifier struct {
 	httpClient *http.Client
 	now        func() time.Time
 
-	mu      sync.Mutex
-	keys    map[string]*rsa.PublicKey
-	expires time.Time
+	mu        sync.Mutex
+	keys      map[string]*rsa.PublicKey
+	expires   time.Time
+	lastFetch time.Time
 }
 
 type accessClaims struct {
@@ -175,12 +177,17 @@ func (v *accessVerifier) key(ctx context.Context, kid string) (*rsa.PublicKey, e
 			return key, nil
 		}
 	}
+	if v.keys[kid] == nil && !v.lastFetch.IsZero() && now.Sub(v.lastFetch) < accessUnknownKidFloor {
+		// Bound upstream fetch amplification from forged assertions.
+		return nil, errors.New("access assertion key not found")
+	}
 	keys, expires, err := v.fetchKeys(ctx, now)
 	if err != nil {
 		return nil, err
 	}
 	v.keys = keys
 	v.expires = expires
+	v.lastFetch = now
 	key := keys[kid]
 	if key == nil {
 		return nil, errors.New("access assertion key not found")

--- a/apps/api/internal/httpapi/access_test.go
+++ b/apps/api/internal/httpapi/access_test.go
@@ -281,6 +281,7 @@ func TestAccessJWKSCacheRefetchesUnknownAndExpiredKeys(t *testing.T) {
 	if requests.Load() != 1 {
 		t.Fatalf("cached key made %d JWKS requests, want 1", requests.Load())
 	}
+	now = now.Add(accessUnknownKidFloor)
 	mu.Lock()
 	keys = map[string]*rsa.PublicKey{"second": &secondKey.PublicKey}
 	mu.Unlock()
@@ -299,6 +300,29 @@ func TestAccessJWKSCacheRefetchesUnknownAndExpiredKeys(t *testing.T) {
 	}
 	if requests.Load() != 3 {
 		t.Fatalf("expired cache requests = %d, want 3", requests.Load())
+	}
+}
+
+func TestAccessJWKSUnknownKidRefreshFloor(t *testing.T) {
+	key := newAccessTestKey(t)
+	jwks, requests := newAccessTestJWKSServer(t, func() map[string]*rsa.PublicKey {
+		return map[string]*rsa.PublicKey{"known": &key.PublicKey}
+	})
+	now := time.Now().UTC().Truncate(time.Second)
+	verifier := newAccessVerifier(AccessConfig{TeamDomain: jwks.URL, Audience: "test-aud", HTTPClient: jwks.Client(), Now: func() time.Time { return now }})
+	claims := jwt.MapClaims{
+		"iss": jwks.URL, "aud": "test-aud",
+		"exp": now.Add(time.Hour).Unix(), "iat": now.Add(-time.Minute).Unix(),
+		"email": "cache@example.com",
+	}
+	assertion := signAccessTestToken(t, key, "unknown", jwt.SigningMethodRS256, claims)
+	for attempt := 1; attempt <= 2; attempt++ {
+		if _, err := verifier.verify(context.Background(), assertion); err == nil {
+			t.Fatalf("unknown kid verification %d unexpectedly succeeded", attempt)
+		}
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("two unknown-kid verifications made %d JWKS requests, want 1", requests.Load())
 	}
 }
 

--- a/apps/api/internal/httpapi/access_test.go
+++ b/apps/api/internal/httpapi/access_test.go
@@ -1,0 +1,381 @@
+package httpapi
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestAccessAssertionProvisionsSessionAndMembership(t *testing.T) {
+	key := newAccessTestKey(t)
+	jwks, requests := newAccessTestJWKSServer(t, func() map[string]*rsa.PublicKey {
+		return map[string]*rsa.PublicKey{"key-1": &key.PublicKey}
+	})
+	st := newAccessTestStore(t)
+	handler := New(st, realtime.NewHub(), Options{
+		DisableDevAuth: true,
+		Access: AccessConfig{
+			TeamDomain: jwks.URL,
+			Audience:   "test-access-aud",
+			HTTPClient: jwks.Client(),
+		},
+	}).Handler()
+	token := signAccessTestToken(t, key, "key-1", jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss":   jwks.URL,
+		"aud":   []string{"test-other-aud", "test-access-aud"},
+		"exp":   time.Now().Add(time.Hour).Unix(),
+		"iat":   time.Now().Add(-time.Minute).Unix(),
+		"email": "Captain@Example.com",
+		"name":  "Access Captain",
+	})
+	blocked := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(`{"name":"Cross Site","slug":"cross-site"}`))
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set(accessAssertionHeader, token)
+	handler.ServeHTTP(blocked, request)
+	if blocked.Code != http.StatusForbidden || len(blocked.Result().Cookies()) != 0 {
+		t.Fatalf("first Access mutation bypassed CSRF checks: status=%d cookies=%#v body=%s", blocked.Code, blocked.Result().Cookies(), blocked.Body.String())
+	}
+	if requests.Load() != 0 {
+		t.Fatalf("CSRF-rejected Access request fetched JWKS: requests=%d", requests.Load())
+	}
+
+	first := httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.Header.Set(accessAssertionHeader, token)
+	handler.ServeHTTP(first, request)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first request status = %d, body = %s", first.Code, first.Body.String())
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("JWKS requests = %d, want 1", requests.Load())
+	}
+	var response struct {
+		User store.User `json:"user"`
+	}
+	if err := json.Unmarshal(first.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.User.DisplayName != "Access Captain" {
+		t.Fatalf("unexpected access user: %#v", response.User)
+	}
+	workspaces, err := st.ListWorkspaces(context.Background(), response.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workspaces) != 1 || workspaces[0].Role != store.WorkspaceRoleOwner {
+		t.Fatalf("expected first access user to own the default workspace, got %#v", workspaces)
+	}
+	cookies := first.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != "cc_session" || cookies[0].Value == "" || !cookies[0].HttpOnly {
+		t.Fatalf("unexpected session cookies: %#v", cookies)
+	}
+
+	second := httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.AddCookie(cookies[0])
+	handler.ServeHTTP(second, request)
+	if second.Code != http.StatusOK {
+		t.Fatalf("cookie request status = %d, body = %s", second.Code, second.Body.String())
+	}
+	if len(second.Result().Cookies()) != 0 {
+		t.Fatalf("cookie-authenticated request unexpectedly replaced its session: %#v", second.Result().Cookies())
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("cookie request fetched JWKS; requests = %d", requests.Load())
+	}
+
+	unsafe := httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodPost, "/api/workspaces", strings.NewReader(`{"name":"Cross Site","slug":"cross-site"}`))
+	request.AddCookie(cookies[0])
+	request.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(unsafe, request)
+	if unsafe.Code != http.StatusForbidden {
+		t.Fatalf("Access session bypassed cookie CSRF checks: status=%d body=%s", unsafe.Code, unsafe.Body.String())
+	}
+
+	memberToken := signAccessTestToken(t, key, "key-1", jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": jwks.URL, "aud": "test-access-aud",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Add(-time.Minute).Unix(),
+		"email": "member@example.com", "common_name": "Access Member",
+	})
+	memberResponse := httptest.NewRecorder()
+	request = httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.AddCookie(&http.Cookie{Name: "cc_session", Value: "expired-session"})
+	request.Header.Set(accessAssertionHeader, memberToken)
+	handler.ServeHTTP(memberResponse, request)
+	if memberResponse.Code != http.StatusOK || len(memberResponse.Result().Cookies()) != 1 {
+		t.Fatalf("Access did not replace an invalid session: status=%d cookies=%#v body=%s", memberResponse.Code, memberResponse.Result().Cookies(), memberResponse.Body.String())
+	}
+	if err := json.Unmarshal(memberResponse.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.User.DisplayName != "Access Member" {
+		t.Fatalf("common name was not used for the member profile: %#v", response.User)
+	}
+	workspaces, err = st.ListWorkspaces(context.Background(), response.User.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workspaces) != 1 || workspaces[0].Role != store.WorkspaceRoleMember {
+		t.Fatalf("expected later access user to join as a member, got %#v", workspaces)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("cached Access key was unexpectedly refetched: requests=%d", requests.Load())
+	}
+}
+
+func TestAccessAssertionRejectsInvalidTokens(t *testing.T) {
+	key := newAccessTestKey(t)
+	jwks, _ := newAccessTestJWKSServer(t, func() map[string]*rsa.PublicKey {
+		return map[string]*rsa.PublicKey{"key-1": &key.PublicKey}
+	})
+	st := newAccessTestStore(t)
+	handler := New(st, realtime.NewHub(), Options{
+		DisableDevAuth: true,
+		Access:         AccessConfig{TeamDomain: jwks.URL, Audience: "test-expected-aud", HTTPClient: jwks.Client()},
+	}).Handler()
+	now := time.Now()
+	validClaims := func() jwt.MapClaims {
+		return jwt.MapClaims{
+			"iss": jwks.URL, "aud": "test-expected-aud",
+			"exp": now.Add(time.Hour).Unix(), "iat": now.Add(-time.Minute).Unix(),
+			"email": "access@example.com",
+		}
+	}
+	tests := []struct {
+		name   string
+		method jwt.SigningMethod
+		key    any
+		claims func() jwt.MapClaims
+	}{
+		{"wrong audience", jwt.SigningMethodRS256, key, func() jwt.MapClaims { claims := validClaims(); claims["aud"] = "wrong"; return claims }},
+		{"wrong issuer", jwt.SigningMethodRS256, key, func() jwt.MapClaims {
+			claims := validClaims()
+			claims["iss"] = "https://wrong.example.com"
+			return claims
+		}},
+		{"expired", jwt.SigningMethodRS256, key, func() jwt.MapClaims {
+			claims := validClaims()
+			claims["exp"] = now.Add(-time.Hour).Unix()
+			return claims
+		}},
+		{"future issued at", jwt.SigningMethodRS256, key, func() jwt.MapClaims {
+			claims := validClaims()
+			claims["iat"] = now.Add(time.Hour).Unix()
+			return claims
+		}},
+		{"missing issued at", jwt.SigningMethodRS256, key, func() jwt.MapClaims { claims := validClaims(); delete(claims, "iat"); return claims }},
+		{"missing email", jwt.SigningMethodRS256, key, func() jwt.MapClaims { claims := validClaims(); delete(claims, "email"); return claims }},
+		{"wrong algorithm", jwt.SigningMethodHS256, []byte("test-signing-key"), validClaims},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			token := signAccessTestToken(t, test.key, "key-1", test.method, test.claims())
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+			request.Header.Set(accessAssertionHeader, token)
+			handler.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+			}
+			if body := recorder.Body.String(); strings.Contains(body, token) {
+				t.Fatal("authentication error echoed the assertion")
+			}
+		})
+	}
+}
+
+func TestAccessAssertionIgnoredWhenUnconfigured(t *testing.T) {
+	st := newAccessTestStore(t)
+	handler := New(st, realtime.NewHub(), Options{DisableDevAuth: true}).Handler()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	request.Header.Set(accessAssertionHeader, "untrusted")
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusUnauthorized || len(recorder.Result().Cookies()) != 0 {
+		t.Fatalf("unconfigured access header was trusted: status=%d cookies=%#v", recorder.Code, recorder.Result().Cookies())
+	}
+}
+
+func TestAccessFailureFallsThroughToLoopbackDevAuth(t *testing.T) {
+	key := newAccessTestKey(t)
+	jwks, _ := newAccessTestJWKSServer(t, func() map[string]*rsa.PublicKey {
+		return map[string]*rsa.PublicKey{"key-1": &key.PublicKey}
+	})
+	st := newAccessTestStore(t)
+	owner, err := st.EnsureBootstrap(context.Background(), "Local Owner", "local@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := New(st, realtime.NewHub(), Options{
+		Access: AccessConfig{TeamDomain: jwks.URL, Audience: "test-expected-aud", HTTPClient: jwks.Client()},
+	}).Handler()
+	token := signAccessTestToken(t, key, "key-1", jwt.SigningMethodRS256, jwt.MapClaims{
+		"iss": jwks.URL, "aud": "test-wrong-aud",
+		"exp": time.Now().Add(time.Hour).Unix(), "iat": time.Now().Add(-time.Minute).Unix(),
+		"email": "access@example.com",
+	})
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "http://localhost/api/me", nil)
+	request.Host = "localhost"
+	request.RemoteAddr = "127.0.0.1:43210"
+	request.Header.Set(accessAssertionHeader, token)
+	handler.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	var response struct {
+		User store.User `json:"user"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.User.ID != owner.ID || len(recorder.Result().Cookies()) != 0 {
+		t.Fatalf("unexpected dev fallback response: user=%#v cookies=%#v", response.User, recorder.Result().Cookies())
+	}
+}
+
+func TestAccessJWKSCacheRefetchesUnknownAndExpiredKeys(t *testing.T) {
+	firstKey := newAccessTestKey(t)
+	secondKey := newAccessTestKey(t)
+	thirdKey := newAccessTestKey(t)
+	var mu sync.RWMutex
+	keys := map[string]*rsa.PublicKey{"first": &firstKey.PublicKey}
+	jwks, requests := newAccessTestJWKSServer(t, func() map[string]*rsa.PublicKey {
+		mu.RLock()
+		defer mu.RUnlock()
+		copy := make(map[string]*rsa.PublicKey, len(keys))
+		for kid, key := range keys {
+			copy[kid] = key
+		}
+		return copy
+	})
+	now := time.Now().UTC().Truncate(time.Second)
+	verifier := newAccessVerifier(AccessConfig{TeamDomain: jwks.URL, Audience: "test-aud", HTTPClient: jwks.Client(), Now: func() time.Time { return now }})
+	claims := func() jwt.MapClaims {
+		return jwt.MapClaims{"iss": jwks.URL, "aud": "test-aud", "exp": now.Add(time.Hour).Unix(), "iat": now.Add(-time.Minute).Unix(), "email": "cache@example.com"}
+	}
+	if _, err := verifier.verify(context.Background(), signAccessTestToken(t, firstKey, "first", jwt.SigningMethodRS256, claims())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.verify(context.Background(), signAccessTestToken(t, firstKey, "first", jwt.SigningMethodRS256, claims())); err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("cached key made %d JWKS requests, want 1", requests.Load())
+	}
+	mu.Lock()
+	keys = map[string]*rsa.PublicKey{"second": &secondKey.PublicKey}
+	mu.Unlock()
+	if _, err := verifier.verify(context.Background(), signAccessTestToken(t, secondKey, "second", jwt.SigningMethodRS256, claims())); err != nil {
+		t.Fatalf("unknown kid did not trigger a successful refetch: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("unknown kid requests = %d, want 2", requests.Load())
+	}
+	mu.Lock()
+	keys = map[string]*rsa.PublicKey{"second": &thirdKey.PublicKey}
+	mu.Unlock()
+	now = now.Add(2 * time.Minute)
+	if _, err := verifier.verify(context.Background(), signAccessTestToken(t, thirdKey, "second", jwt.SigningMethodRS256, claims())); err != nil {
+		t.Fatalf("expired cache did not refresh: %v", err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("expired cache requests = %d, want 3", requests.Load())
+	}
+}
+
+func TestAccessJWKSFetchDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int64
+	redirectTarget := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		_ = json.NewEncoder(w).Encode(accessJWKS{})
+	}))
+	t.Cleanup(redirectTarget.Close)
+	teamDomain := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", redirectTarget.URL+accessJWKSPath)
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(teamDomain.Close)
+	verifier := newAccessVerifier(AccessConfig{TeamDomain: teamDomain.URL, Audience: "test-aud", HTTPClient: teamDomain.Client()})
+	if _, _, err := verifier.fetchKeys(context.Background(), time.Now()); err == nil {
+		t.Fatal("expected redirected JWKS fetch to fail")
+	}
+	if redirectedRequests.Load() != 0 {
+		t.Fatalf("JWKS client followed redirect outside the configured team domain: requests=%d", redirectedRequests.Load())
+	}
+}
+
+func newAccessTestStore(t *testing.T) *sqlitestore.Store {
+	t.Helper()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	return st
+}
+
+func newAccessTestKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func newAccessTestJWKSServer(t *testing.T, keys func() map[string]*rsa.PublicKey) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	requests := &atomic.Int64{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != accessJWKSPath {
+			http.NotFound(w, r)
+			return
+		}
+		requests.Add(1)
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		set := accessJWKS{}
+		for kid, key := range keys() {
+			set.Keys = append(set.Keys, accessJWK{
+				Kid: kid, Kty: "RSA", Alg: "RS256", Use: "sig",
+				N: base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+				E: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+			})
+		}
+		_ = json.NewEncoder(w).Encode(set)
+	}))
+	t.Cleanup(server.Close)
+	return server, requests
+}
+
+func signAccessTestToken(t *testing.T, key any, kid string, method jwt.SigningMethod, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(method, claims)
+	token.Header["kid"] = kid
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signed
+}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	uploadDir             string
 	uploadStorage         uploadstore.Store
 	githubOAuth           GitHubOAuthConfig
+	access                *accessVerifier
 	frontendURL           string
 	publicAPIURL          string
 	embedFrameAncestors   []string
@@ -71,6 +72,7 @@ type Options struct {
 	UploadDir           string
 	UploadStorage       uploadstore.Store
 	GitHubOAuth         GitHubOAuthConfig
+	Access              AccessConfig
 	FrontendURL         string
 	PublicAPIURL        string
 	EmbedFrameAncestors []string
@@ -102,6 +104,7 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 		uploadDir:             options.UploadDir,
 		uploadStorage:         uploadStorage,
 		githubOAuth:           options.GitHubOAuth.withDefaults(),
+		access:                newAccessVerifier(options.Access),
 		frontendURL:           strings.TrimSpace(options.FrontendURL),
 		publicAPIURL:          strings.TrimRight(strings.TrimSpace(options.PublicAPIURL), "/"),
 		embedFrameAncestors:   append([]string(nil), options.EmbedFrameAncestors...),
@@ -135,6 +138,7 @@ func (s *Server) Handler() http.Handler {
 	r.Route("/api", func(r chi.Router) {
 		r.Use(s.cors)
 		r.Use(s.requireCookieCSRF)
+		r.Use(bindAccessResponseWriter)
 		r.Post("/auth/magic/request", s.requestMagicLink)
 		r.Post("/auth/magic/consume", s.consumeMagicLink)
 		r.Get("/auth/github/start", s.githubStart)
@@ -228,7 +232,7 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) requireCookieCSRF(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if isSafeMethod(r.Method) || hasBearerAuth(r) || !s.hasSessionCookie(r) {
+		if isSafeMethod(r.Method) || hasBearerAuth(r) || (!s.hasSessionCookie(r) && !s.hasAccessAssertion(r)) {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -238,6 +242,10 @@ func (s *Server) requireCookieCSRF(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func (s *Server) hasAccessAssertion(r *http.Request) bool {
+	return s.access != nil && r.Header.Get(accessAssertionHeader) != ""
 }
 
 func isSafeMethod(method string) bool {
@@ -1405,7 +1413,19 @@ func (s *Server) currentActor(r *http.Request) (actor, error) {
 	}
 	if err == nil && cookie.Value != "" {
 		user, err := s.store.GetSessionUser(r.Context(), cookie.Value)
-		return actor{user: user}, err
+		if err == nil {
+			return actor{user: user}, nil
+		}
+		if s.access == nil || r.Header.Get(accessAssertionHeader) == "" {
+			return actor{}, err
+		}
+	}
+	if s.access != nil {
+		if assertion := r.Header.Get(accessAssertionHeader); assertion != "" {
+			if act, err := s.accessActor(r, assertion); err == nil {
+				return act, nil
+			}
+		}
 	}
 	if s.disableDevAuth {
 		return actor{}, errors.New("authentication required")

--- a/apps/api/internal/store/postgres/auth.go
+++ b/apps/api/internal/store/postgres/auth.go
@@ -57,7 +57,7 @@ func (s *Store) ConsumeMagicLink(ctx context.Context, token string) (store.User,
 	if err != nil || time.Now().UTC().After(expiresAt) {
 		return store.User{}, store.Session{}, errors.New("magic link expired")
 	}
-	user, err := getOrCreateMagicUser(ctx, qtx, link.Email, link.DisplayName)
+	user, err := getOrCreateUserByEmail(ctx, qtx, "magic", link.Email, link.DisplayName)
 	if err != nil {
 		return store.User{}, store.Session{}, err
 	}
@@ -106,7 +106,38 @@ func (s *Store) CreateSession(ctx context.Context, userID string) (store.Session
 	return session, tx.Commit()
 }
 
-func getOrCreateMagicUser(ctx context.Context, q *storedb.Queries, email, displayName string) (store.User, error) {
+func (s *Store) GetOrCreateUserByEmail(ctx context.Context, provider, email, displayName string) (store.User, error) {
+	provider = strings.TrimSpace(provider)
+	email = strings.ToLower(strings.TrimSpace(email))
+	if provider == "" || email == "" {
+		return store.User{}, errors.New("identity provider and email are required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.User{}, err
+	}
+	defer tx.Rollback()
+	user, err := getOrCreateUserByEmail(ctx, s.q.WithTx(tx), provider, email, displayName)
+	if err == nil {
+		err = tx.Commit()
+	}
+	if err == nil {
+		return user, nil
+	}
+	_ = tx.Rollback()
+	row, lookupErr := s.q.GetUserByIdentityEmail(ctx, email)
+	if lookupErr == nil {
+		return storeUserFromIdentityEmail(row), nil
+	}
+	return store.User{}, err
+}
+
+func getOrCreateUserByEmail(ctx context.Context, q *storedb.Queries, provider, email, displayName string) (store.User, error) {
+	provider = strings.TrimSpace(provider)
+	email = strings.ToLower(strings.TrimSpace(email))
+	if provider == "" || email == "" {
+		return store.User{}, errors.New("identity provider and email are required")
+	}
 	row, err := q.GetUserByIdentityEmail(ctx, email)
 	if err == nil {
 		return storeUserFromIdentityEmail(row), nil
@@ -124,7 +155,7 @@ func getOrCreateMagicUser(ctx context.Context, q *storedb.Queries, email, displa
 	err = q.InsertIdentity(ctx, storedb.InsertIdentityParams{
 		ID:              newID("idn"),
 		UserID:          user.ID,
-		Provider:        "magic",
+		Provider:        provider,
 		ProviderSubject: email,
 		Email:           email,
 		CreatedAt:       user.CreatedAt,

--- a/apps/api/internal/store/sqlite/auth.go
+++ b/apps/api/internal/store/sqlite/auth.go
@@ -57,7 +57,7 @@ func (s *Store) ConsumeMagicLink(ctx context.Context, token string) (store.User,
 	if err != nil || time.Now().UTC().After(expiresAt) {
 		return store.User{}, store.Session{}, errors.New("magic link expired")
 	}
-	user, err := getOrCreateMagicUser(ctx, qtx, link.Email, link.DisplayName)
+	user, err := getOrCreateUserByEmail(ctx, qtx, "magic", link.Email, link.DisplayName)
 	if err != nil {
 		return store.User{}, store.Session{}, err
 	}
@@ -106,7 +106,38 @@ func (s *Store) CreateSession(ctx context.Context, userID string) (store.Session
 	return session, tx.Commit()
 }
 
-func getOrCreateMagicUser(ctx context.Context, q *storedb.Queries, email, displayName string) (store.User, error) {
+func (s *Store) GetOrCreateUserByEmail(ctx context.Context, provider, email, displayName string) (store.User, error) {
+	provider = strings.TrimSpace(provider)
+	email = strings.ToLower(strings.TrimSpace(email))
+	if provider == "" || email == "" {
+		return store.User{}, errors.New("identity provider and email are required")
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.User{}, err
+	}
+	defer tx.Rollback()
+	user, err := getOrCreateUserByEmail(ctx, s.q.WithTx(tx), provider, email, displayName)
+	if err == nil {
+		err = tx.Commit()
+	}
+	if err == nil {
+		return user, nil
+	}
+	_ = tx.Rollback()
+	row, lookupErr := s.q.GetUserByIdentityEmail(ctx, email)
+	if lookupErr == nil {
+		return storeUserFromIdentityEmail(row), nil
+	}
+	return store.User{}, err
+}
+
+func getOrCreateUserByEmail(ctx context.Context, q *storedb.Queries, provider, email, displayName string) (store.User, error) {
+	provider = strings.TrimSpace(provider)
+	email = strings.ToLower(strings.TrimSpace(email))
+	if provider == "" || email == "" {
+		return store.User{}, errors.New("identity provider and email are required")
+	}
 	row, err := q.GetUserByIdentityEmail(ctx, email)
 	if err == nil {
 		return storeUserFromIdentityEmail(row), nil
@@ -124,7 +155,7 @@ func getOrCreateMagicUser(ctx context.Context, q *storedb.Queries, email, displa
 	err = q.InsertIdentity(ctx, storedb.InsertIdentityParams{
 		ID:              newID("idn"),
 		UserID:          user.ID,
-		Provider:        "magic",
+		Provider:        provider,
 		ProviderSubject: email,
 		Email:           email,
 		CreatedAt:       user.CreatedAt,

--- a/apps/api/internal/store/sqlite/misc_test.go
+++ b/apps/api/internal/store/sqlite/misc_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -256,6 +257,63 @@ func TestStoreMiscBranches(t *testing.T) {
 	}
 	if len(recipients) != 0 {
 		t.Fatalf("revoked DM member should not receive push notifications, got %#v", recipients)
+	}
+}
+
+func TestGetOrCreateUserByEmailConcurrent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "concurrent-identity.db")
+	const callers = 6
+	stores := make([]*Store, callers)
+	for index := range stores {
+		st, err := Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		stores[index] = st
+		t.Cleanup(func() { _ = st.Close() })
+	}
+	if err := stores[0].Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	start := make(chan struct{})
+	users := make(chan store.User, callers)
+	errors := make(chan error, callers)
+	var group sync.WaitGroup
+	for _, st := range stores {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			<-start
+			user, err := st.GetOrCreateUserByEmail(ctx, "cloudflare-access", "Concurrent@Example.com", "Concurrent User")
+			if err != nil {
+				errors <- err
+				return
+			}
+			users <- user
+		}()
+	}
+	close(start)
+	group.Wait()
+	close(users)
+	close(errors)
+	for err := range errors {
+		t.Errorf("concurrent get-or-create failed: %v", err)
+	}
+	var userID string
+	count := 0
+	for user := range users {
+		count++
+		if userID == "" {
+			userID = user.ID
+		}
+		if user.ID != userID {
+			t.Errorf("concurrent get-or-create returned different users: %q and %q", userID, user.ID)
+		}
+	}
+	if count != callers {
+		t.Fatalf("successful callers = %d, want %d", count, callers)
 	}
 }
 

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -1080,6 +1080,7 @@ type Store interface {
 	CreateInvite(ctx context.Context, workspaceID, createdBy string) (Invite, error)
 	CreateMagicLink(ctx context.Context, email, displayName string) (MagicLink, error)
 	ConsumeMagicLink(ctx context.Context, token string) (User, Session, error)
+	GetOrCreateUserByEmail(ctx context.Context, provider, email, displayName string) (User, error)
 	CreateSession(ctx context.Context, userID string) (Session, error)
 	GetSessionUser(ctx context.Context, token string) (User, error)
 	CreateOAuthTransaction(ctx context.Context, transaction OAuthTransaction) error

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,8 @@ hook in `cmd/clickclack/main.go`.
 | —                     | `CLICKCLACK_PUBLIC_URL`          | unset       | Canonical external origin. Required for GitHub OAuth and namespaced cookies. |
 | —                     | `CLICKCLACK_PUBLIC_API_URL`      | public URL  | Canonical external API base. May use a different origin and a normalized base path. |
 | `--embed-frame-ancestors` | `CLICKCLACK_EMBED_FRAME_ANCESTORS` | unset | Comma- or whitespace-separated exact origins allowed to frame `/embed/*`; see [Embedded threads](features/embedding.md). |
+| `--access-team-domain` | `CLICKCLACK_ACCESS_TEAM_DOMAIN` | unset | Cloudflare Access team HTTPS origin. Must be configured together with the Access audience. |
+| `--access-aud`        | `CLICKCLACK_ACCESS_AUD`         | unset       | Expected Cloudflare Access application audience tag. Must be non-empty when the team domain is set. |
 | —                     | `CLICKCLACK_COOKIE_NAMESPACE`    | unset       | Stable lowercase cookie namespace for multiple trusted ClickClack instances on one hostname. |
 | —                     | `CLICKCLACK_GITHUB_CLIENT_ID`    | unset       | GitHub OAuth app client ID. |
 | —                     | `CLICKCLACK_GITHUB_CLIENT_SECRET`| unset       | GitHub OAuth app client secret. |
@@ -62,6 +64,8 @@ hook in `cmd/clickclack/main.go`.
   "public_url": "https://chat.example.com",
   "public_api_url": "https://api.example.com/services/clickclack",
   "embed_frame_ancestors": ["https://control.example.com"],
+  "access_team_domain": "https://openclaw.cloudflareaccess.com",
+  "access_aud": "<application-audience-tag>",
   "cookie_namespace": "production",
   "github_client_id": "Iv1.xxxxxxxxxxxx",
   "github_client_secret": "...",
@@ -77,6 +81,12 @@ hook in `cmd/clickclack/main.go`.
 Pass with `--config /etc/clickclack/config.json`. Values from the file
 are overridden by environment variables; CLI flags override both when
 explicitly set. The `dev_bootstrap` exception is described above.
+
+The Access team domain is an HTTPS origin without credentials, a path, query,
+or fragment. `access_team_domain` and `access_aud` are an all-or-nothing pair;
+when both are absent, trusted-proxy authentication is disabled. See
+[Trusted proxy (Cloudflare Access)](features/auth.md#trusted-proxy-cloudflare-access)
+for verification, provisioning, and session behavior.
 
 ## Public frontend and API URLs
 

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -112,10 +112,13 @@ the Access assertion header is ignored.
 For a request without a valid ClickClack session cookie, the server verifies
 the `Cf-Access-Jwt-Assertion` as an RS256 JWT. It fetches keys only from
 `<team-domain>/cdn-cgi/access/certs`, does not follow redirects, caches the JWKS
-with bounded expiry, and refreshes immediately when a token names an unknown
-key ID. The issuer must exactly match the configured team domain, the audience
+with bounded expiry, and refreshes an unknown key ID at most once every 30
+seconds. The issuer must exactly match the configured team domain, the audience
 must include the configured tag, expiration and issued-at claims must be valid,
 and the email claim is required.
+
+Cloudflare Access service tokens produce assertions without an email claim, so
+this path rejects them. Automation must use ClickClack bot tokens instead.
 
 After verification, ClickClack resolves or creates the human user by normalized
 email and joins the default workspace. The first Access user becomes its owner;

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -7,17 +7,20 @@ read_when:
 
 # Auth
 
-ClickClack accepts four ways to identify a caller, in order of precedence. The
+ClickClack accepts five ways to identify a caller, in order of precedence. The
 resolver lives in `apps/api/internal/httpapi/server.go` (`currentActor`).
 
 1. `Authorization: Bearer <token>` — bearer session token or `ccb_...` bot
    token. Bot tokens resolve to the bot user plus token workspace/scopes.
 2. Session cookie — `cc_session` by default, or the configured namespaced
    cookie. It is HTTP-only and set by magic-link consume and GitHub OAuth.
-3. `X-ClickClack-User: usr_...` header — explicit user impersonation for local
+3. Cloudflare Access assertion — when trusted-proxy authentication is
+   configured, a valid `Cf-Access-Jwt-Assertion` provisions or resolves the
+   asserted email and creates a normal ClickClack session.
+4. `X-ClickClack-User: usr_...` header — explicit user impersonation for local
    development and tests, accepted only from loopback clients using local
    request hosts.
-4. Dev fallback — the very first user in the database. Enabled only by
+5. Dev fallback — the very first user in the database. Enabled only by
    `clickclack serve --dev-bootstrap=true` so a fresh checkout can boot into a
    working app without any token plumbing, and accepted only from local
    requests.
@@ -89,6 +92,44 @@ should hold the `session.token` for the `Authorization` header. Session cookies
 default to `Secure` outside local dev HTTP, even if a reverse proxy omits HTTPS
 headers. Duplicate cookies with the active session-cookie name are rejected
 instead of relying on cookie ordering.
+
+## Trusted proxy (Cloudflare Access)
+
+Team deployments may put ClickClack behind a Cloudflare Tunnel and Cloudflare
+Access. Configure the Access team HTTPS origin and the application's audience
+tag together:
+
+```sh
+CLICKCLACK_ACCESS_TEAM_DOMAIN=https://openclaw.cloudflareaccess.com
+CLICKCLACK_ACCESS_AUD=<application-audience-tag>
+```
+
+The equivalent serve flags are `--access-team-domain` and `--access-aud`; the
+JSON config keys are `access_team_domain` and `access_aud`. Setting only one
+value fails startup validation. Leaving both unset disables this auth path, and
+the Access assertion header is ignored.
+
+For a request without a valid ClickClack session cookie, the server verifies
+the `Cf-Access-Jwt-Assertion` as an RS256 JWT. It fetches keys only from
+`<team-domain>/cdn-cgi/access/certs`, does not follow redirects, caches the JWKS
+with bounded expiry, and refreshes immediately when a token names an unknown
+key ID. The issuer must exactly match the configured team domain, the audience
+must include the configured tag, expiration and issued-at claims must be valid,
+and the email claim is required.
+
+After verification, ClickClack resolves or creates the human user by normalized
+email and joins the default workspace. The first Access user becomes its owner;
+later users join as members. The current request is authenticated immediately,
+and the response sets the same configured HTTP-only session cookie used by
+magic-link and GitHub OAuth sign-in. Later HTTP and WebSocket requests use that
+cookie without revalidating Access on every request. Unsafe requests carrying
+either an Access assertion or a ClickClack session cookie remain subject to the
+existing same-origin and `X-ClickClack-CSRF` checks, including the first SSO
+request before a local cookie exists.
+
+This mode trusts Cloudflare Access as the deployment's identity boundary. Do
+not expose the ClickClack origin directly around Access, and do not configure
+these settings for a proxy that can pass client-supplied assertion headers.
 
 ## GitHub OAuth (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/coder/websocket v1.8.15
 	github.com/go-chi/chi/v5 v5.3.1
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/lib/pq v1.12.3
 	github.com/oklog/ulid/v2 v2.1.1

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/google/pprof v0.0.0-20260507013755-92041b743c96 h1:YDDnaZ9afWajDboPMt9Vikqca/yWAX7KAxVzb4lJU1M=
 github.com/google/pprof v0.0.0-20260507013755-92041b743c96/go.mod h1:MxpfABSjhmINe3F1It9d+8exIHFvUqtLIRCdOGNXqiI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
## What Problem This Solves

The team deployment fronts ClickClack with a Cloudflare Tunnel and Cloudflare Access (GitHub-federated, org-gated). Users who already authenticated at the Access edge still had to mint and consume a CLI magic link to get a ClickClack session — a second login for an identity the proxy has already verified.

## Why This Change Was Made

Adds opt-in trusted-proxy SSO: when `CLICKCLACK_ACCESS_TEAM_DOMAIN` + `CLICKCLACK_ACCESS_AUD` are configured, the API validates the `Cf-Access-Jwt-Assertion` header (RS256 against the team domain's JWKS with kid-rotation refresh, a 30s unknown-kid refetch floor, issuer/audience/expiry/issued-at enforcement, redirect-refusing size-capped fetches), then gets-or-creates the user by verified email, ensures default-workspace membership (first user becomes owner, like OAuth), and issues a normal `cc_session` cookie so subsequent requests and WebSockets ride the standard session path. Valid cookies win over the header; expired cookies fall through to Access re-auth; unconfigured deployments ignore the header entirely. CSRF origin checks now also cover assertion-authenticated unsafe requests. Access service tokens (no email claim) are rejected — automation uses bot tokens.

## User Impact

On an Access-fronted deployment, opening ClickClack just works — one GitHub login at the edge, no magic links. Existing auth paths are unchanged; deployments without the two new settings see no behavior change.

## Evidence

Go tests cover: valid assertion provisions user + membership + cookie; second request rides the cookie; wrong aud/iss/exp/alg/kid rejected; unknown-kid refetch floor (two failures → one JWKS fetch); concurrent first-login provisioning race (10x repeat); unconfigured header ignored; single-setting config rejected; CSRF and dev-fallback behavior preserved. `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check` all pass. Dependency added: `github.com/golang-jwt/jwt/v5` (smallest maintained option; JWKS handling is stdlib).
