### PR TITLE
feat: add CLI reaction commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
+- Added agent-friendly CLI commands for adding and removing message reactions through the existing public APIs, with exact JSON output and terminal-safe human output. Thanks @PollyBot13.
 - Removed the redundant "Open in ClickClack" link from embedded channel headers, leaving external navigation to the host's own control.
 - Fixed the embedded channel view overflowing narrow host panels (such as OpenClaw's discussion sidebar), where long session channel names clipped the header link and send button off the right edge.
 - Compacted the embedded channel and thread headers and aligned the embed composer gutters and bottom spacing with narrow host panels.

--- a/apps/api/cmd/clickclack/client.go
+++ b/apps/api/cmd/clickclack/client.go
@@ -84,6 +84,8 @@ func client(args []string) error {
 		return c.messages(rest[1:])
 	case "threads", "thread":
 		return c.threads(rest[1:])
+	case "reactions":
+		return c.reactions(rest[1:])
 	case "reply":
 		if len(rest) < 2 {
 			return errors.New("usage: clickclack reply <message-id> [body]")

--- a/apps/api/cmd/clickclack/client_commands.go
+++ b/apps/api/cmd/clickclack/client_commands.go
@@ -313,6 +313,66 @@ func (c apiClient) threadReply(messageID string, args []string) error {
 	return c.write(result, result.Message.ID, fmt.Sprintf("replied %s to %s\n", result.Message.ID, messageID))
 }
 
+type reactionMutationResponse struct {
+	Event     store.Event             `json:"event"`
+	Reactions []store.ReactionSummary `json:"reactions"`
+}
+
+func (c apiClient) reactions(args []string) error {
+	if len(args) == 0 {
+		return errors.New("usage: clickclack reactions <add|remove> <message-id> <emoji>")
+	}
+	action := args[0]
+	if action != "add" && action != "remove" {
+		return fmt.Errorf("unknown reactions command %q", action)
+	}
+
+	opts := c.opts
+	flags := flag.NewFlagSet("reactions "+action, flag.ExitOnError)
+	addClientFlags(flags, &opts)
+	var rest []string
+	if len(args) >= 3 && !strings.HasPrefix(args[1], "-") {
+		rest = args[1:3]
+		if err := flags.Parse(args[3:]); err != nil {
+			return err
+		}
+		if len(flags.Args()) != 0 {
+			return fmt.Errorf("usage: clickclack reactions %s <message-id> <emoji>", action)
+		}
+	} else {
+		if err := flags.Parse(args[1:]); err != nil {
+			return err
+		}
+		rest = flags.Args()
+	}
+	if len(rest) != 2 {
+		return fmt.Errorf("usage: clickclack reactions %s <message-id> <emoji>", action)
+	}
+	if opts.Plain {
+		return errors.New("--plain is not supported for reaction commands; omit it or use --json")
+	}
+	c = c.withOptions(opts, true)
+
+	messageID, emoji := rest[0], rest[1]
+	messagePath := "/api/messages/" + url.PathEscape(messageID) + "/reactions"
+	method := http.MethodPost
+	var body any = map[string]string{"emoji": emoji}
+	pastTense := "added"
+	if action == "remove" {
+		method = http.MethodDelete
+		messagePath += "/" + url.PathEscape(emoji)
+		body = nil
+		pastTense = "removed"
+	}
+
+	var result reactionMutationResponse
+	if err := c.doJSON(context.Background(), method, messagePath, body, &result); err != nil {
+		return err
+	}
+	human := fmt.Sprintf("reaction %s on %s\n", pastTense, url.PathEscape(messageID))
+	return c.write(result, "", human)
+}
+
 func parseBodyCommand(name string, args []string, opts *clientOptions) (*string, *bool, *string, *string, []string, error) {
 	flags := flag.NewFlagSet(name, flag.ExitOnError)
 	addClientFlags(flags, opts)

--- a/apps/api/cmd/clickclack/reactions_test.go
+++ b/apps/api/cmd/clickclack/reactions_test.go
@@ -1,0 +1,318 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestReactionCommandsUseExistingAPIAndAuth(t *testing.T) {
+	tests := []struct {
+		name        string
+		action      string
+		method      string
+		messageID   string
+		emoji       string
+		token       string
+		userID      string
+		wantAuth    string
+		wantDevUser string
+	}{
+		{
+			name:      "add with bearer token",
+			action:    "add",
+			method:    http.MethodPost,
+			messageID: "msg/add",
+			emoji:     "👍",
+			token:     "ses_test",
+			wantAuth:  "Bearer ses_test",
+		},
+		{
+			name:        "remove with development user",
+			action:      "remove",
+			method:      http.MethodDelete,
+			messageID:   "msg_remove",
+			emoji:       ":claw:/blue",
+			userID:      "usr_test",
+			wantDevUser: "usr_test",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestCount int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				if r.Method != tc.method {
+					t.Fatalf("method = %s, want %s", r.Method, tc.method)
+				}
+				wantPath := "/api/messages/" + tc.messageID + "/reactions"
+				if tc.action == "remove" {
+					wantPath += "/" + tc.emoji
+				}
+				if r.URL.Path != wantPath {
+					t.Fatalf("path = %q, want %q", r.URL.Path, wantPath)
+				}
+				wantEscapedPath := "/api/messages/" + url.PathEscape(tc.messageID) + "/reactions"
+				if tc.action == "remove" {
+					wantEscapedPath += "/" + url.PathEscape(tc.emoji)
+				}
+				if r.URL.EscapedPath() != wantEscapedPath {
+					t.Fatalf("escaped path = %q, want %q", r.URL.EscapedPath(), wantEscapedPath)
+				}
+				if r.Header.Get("Authorization") != tc.wantAuth {
+					t.Fatalf("Authorization = %q, want %q", r.Header.Get("Authorization"), tc.wantAuth)
+				}
+				if r.Header.Get("X-ClickClack-User") != tc.wantDevUser {
+					t.Fatalf("X-ClickClack-User = %q, want %q", r.Header.Get("X-ClickClack-User"), tc.wantDevUser)
+				}
+				if tc.action == "add" {
+					var body map[string]string
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatal(err)
+					}
+					if body["emoji"] != tc.emoji {
+						t.Fatalf("emoji = %q, want %q", body["emoji"], tc.emoji)
+					}
+				} else if r.Header.Get("Content-Type") != "" {
+					t.Fatalf("DELETE Content-Type = %q, want empty", r.Header.Get("Content-Type"))
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(reactionMutationResponse{
+					Event: store.Event{ID: "evt_1", Type: "reaction." + pastTenseAction(tc.action)},
+					Reactions: []store.ReactionSummary{{
+						Emoji:       tc.emoji,
+						Count:       1,
+						ReactedByMe: tc.action == "add",
+					}},
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			c := apiClient{
+				opts: clientOptions{
+					Server: server.URL,
+					Token:  tc.token,
+					UserID: tc.userID,
+					JSON:   true,
+				},
+				http: server.Client(),
+			}
+			output := captureStdout(t, func() error {
+				return c.reactions([]string{tc.action, tc.messageID, tc.emoji})
+			})
+			var result reactionMutationResponse
+			if err := json.Unmarshal([]byte(output), &result); err != nil {
+				t.Fatalf("decode JSON output: %v\n%s", err, output)
+			}
+			var fields map[string]json.RawMessage
+			if err := json.Unmarshal([]byte(output), &fields); err != nil {
+				t.Fatalf("decode JSON fields: %v\n%s", err, output)
+			}
+			if len(fields) != 2 || fields["event"] == nil || fields["reactions"] == nil {
+				t.Fatalf("JSON output keys = %v, want exactly event and reactions", fields)
+			}
+			if result.Event.ID != "evt_1" || len(result.Reactions) != 1 || result.Reactions[0].Emoji != tc.emoji {
+				t.Fatalf("unexpected JSON output: %#v", result)
+			}
+			if requestCount != 1 {
+				t.Fatalf("request count = %d, want 1", requestCount)
+			}
+		})
+	}
+}
+
+func TestClientDispatchesReactionCommands(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/messages/msg_1/reactions" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(reactionMutationResponse{})
+	}))
+	t.Cleanup(server.Close)
+
+	output := captureStdout(t, func() error {
+		return client([]string{
+			"--server", server.URL,
+			"--user", "usr_test",
+			"reactions", "add", "msg_1", "👍", "--json",
+		})
+	})
+	var result reactionMutationResponse
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, output)
+	}
+}
+
+func TestReactionHumanOutputDoesNotEchoUntrustedEmoji(t *testing.T) {
+	messageID := "msg_\n\u202eunsafe"
+	inputs := []string{
+		"ordinary",
+		"line\nbreak",
+		"carriage\rreturn",
+		"escape\x1b[31m",
+		"bidi\u202ereversed",
+		"👍",
+	}
+	for index, emoji := range inputs {
+		t.Run(pastTenseAction("add")+"_"+string(rune('a'+index)), func(t *testing.T) {
+			var receivedEmoji string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]string
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				receivedEmoji = body["emoji"]
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(reactionMutationResponse{
+					Reactions: []store.ReactionSummary{{Emoji: emoji, Count: 1, ReactedByMe: true}},
+				})
+			}))
+			t.Cleanup(server.Close)
+
+			c := apiClient{opts: clientOptions{Server: server.URL}, http: server.Client()}
+			output := captureStdout(t, func() error {
+				return c.reactions([]string{"add", messageID, emoji})
+			})
+			if receivedEmoji != emoji {
+				t.Fatalf("API emoji = %q, want original %q", receivedEmoji, emoji)
+			}
+			wantOutput := "reaction added on " + url.PathEscape(messageID) + "\n"
+			if output != wantOutput {
+				t.Fatalf("human output = %q", output)
+			}
+			if strings.ContainsAny(output[:len(output)-1], "\r\n\x1b") || strings.ContainsRune(output, '\u202e') {
+				t.Fatalf("human output contains unsafe terminal controls: %q", output)
+			}
+		})
+	}
+}
+
+func TestReactionCommandsValidateBeforeNetworkRequest(t *testing.T) {
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requestCount++
+	}))
+	t.Cleanup(server.Close)
+
+	tests := []struct {
+		name string
+		opts clientOptions
+		args []string
+		want string
+	}{
+		{name: "missing command", args: nil, want: "usage:"},
+		{name: "unknown command", args: []string{"toggle", "msg_1", "👍"}, want: `unknown reactions command "toggle"`},
+		{name: "missing emoji", args: []string{"add", "msg_1"}, want: "usage:"},
+		{name: "extra argument", args: []string{"remove", "msg_1", "👍", "extra"}, want: "usage:"},
+		{
+			name: "plain output",
+			opts: clientOptions{Plain: true},
+			args: []string{"add", "msg_1", "👍"},
+			want: "--plain is not supported",
+		},
+		{
+			name: "post-operand plain output",
+			args: []string{"remove", "msg_1", "👍", "--plain"},
+			want: "--plain is not supported",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := apiClient{opts: clientOptions{Server: server.URL, Plain: tc.opts.Plain}, http: server.Client()}
+			err := c.reactions(tc.args)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+	if requestCount != 0 {
+		t.Fatalf("request count = %d, want 0", requestCount)
+	}
+}
+
+func TestReactionCommandsUseCurrentClientErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		response   string
+		want       string
+	}{
+		{name: "API error", statusCode: http.StatusForbidden, response: `{"error":"forbidden"}`, want: "403 Forbidden: forbidden"},
+		{name: "malformed success", statusCode: http.StatusOK, response: `{`, want: "unexpected end of JSON input"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = io.WriteString(w, tc.response)
+			}))
+			t.Cleanup(server.Close)
+			c := apiClient{opts: clientOptions{Server: server.URL}, http: server.Client()}
+			err := c.reactions([]string{"add", "msg_1", "👍"})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want containing %q", err, tc.want)
+			}
+		})
+	}
+
+	c := apiClient{
+		opts: clientOptions{Server: "http://clickclack.invalid"},
+		http: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network unavailable")
+		})},
+	}
+	err := c.reactions([]string{"remove", "msg_1", "👍"})
+	if err == nil || !strings.Contains(err.Error(), "network unavailable") {
+		t.Fatalf("network error = %v", err)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	read, write, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = write
+	t.Cleanup(func() { os.Stdout = oldStdout })
+	if err := fn(); err != nil {
+		_ = write.Close()
+		t.Fatal(err)
+	}
+	if err := write.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = oldStdout
+	output, err := io.ReadAll(read)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := read.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(output)
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+func pastTenseAction(action string) string {
+	if action == "add" {
+		return "added"
+	}
+	return "removed"
+}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1190,7 +1190,12 @@ func (s *Server) removeReaction(w http.ResponseWriter, r *http.Request) {
 	if _, ok := s.requireBotMessageResource(w, r, act, chi.URLParam(r, "message_id"), "dms:write"); !ok {
 		return
 	}
-	event, err := s.store.RemoveReaction(r.Context(), store.CreateReactionInput{MessageID: chi.URLParam(r, "message_id"), UserID: act.user.ID, Emoji: chi.URLParam(r, "emoji")})
+	emoji, err := url.PathUnescape(chi.URLParam(r, "emoji"))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	event, err := s.store.RemoveReaction(r.Context(), store.CreateReactionInput{MessageID: chi.URLParam(r, "message_id"), UserID: act.user.ID, Emoji: emoji})
 	if err == nil && event.ID != "" {
 		s.publishEvent(r.Context(), event)
 	}

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -266,6 +266,21 @@ func TestChatAPIVerticalSlice(t *testing.T) {
 		t.Fatalf("expected duplicate reaction no-op, status=%d response=%#v", duplicateStatus, duplicateReaction)
 	}
 	deleteJSON(t, server.URL+"/api/messages/"+created.Message.ID+"/reactions/lobster")
+	slashEmoji := ":claw:/blue"
+	slashReaction := postJSON[struct {
+		Event     store.Event             `json:"event"`
+		Reactions []store.ReactionSummary `json:"reactions"`
+	}](t, server.URL+"/api/messages/"+created.Message.ID+"/reactions", map[string]string{"emoji": slashEmoji})
+	if slashReaction.Event.Type != "reaction.added" || len(slashReaction.Reactions) != 1 || slashReaction.Reactions[0].Emoji != slashEmoji {
+		t.Fatalf("unexpected slash reaction response: %#v", slashReaction)
+	}
+	removedSlashReaction := deleteJSONAsUser[struct {
+		Event     store.Event             `json:"event"`
+		Reactions []store.ReactionSummary `json:"reactions"`
+	}](t, owner.ID, server.URL+"/api/messages/"+created.Message.ID+"/reactions/"+url.PathEscape(slashEmoji))
+	if removedSlashReaction.Event.Type != "reaction.removed" || len(removedSlashReaction.Reactions) != 0 {
+		t.Fatalf("slash reaction was not removed: %#v", removedSlashReaction)
+	}
 
 	dm := postJSON[struct {
 		Conversation store.DirectConversation `json:"conversation"`

--- a/docs/agent-friendly-cli.md
+++ b/docs/agent-friendly-cli.md
@@ -37,6 +37,7 @@ Implemented now:
 - `channels list`.
 - `send`, `messages send`, `messages list`.
 - `threads open`, `threads reply`, and `reply`.
+- `reactions add` and `reactions remove`.
 - `canary` for a correlated human-to-OpenClaw quoted-reply check.
 - `--server`, `--token`, `--user` / `--user-id`, `--workspace`, `--channel`,
   `--json`, `--plain`, `--no-input`, and `--verbose`.
@@ -45,7 +46,6 @@ Still target-only:
 
 - `workspaces use`, `channels use`, `channels create`.
 - `messages tail`, `messages watch`, `events tail`.
-- reactions from the CLI.
 - Stable non-generic exit-code mapping.
 
 ```text

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,8 @@ Commands:
   messages list
   threads open
   threads reply
+  reactions add
+  reactions remove
 ```
 
 Client commands accept these common flags before the command or on the command
@@ -254,6 +256,17 @@ clickclack --server http://localhost:8080 --token sst_... threads reply msg_... 
 inline-quote an existing message in the same channel/thread (see
 [features/replies.md](features/replies.md)). `--plain` prints only the
 created message ID; `--json` prints the API response.
+
+Reaction commands use the existing public reaction API:
+
+```sh
+clickclack reactions add msg_01kr... "👍"
+clickclack reactions remove msg_01kr... "👍"
+```
+
+Human output confirms the action without echoing the reaction value. `--json`
+prints the API's `{event,reactions}` response. `--plain` is unsupported and
+fails before making a request.
 
 ## `canary`
 


### PR DESCRIPTION
Closes #122

## What Problem This Solves

Agents and scripts can read and send messages with the ClickClack CLI, but they
must drop to custom HTTP calls to add or remove reactions.

## Why This Change Was Made

This adds finite `reactions add` and `reactions remove` commands over the
existing public reaction endpoints. JSON output preserves the API's exact
`{event,reactions}` envelope, human output does not echo the reaction value,
and unsupported plain output fails before any request.

The DELETE route now decodes its escaped emoji path parameter before storage
lookup. That preserves the existing verbatim reaction contract for values
containing `/`; no endpoint or storage semantics changed.

## User Impact

Humans, scripts, and external agents can add and remove reactions through the
standard CLI with existing bearer-token or local development authentication.
Channel, thread, and DM authorization remains owned by the server.

## Evidence

- `umask 022; pnpm check`
- `go test -race ./apps/api/cmd/clickclack`
- Focused real-handler coverage for slash-containing reaction values
- Independent review converged to zero unresolved findings

### Real behavior proof

Executed on macOS from exact PR head
`c111f769a1b6ddb83d25a525cd999684246b5b09`. The compiled binary SHA-256 was
`9ad9f1c2693255b1a3f0aea59b1c7ebe8fe749991c64c3df17825d3a44b54e01`.

The binary talked over HTTP to a fresh, running ClickClack server with a new
SQLite database on loopback. Authentication used the server's explicit local
development `--user` path; no hosted token, private endpoint, or user data was
involved.

```text
$ clickclack --server <loopback> --user <dev-user> send --plain \
    "PR 123 real behavior proof"
msg_<redacted>

$ clickclack --server <loopback> --user <dev-user> \
    reactions add msg_<redacted> ':claw:/blue'
reaction added on msg_<redacted>

$ clickclack --server <loopback> --user <dev-user> messages list --json \
    | jq -c '<select proof message and print id,reactions>'
{"id":"msg_<redacted>","reactions":[{"emoji":":claw:/blue","count":1,"reacted_by_me":true}]}

$ clickclack --server <loopback> --user <dev-user> \
    reactions add msg_<redacted> ':claw:/blue' --json \
    | jq -c '{keys:(keys|sort),event_id:.event.id,reactions}'
{"keys":["event","reactions"],"event_id":"","reactions":[{"emoji":":claw:/blue","count":1,"reacted_by_me":true}]}

$ clickclack --server <loopback> --user <dev-user> \
    reactions remove msg_<redacted> ':claw:/blue'
reaction removed on msg_<redacted>

$ clickclack --server <loopback> --user <dev-user> messages list --json \
    | jq -c '<select proof message and print id,reactions-or-empty>'
{"id":"msg_<redacted>","reactions":[]}

$ clickclack --server <loopback> --user <dev-user> \
    reactions remove msg_<redacted> ':claw:/blue' --json \
    | jq -c '{keys:(keys|sort),event_id:.event.id,reactions}'
{"keys":["event","reactions"],"event_id":"","reactions":[]}
```

This proves real command parsing, explicit authentication selection, HTTP
transport, persisted add state, slash-containing DELETE routing, terminal
output, exact JSON keys, and idempotent add/remove behavior outside test
doubles.
