### PR TITLE
chore(store): cover NormalizeBotSetupCodeDefaults validation gates

### DIFF
--- a/apps/api/internal/store/setup_code_defaults_test.go
+++ b/apps/api/internal/store/setup_code_defaults_test.go
@@ -1,0 +1,162 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// Characterization tests pinning NormalizeBotSetupCodeDefaults, the public
+// API-boundary validator invoked from both the sqlite and postgres setup-code
+// mint paths (internal/store/{sqlite,postgres}/setup_codes.go:85). The function
+// shipped with no direct coverage, so its trim/dedup/bound/scope gates could
+// regress silently. These cases drive the real exported function.
+
+func TestNormalizeBotSetupCodeDefaults_TrimsAndDedupes(t *testing.T) {
+	out, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{
+		DefaultTo: "  alice  ",
+		AllowFrom: []string{"  bob  ", "bob", "carol"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.DefaultTo != "alice" {
+		t.Errorf("DefaultTo not trimmed: got %q, want %q", out.DefaultTo, "alice")
+	}
+	// Entries are trimmed before comparison, so "  bob  " and "bob" collapse to
+	// one, and first-seen order is preserved.
+	want := []string{"bob", "carol"}
+	if len(out.AllowFrom) != len(want) {
+		t.Fatalf("AllowFrom not deduped: got %v, want %v", out.AllowFrom, want)
+	}
+	for i := range want {
+		if out.AllowFrom[i] != want[i] {
+			t.Errorf("AllowFrom[%d] = %q, want %q (order/dedup)", i, out.AllowFrom[i], want[i])
+		}
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_NilAllowFromStaysNil(t *testing.T) {
+	// The `!= nil` guard means a nil slice must round-trip as nil, not become an
+	// allocated empty slice.
+	out, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{DefaultTo: "x"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.AllowFrom != nil {
+		t.Errorf("nil AllowFrom mutated to %#v, want nil", out.AllowFrom)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_DefaultToLengthIsRuneCount(t *testing.T) {
+	// The cap is measured in runes (utf8.RuneCountInString), not bytes: 256
+	// two-byte runes (512 bytes) must pass, while 257 runes must fail. A
+	// byte-length mutation would reject the 256-rune multibyte value.
+	pass := strings.Repeat("é", maxBotSetupDefaultLength) // 256 runes, 512 bytes
+	if _, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{DefaultTo: pass}, nil); err != nil {
+		t.Errorf("256-rune multibyte DefaultTo rejected: %v", err)
+	}
+	tooLong := strings.Repeat("a", maxBotSetupDefaultLength+1) // 257 runes
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{DefaultTo: tooLong}, nil)
+	if err == nil || !strings.Contains(err.Error(), "defaultTo is too long") {
+		t.Errorf("over-length DefaultTo: got err %v, want 'defaultTo is too long'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_DefaultToRejectsNUL(t *testing.T) {
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{DefaultTo: "a\x00b"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "must not contain NUL") {
+		t.Errorf("NUL in DefaultTo: got err %v, want 'must not contain NUL'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_DefaultToRejectsInvalidUTF8(t *testing.T) {
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{DefaultTo: string([]byte{0xff, 0xfe})}, nil)
+	if err == nil || !strings.Contains(err.Error(), "must be valid UTF-8") {
+		t.Errorf("invalid UTF-8 DefaultTo: got err %v, want 'must be valid UTF-8'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AllowFromTooManyEntries(t *testing.T) {
+	// The count cap is checked against the raw input length before dedup, so
+	// even duplicate entries beyond the limit are rejected.
+	entries := make([]string, maxBotSetupAllowFrom+1)
+	for i := range entries {
+		entries[i] = "dup"
+	}
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{AllowFrom: entries}, nil)
+	if err == nil || !strings.Contains(err.Error(), "too many entries") {
+		t.Errorf("over-cap AllowFrom: got err %v, want 'too many entries'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AllowFromAtCapPasses(t *testing.T) {
+	// Exactly maxBotSetupAllowFrom unique entries is allowed (boundary: the
+	// check is strictly greater-than).
+	entries := make([]string, maxBotSetupAllowFrom)
+	for i := range entries {
+		entries[i] = "user-" + strings.Repeat("x", i%3) + string(rune('a'+i%26)) + string(rune('0'+i%10)) + strings.Repeat("y", i/26)
+	}
+	out, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{AllowFrom: entries}, nil)
+	if err != nil {
+		t.Fatalf("at-cap AllowFrom rejected: %v", err)
+	}
+	if len(out.AllowFrom) != maxBotSetupAllowFrom {
+		t.Errorf("at-cap AllowFrom length = %d, want %d", len(out.AllowFrom), maxBotSetupAllowFrom)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AllowFromRejectsEmptyAfterTrim(t *testing.T) {
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{AllowFrom: []string{"  "}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("whitespace-only AllowFrom entry: got err %v, want 'must not be empty'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AllowFromEntryValidated(t *testing.T) {
+	// A non-empty but invalid entry is rejected by validateBotSetupDefault under
+	// the "defaults.allowFrom entry" name.
+	_, err := NormalizeBotSetupCodeDefaults(BotSetupCodeDefaults{AllowFrom: []string{"a\x00b"}}, nil)
+	if err == nil || !strings.Contains(err.Error(), "defaults.allowFrom entry must not contain NUL") {
+		t.Errorf("NUL in AllowFrom entry: got err %v, want 'defaults.allowFrom entry must not contain NUL'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AgentActivityRequiresScope(t *testing.T) {
+	_, err := NormalizeBotSetupCodeDefaults(
+		BotSetupCodeDefaults{AgentActivity: boolPtr(true)},
+		[]string{"chat:write"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "requires agent_activity:write") {
+		t.Errorf("agentActivity without scope: got err %v, want 'requires agent_activity:write'", err)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AgentActivityWithScopePasses(t *testing.T) {
+	out, err := NormalizeBotSetupCodeDefaults(
+		BotSetupCodeDefaults{AgentActivity: boolPtr(true)},
+		[]string{AgentActivityWriteScope},
+	)
+	if err != nil {
+		t.Fatalf("agentActivity with scope rejected: %v", err)
+	}
+	if out.AgentActivity == nil || !*out.AgentActivity {
+		t.Errorf("AgentActivity not preserved: got %v", out.AgentActivity)
+	}
+}
+
+func TestNormalizeBotSetupCodeDefaults_AgentActivityFalseNeedsNoScope(t *testing.T) {
+	// The gate fires only when the flag is present AND true; an explicit false
+	// must pass without the scope.
+	out, err := NormalizeBotSetupCodeDefaults(
+		BotSetupCodeDefaults{AgentActivity: boolPtr(false)},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("agentActivity=false without scope rejected: %v", err)
+	}
+	if out.AgentActivity == nil || *out.AgentActivity {
+		t.Errorf("AgentActivity=false not preserved: got %v", out.AgentActivity)
+	}
+}


### PR DESCRIPTION
## What Problem This Solves

`NormalizeBotSetupCodeDefaults` (`apps/api/internal/store/setup_code_defaults.go`) validates the `defaults` payload carried by every bot **setup-code** grant. It runs on the mint path of both store backends (`internal/store/sqlite/setup_codes.go:85` and `internal/store/postgres/setup_codes.go:85`), so it sits on the public API boundary. It enforces several non-obvious gates:

- `defaultTo` is trimmed, then bounded for UTF-8 validity, NUL bytes, and a **rune-count** length cap (not byte length);
- `allowFrom` has a hard entry-count cap, per-entry trim + non-empty check + the same UTF-8/NUL/length validation, and **first-seen de-duplication**;
- `agentActivity: true` requires the dedicated `agent_activity:write` scope.

The function shipped with **no direct test coverage**. A regression in any of these gates — dropping the dedup, measuring the length in bytes instead of runes, or removing the scope requirement — would not be caught before merge.

## Why This Change Was Made

Coverage-only. This adds one new file, `apps/api/internal/store/setup_code_defaults_test.go` (+162, test-only), pinning the validator's current `main` behavior. The tests drive the **real** exported `NormalizeBotSetupCodeDefaults` directly (no stubs), including the boundary cases (256-rune multibyte `defaultTo`, exactly-at-cap `allowFrom`) and the pointer cases (`agentActivity` nil / true / false).

## User Impact

No user-visible or runtime change — no production code is touched. For maintainers, the setup-code `defaults` validation gates now regress loudly instead of silently: a future edit that breaks the rune-length measure, the de-duplication, the NUL/UTF-8 checks, or the `agent_activity:write` gate will fail this suite.

## Evidence

Linux, Go toolchain from `go.mod` (1.26.x), branched off current `main` (`c9cf5ba`).

**12/12 pass on clean `main`:**

```text
$ go test ./internal/store/ -run TestNormalizeBotSetupCodeDefaults -v
--- PASS: TestNormalizeBotSetupCodeDefaults_TrimsAndDedupes (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_NilAllowFromStaysNil (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_DefaultToLengthIsRuneCount (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_DefaultToRejectsNUL (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_DefaultToRejectsInvalidUTF8 (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AllowFromTooManyEntries (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AllowFromAtCapPasses (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AllowFromRejectsEmptyAfterTrim (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AllowFromEntryValidated (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AgentActivityRequiresScope (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AgentActivityWithScopePasses (0.00s)
--- PASS: TestNormalizeBotSetupCodeDefaults_AgentActivityFalseNeedsNoScope (0.00s)
ok      github.com/openclaw/clickclack/apps/api/internal/store
```

**Non-vacuous — each case bites when the target is mutated** (mutation applied to `setup_code_defaults.go`, suite re-run, then reverted):

| Mutation to `setup_code_defaults.go` | Result |
| --- | --- |
| `utf8.RuneCountInString(value)` → `len(value)` (byte length) | `DefaultToLengthIsRuneCount` fails |
| `allowFrom` count cap `>` → `>=` | `AllowFromAtCapPasses` fails |
| de-duplication disabled | `TrimsAndDedupes` fails |
| `agentActivity` scope gate disabled | `AgentActivityRequiresScope` fails |
| NUL check inverted (`>= 0` → `< 0`) | 6 tests fail |
| *(reverted — control)* | **12/12 pass** |

`gofmt -l` reports the file clean; `go vet ./internal/store/` exits 0; the full `go test ./internal/store/` package is green with the file added.

**Scope boundary:** no production code changed, no new config/defaults, no dependency change — a single new `_test.go` under `apps/api/internal/store`. Maintainer edits to the branch are welcome.

Related: none — coverage mined from the module itself; no linked issue.

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y3ZFi6oNsxyDk2TdeoYDu)_