### PR TITLE
feat: reconcile externally managed channels

### DIFF
--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -177,14 +177,23 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	}
 	reconcileBody["name"] = "pr-125-review"
 	reconcileBody["archived"] = true
+	reconcileBody["kind"] = "private"
 	changed, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
-	if status != http.StatusOK || changed.Action != store.ManagedChannelActionUpdated || changed.Event == nil || changed.Event.Type != "channel.updated" || changed.Channel.ID != reconciled.Channel.ID || changed.Channel.ArchivedAt == nil {
+	if status != http.StatusOK || changed.Action != store.ManagedChannelActionUpdated || changed.Event == nil || changed.Event.Type != "channel.updated" || changed.Channel.ID != reconciled.Channel.ID || changed.Channel.ArchivedAt == nil || changed.Channel.Kind != "private" {
 		t.Fatalf("unexpected managed channel update reconciliation: status=%d result=%#v", status, changed)
 	}
 	reconcileBody["archived"] = false
 	reopened, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
 	if status != http.StatusOK || reopened.Action != store.ManagedChannelActionUpdated || reopened.Channel.ID != reconciled.Channel.ID || reopened.Channel.ArchivedAt != nil {
 		t.Fatalf("unexpected managed channel reopen reconciliation: status=%d result=%#v", status, reopened)
+	}
+	delete(reconcileBody, "kind")
+	delete(reconcileBody, "archived")
+	delete(reconcileBody, "external_url")
+	delete(reconcileBody, "sidebar_section")
+	defaulted, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
+	if status != http.StatusOK || defaulted.Action != store.ManagedChannelActionUpdated || defaulted.Channel.Kind != "public" || defaulted.Channel.ArchivedAt != nil || defaulted.Channel.ExternalURL != nil || defaulted.Channel.SidebarSection != nil {
+		t.Fatalf("omitted desired fields did not reconcile to defaults: status=%d result=%#v", status, defaulted)
 	}
 	expectStatus(t, http.MethodPatch, server.URL+"/api/channels/"+reconciled.Channel.ID, strings.NewReader(`{"external_ref":""}`), http.StatusBadRequest)
 	message := postJSON[struct {

--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -19,6 +19,68 @@ import (
 	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
 )
 
+func TestManagedChannelReconciliationBotAuthorization(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	otherWorkspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Other Workspace"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bot, token, err := st.CreateBot(ctx, store.CreateBotInput{
+		WorkspaceID: workspace.ID,
+		OwnerUserID: owner.ID,
+		DisplayName: "Managed Channel Bot",
+		Scopes:      []string{"channels:write"},
+		CreatedBy:   owner.ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, otherWorkspace.ID, bot.ID, "bot"); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	t.Cleanup(server.Close)
+	body := `{"external_provider":"github","external_ref":"openclaw/clickclack#125","name":"pr-125"}`
+	result, status := postJSONWithBearerStatus[store.ReconcileManagedChannelResult](
+		t,
+		token.Token,
+		server.URL+"/api/workspaces/"+workspace.ID+"/managed-channels/reconcile",
+		body,
+	)
+	if status != http.StatusCreated || result.Action != store.ManagedChannelActionCreated {
+		t.Fatalf("expected authorized bot reconciliation, status=%d result=%#v", status, result)
+	}
+	_, status = postJSONWithBearerStatus[store.ReconcileManagedChannelResult](
+		t,
+		token.Token,
+		server.URL+"/api/workspaces/"+otherWorkspace.ID+"/managed-channels/reconcile",
+		body,
+	)
+	if status != http.StatusForbidden {
+		t.Fatalf("expected workspace-bound bot token to be rejected, got %d", status)
+	}
+}
+
 func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -97,6 +159,34 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	if payload, ok := archivedManaged.Event.Payload.(map[string]any); !ok || payload["archived"] != true {
 		t.Fatalf("archive state missing from channel.updated metadata: %#v", archivedManaged.Event.Payload)
 	}
+	reconcileURL := server.URL + "/api/workspaces/" + workspaces[0].ID + "/managed-channels/reconcile"
+	reconcileBody := map[string]any{
+		"external_provider": "github",
+		"external_ref":      "repo:42:pull:125",
+		"name":              "pr-125",
+		"external_url":      "https://github.com/openclaw/clickclack/pull/125",
+		"sidebar_section":   "Pull requests",
+	}
+	reconciled, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
+	if status != http.StatusCreated || reconciled.Action != store.ManagedChannelActionCreated || reconciled.Event == nil || reconciled.Channel.ExternalProvider == nil || *reconciled.Channel.ExternalProvider != "github" {
+		t.Fatalf("unexpected managed channel create reconciliation: status=%d result=%#v", status, reconciled)
+	}
+	replayed, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
+	if status != http.StatusOK || replayed.Action != store.ManagedChannelActionUnchanged || replayed.Event != nil || replayed.Channel.ID != reconciled.Channel.ID {
+		t.Fatalf("unexpected managed channel replay: status=%d result=%#v", status, replayed)
+	}
+	reconcileBody["name"] = "pr-125-review"
+	reconcileBody["archived"] = true
+	changed, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
+	if status != http.StatusOK || changed.Action != store.ManagedChannelActionUpdated || changed.Event == nil || changed.Event.Type != "channel.updated" || changed.Channel.ID != reconciled.Channel.ID || changed.Channel.ArchivedAt == nil {
+		t.Fatalf("unexpected managed channel update reconciliation: status=%d result=%#v", status, changed)
+	}
+	reconcileBody["archived"] = false
+	reopened, status := postJSONWithStatus[store.ReconcileManagedChannelResult](t, reconcileURL, reconcileBody)
+	if status != http.StatusOK || reopened.Action != store.ManagedChannelActionUpdated || reopened.Channel.ID != reconciled.Channel.ID || reopened.Channel.ArchivedAt != nil {
+		t.Fatalf("unexpected managed channel reopen reconciliation: status=%d result=%#v", status, reopened)
+	}
+	expectStatus(t, http.MethodPatch, server.URL+"/api/channels/"+reconciled.Channel.ID, strings.NewReader(`{"external_ref":""}`), http.StatusBadRequest)
 	message := postJSON[struct {
 		Message store.Message `json:"message"`
 	}](t, server.URL+"/api/channels/"+channels[0].ID+"/messages", map[string]string{"body": "original"}).Message

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -169,6 +169,7 @@ func (s *Server) Handler() http.Handler {
 		r.Patch("/workspaces/{workspace_id}/moderation/members/{user_id}", s.updateWorkspaceMemberModeration)
 		r.Get("/workspaces/{workspace_id}/channels", s.listChannels)
 		r.Post("/workspaces/{workspace_id}/channels", s.createChannel)
+		r.Post("/workspaces/{workspace_id}/managed-channels/reconcile", s.reconcileManagedChannel)
 		r.Get("/workspaces/{workspace_id}/topics", s.listTopics)
 		r.Post("/workspaces/{workspace_id}/topics", s.createTopic)
 		r.Get("/workspaces/{workspace_id}/bots", s.listBots)
@@ -887,6 +888,59 @@ func (s *Server) createChannel(w http.ResponseWriter, r *http.Request) {
 		s.publishEvent(r.Context(), event)
 	}
 	writeResultStatus(w, http.StatusCreated, map[string]any{"channel": channel, "event": event}, err)
+}
+
+func (s *Server) reconcileManagedChannel(w http.ResponseWriter, r *http.Request) {
+	act, err := s.currentActor(r)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, err)
+		return
+	}
+	if err := act.requireScope("channels:write"); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+	workspaceID := chi.URLParam(r, "workspace_id")
+	if err := act.requireWorkspace(workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+	var body struct {
+		ExternalProvider string `json:"external_provider"`
+		ExternalRef      string `json:"external_ref"`
+		Name             string `json:"name"`
+		Kind             string `json:"kind"`
+		Archived         bool   `json:"archived"`
+		ExternalURL      string `json:"external_url"`
+		SidebarSection   string `json:"sidebar_section"`
+	}
+	if err := readJSON(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	result, err := s.store.ReconcileManagedChannel(r.Context(), store.ReconcileManagedChannelInput{
+		WorkspaceID:      workspaceID,
+		UserID:           act.user.ID,
+		ExternalProvider: body.ExternalProvider,
+		ExternalRef:      body.ExternalRef,
+		Name:             body.Name,
+		Kind:             body.Kind,
+		Archived:         body.Archived,
+		ExternalURL:      body.ExternalURL,
+		SidebarSection:   body.SidebarSection,
+	})
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if result.Event != nil {
+		s.publishEvent(r.Context(), *result.Event)
+	}
+	status := http.StatusOK
+	if result.Action == store.ManagedChannelActionCreated {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, result)
 }
 
 func (s *Server) listTopics(w http.ResponseWriter, r *http.Request) {

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -1725,6 +1725,7 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 		{"get workspace", http.MethodGet, "/api/workspaces/" + workspace.ID, "", ""},
 		{"list channels", http.MethodGet, "/api/workspaces/" + workspace.ID + "/channels", "", ""},
 		{"create channel", http.MethodPost, "/api/workspaces/" + workspace.ID + "/channels", `{"name":"bot-channel"}`, "application/json"},
+		{"reconcile managed channel", http.MethodPost, "/api/workspaces/" + workspace.ID + "/managed-channels/reconcile", `{"external_provider":"github","external_ref":"repo:42:pull:125","name":"pr-125"}`, "application/json"},
 		{"update channel", http.MethodPatch, "/api/channels/" + channel.ID, `{"name":"bot-channel"}`, "application/json"},
 		{"list messages", http.MethodGet, "/api/channels/" + channel.ID + "/messages", "", ""},
 		{"update message", http.MethodPatch, "/api/messages/" + messageID, `{"body":"blocked"}`, "application/json"},

--- a/apps/api/internal/store/managed_channels.go
+++ b/apps/api/internal/store/managed_channels.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	ManagedChannelActionCreated   = "created"
+	ManagedChannelActionUpdated   = "updated"
+	ManagedChannelActionUnchanged = "unchanged"
+
+	maxExternalRefRunes = 512
+)
+
+var (
+	externalProviderPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]{0,63}$`)
+
+	ErrManagedChannelIdentityImmutable = errors.New("reconciled managed channel identity is immutable")
+)
+
+type ReconcileManagedChannelInput struct {
+	WorkspaceID      string
+	UserID           string
+	ExternalProvider string
+	ExternalRef      string
+	Name             string
+	Kind             string
+	Archived         bool
+	ExternalURL      string
+	SidebarSection   string
+}
+
+type ReconcileManagedChannelResult struct {
+	Channel Channel `json:"channel"`
+	Action  string  `json:"action"`
+	Event   *Event  `json:"event,omitempty"`
+}
+
+func NormalizeManagedChannelIdentity(provider, ref string) (string, string, error) {
+	provider = strings.TrimSpace(provider)
+	ref = strings.TrimSpace(ref)
+	if !externalProviderPattern.MatchString(provider) {
+		return "", "", errors.New("external_provider must be 1-64 lowercase letters, digits, dots, underscores, or hyphens")
+	}
+	if ref == "" {
+		return "", "", errors.New("external_ref is required")
+	}
+	if !utf8.ValidString(ref) || utf8.RuneCountInString(ref) > maxExternalRefRunes {
+		return "", "", errors.New("external_ref must be valid UTF-8 with at most 512 characters")
+	}
+	for _, value := range ref {
+		if unicode.IsControl(value) {
+			return "", "", errors.New("external_ref cannot contain control characters")
+		}
+	}
+	return provider, ref, nil
+}

--- a/apps/api/internal/store/managed_channels_test.go
+++ b/apps/api/internal/store/managed_channels_test.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeManagedChannelIdentity(t *testing.T) {
+	t.Parallel()
+	provider, ref, err := NormalizeManagedChannelIdentity(" github ", " openclaw/clickclack#125 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if provider != "github" || ref != "openclaw/clickclack#125" {
+		t.Fatalf("unexpected normalized identity: provider=%q ref=%q", provider, ref)
+	}
+
+	tests := []struct {
+		name     string
+		provider string
+		ref      string
+	}{
+		{name: "empty provider", ref: "item"},
+		{name: "uppercase provider", provider: "GitHub", ref: "item"},
+		{name: "provider too long", provider: strings.Repeat("a", 65), ref: "item"},
+		{name: "empty ref", provider: "github"},
+		{name: "ref too long", provider: "github", ref: strings.Repeat("x", 513)},
+		{name: "control character in ref", provider: "github", ref: "pull\n125"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := NormalizeManagedChannelIdentity(tt.provider, tt.ref); err == nil {
+				t.Fatal("expected invalid managed channel identity")
+			}
+		})
+	}
+}

--- a/apps/api/internal/store/postgres/managed_channels.go
+++ b/apps/api/internal/store/postgres/managed_channels.go
@@ -202,6 +202,7 @@ func isManagedChannelReconcileConflict(err error) bool {
 	}
 	message := err.Error()
 	return strings.Contains(message, "idx_channels_managed_identity") ||
+		strings.Contains(message, "channels_workspace_id_name_key") ||
 		strings.Contains(message, "route_id") ||
 		strings.Contains(message, "could not serialize access")
 }

--- a/apps/api/internal/store/postgres/managed_channels.go
+++ b/apps/api/internal/store/postgres/managed_channels.go
@@ -1,0 +1,207 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/postgres/storedb"
+)
+
+const managedChannelReconcileAttempts = 5
+
+func (s *Store) ReconcileManagedChannel(ctx context.Context, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	provider, ref, err := store.NormalizeManagedChannelIdentity(input.ExternalProvider, input.ExternalRef)
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	input.ExternalProvider = provider
+	input.ExternalRef = ref
+	for attempt := 0; attempt < managedChannelReconcileAttempts; attempt++ {
+		result, err := s.reconcileManagedChannelOnce(ctx, input)
+		if err == nil {
+			return result, nil
+		}
+		if !isManagedChannelReconcileConflict(err) {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+		time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+	}
+	return store.ReconcileManagedChannelResult{}, errors.New("could not reconcile managed channel after concurrent updates")
+}
+
+func (s *Store) reconcileManagedChannelOnce(ctx context.Context, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	defer tx.Rollback()
+	if err := requireNonGuestTx(ctx, tx, input.WorkspaceID, input.UserID); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if err := requireNoModerationBlockTx(ctx, tx, input.WorkspaceID, input.UserID); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetManagedChannelByIdentity(ctx, storedb.GetManagedChannelByIdentityParams{
+		WorkspaceID:      input.WorkspaceID,
+		ExternalProvider: sqlText(input.ExternalProvider),
+		ExternalRef:      sqlText(input.ExternalRef),
+	})
+	switch {
+	case err == nil:
+		return reconcileExistingManagedChannel(ctx, tx, qtx, storeChannelFromGetManagedChannelByIdentity(row), input)
+	case !errors.Is(err, sql.ErrNoRows):
+		return store.ReconcileManagedChannelResult{}, err
+	}
+
+	name := slug(input.Name)
+	if name == "" {
+		return store.ReconcileManagedChannelResult{}, errors.New("managed channel name is required")
+	}
+	if name == store.GuestChannelName {
+		return store.ReconcileManagedChannelResult{}, errors.New("guest channel name is reserved")
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = "public"
+	}
+	provider := input.ExternalProvider
+	ref := input.ExternalRef
+	channel := store.Channel{
+		ID:               newID("chn"),
+		WorkspaceID:      input.WorkspaceID,
+		Name:             name,
+		Kind:             kind,
+		CreatedAt:        now(),
+		ExternalManaged:  true,
+		ExternalProvider: &provider,
+		ExternalRef:      &ref,
+		ExternalURL:      optionalTrimmedString(input.ExternalURL),
+		SidebarSection:   optionalTrimmedString(input.SidebarSection),
+	}
+	if input.Archived {
+		value := now()
+		channel.ArchivedAt = &value
+	}
+	routeID, err := newRouteID('C')
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	channel.RouteID = routeID
+	if err := qtx.InsertChannel(ctx, storedb.InsertChannelParams{
+		ID:               channel.ID,
+		RouteID:          sqlText(channel.RouteID),
+		WorkspaceID:      channel.WorkspaceID,
+		Name:             channel.Name,
+		Kind:             channel.Kind,
+		CreatedAt:        channel.CreatedAt,
+		ExternalManaged:  databaseBool(true),
+		ExternalProvider: sqlText(input.ExternalProvider),
+		ExternalRef:      sqlText(input.ExternalRef),
+		ExternalUrl:      nullFromPtr(channel.ExternalURL),
+		SidebarSection:   nullFromPtr(channel.SidebarSection),
+	}); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if channel.ArchivedAt != nil {
+		if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
+			Name:             channel.Name,
+			Kind:             channel.Kind,
+			ArchivedAt:       nullFromPtr(channel.ArchivedAt),
+			ExternalManaged:  databaseBool(true),
+			ExternalProvider: sqlText(input.ExternalProvider),
+			ExternalRef:      sqlText(input.ExternalRef),
+			ExternalUrl:      nullFromPtr(channel.ExternalURL),
+			SidebarSection:   nullFromPtr(channel.SidebarSection),
+			ID:               channel.ID,
+		}); err != nil {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+	}
+	event, err := insertEvent(ctx, tx, channel.WorkspaceID, channel.ID, "channel.created", nil, map[string]string{"channel_id": channel.ID})
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionCreated, Event: &event}, nil
+}
+
+func reconcileExistingManagedChannel(ctx context.Context, tx *sql.Tx, qtx *storedb.Queries, channel store.Channel, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	name := slug(input.Name)
+	if name == "" {
+		return store.ReconcileManagedChannelResult{}, errors.New("managed channel name is required")
+	}
+	if name == store.GuestChannelName {
+		return store.ReconcileManagedChannelResult{}, errors.New("guest channel name is reserved")
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = "public"
+	}
+	archivedAt := channel.ArchivedAt
+	if input.Archived && archivedAt == nil {
+		value := now()
+		archivedAt = &value
+	}
+	if !input.Archived {
+		archivedAt = nil
+	}
+	externalURL := optionalTrimmedString(input.ExternalURL)
+	sidebarSection := optionalTrimmedString(input.SidebarSection)
+	changed := !channel.ExternalManaged ||
+		channel.Name != name ||
+		channel.Kind != kind ||
+		(channel.ArchivedAt == nil) != (archivedAt == nil) ||
+		!equalOptionalString(channel.ExternalURL, externalURL) ||
+		!equalOptionalString(channel.SidebarSection, sidebarSection)
+	if !changed {
+		if err := tx.Commit(); err != nil {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+		return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionUnchanged}, nil
+	}
+	if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
+		Name:             name,
+		Kind:             kind,
+		ArchivedAt:       nullFromPtr(archivedAt),
+		ExternalManaged:  databaseBool(true),
+		ExternalProvider: nullFromPtr(channel.ExternalProvider),
+		ExternalRef:      nullFromPtr(channel.ExternalRef),
+		ExternalUrl:      nullFromPtr(externalURL),
+		SidebarSection:   nullFromPtr(sidebarSection),
+		ID:               channel.ID,
+	}); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	event, err := insertEvent(ctx, tx, channel.WorkspaceID, channel.ID, "channel.updated", nil, map[string]any{"channel_id": channel.ID, "archived": archivedAt != nil})
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	channel.Name = name
+	channel.Kind = kind
+	channel.ArchivedAt = archivedAt
+	channel.ExternalManaged = true
+	channel.ExternalURL = externalURL
+	channel.SidebarSection = sidebarSection
+	if err := tx.Commit(); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionUpdated, Event: &event}, nil
+}
+
+func isManagedChannelReconcileConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "idx_channels_managed_identity") ||
+		strings.Contains(message, "route_id") ||
+		strings.Contains(message, "could not serialize access")
+}

--- a/apps/api/internal/store/postgres/migrations/0033_managed_channel_reconciliation.sql
+++ b/apps/api/internal/store/postgres/migrations/0033_managed_channel_reconciliation.sql
@@ -1,0 +1,5 @@
+ALTER TABLE channels ADD COLUMN external_provider TEXT;
+
+CREATE UNIQUE INDEX idx_channels_managed_identity
+  ON channels(workspace_id, external_provider, external_ref)
+  WHERE external_provider IS NOT NULL AND external_ref IS NOT NULL;

--- a/apps/api/internal/store/postgres/mutations.go
+++ b/apps/api/internal/store/postgres/mutations.go
@@ -282,6 +282,11 @@ func (s *Store) UpdateChannel(ctx context.Context, input store.UpdateChannelInpu
 	if input.ExternalRef != nil {
 		externalRef = optionalTrimmedString(*input.ExternalRef)
 	}
+	if ch.ExternalProvider != nil &&
+		((input.ExternalManaged != nil && !externalManaged) ||
+			(input.ExternalRef != nil && !equalOptionalString(externalRef, ch.ExternalRef))) {
+		return store.Channel{}, store.Event{}, store.ErrManagedChannelIdentityImmutable
+	}
 	externalURL := ch.ExternalURL
 	if input.ExternalURL != nil {
 		externalURL = optionalTrimmedString(*input.ExternalURL)
@@ -291,14 +296,15 @@ func (s *Store) UpdateChannel(ctx context.Context, input store.UpdateChannelInpu
 		sidebarSection = optionalTrimmedString(*input.SidebarSection)
 	}
 	if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
-		Name:            name,
-		Kind:            kind,
-		ArchivedAt:      nullFromPtr(archivedValue),
-		ExternalManaged: databaseBool(externalManaged),
-		ExternalRef:     nullFromPtr(externalRef),
-		ExternalUrl:     nullFromPtr(externalURL),
-		SidebarSection:  nullFromPtr(sidebarSection),
-		ID:              ch.ID,
+		Name:             name,
+		Kind:             kind,
+		ArchivedAt:       nullFromPtr(archivedValue),
+		ExternalManaged:  databaseBool(externalManaged),
+		ExternalProvider: nullFromPtr(ch.ExternalProvider),
+		ExternalRef:      nullFromPtr(externalRef),
+		ExternalUrl:      nullFromPtr(externalURL),
+		SidebarSection:   nullFromPtr(sidebarSection),
+		ID:               ch.ID,
 	}); err != nil {
 		return store.Channel{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/postgres/mutations_test.go
+++ b/apps/api/internal/store/postgres/mutations_test.go
@@ -141,6 +141,61 @@ func TestManagedChannelReconciliationConvergesPostgres(t *testing.T) {
 	}
 }
 
+func TestManagedChannelReconciliationMigrationPreservesLegacyChannelsPostgres(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	applyPostgresMigrationsBefore(t, ctx, st, "0033_managed_channel_reconciliation.sql")
+
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Upgrade Owner", Email: "upgrade-postgres@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Upgrade Postgres", Slug: "upgrade-postgres"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const legacyID = "chn_legacy_managed"
+	if _, err := st.db.ExecContext(ctx, `
+		INSERT INTO channels (id, workspace_id, name, kind, created_at, external_managed, external_ref)
+		VALUES ($1, $2, 'legacy-managed', 'public', $3, 1, 'repo:42:pull:125')`,
+		legacyID, workspace.ID, now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var migrated store.Channel
+	for _, channel := range channels {
+		if channel.ID == legacyID {
+			migrated = channel
+			break
+		}
+	}
+	if migrated.ID == "" || !migrated.ExternalManaged || migrated.ExternalProvider != nil || migrated.ExternalRef == nil || *migrated.ExternalRef != "repo:42:pull:125" {
+		t.Fatalf("legacy managed channel was not preserved: %#v", migrated)
+	}
+
+	result, err := st.ReconcileManagedChannel(ctx, store.ReconcileManagedChannelInput{
+		WorkspaceID:      workspace.ID,
+		UserID:           owner.ID,
+		ExternalProvider: "github",
+		ExternalRef:      "repo:42:pull:125",
+		Name:             "provider-managed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Action != store.ManagedChannelActionCreated || result.Channel.ID == legacyID {
+		t.Fatalf("provider identity should not capture a legacy unnamespaced channel: %#v", result)
+	}
+}
+
 func TestManagedChannelReconcileRetriesConcurrentNameConflictPostgres(t *testing.T) {
 	t.Parallel()
 	if !isManagedChannelReconcileConflict(errors.New(`duplicate key value violates unique constraint "channels_workspace_id_name_key"`)) {

--- a/apps/api/internal/store/postgres/mutations_test.go
+++ b/apps/api/internal/store/postgres/mutations_test.go
@@ -141,6 +141,13 @@ func TestManagedChannelReconciliationConvergesPostgres(t *testing.T) {
 	}
 }
 
+func TestManagedChannelReconcileRetriesConcurrentNameConflictPostgres(t *testing.T) {
+	t.Parallel()
+	if !isManagedChannelReconcileConflict(errors.New(`duplicate key value violates unique constraint "channels_workspace_id_name_key"`)) {
+		t.Fatal("expected concurrent channel-name collision to be retried")
+	}
+}
+
 func TestWorkspaceUpdateSerializesPartialWrites(t *testing.T) {
 	ctx := context.Background()
 	st := newIsolatedPostgresTestStore(t)

--- a/apps/api/internal/store/postgres/mutations_test.go
+++ b/apps/api/internal/store/postgres/mutations_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -58,6 +59,85 @@ func TestManagedChannelFieldsRoundTripPostgres(t *testing.T) {
 	payload, ok := event.Payload.(map[string]any)
 	if !ok || payload["archived"] != true {
 		t.Fatalf("channel.updated archive metadata missing: %#v", event.Payload)
+	}
+}
+
+func TestManagedChannelReconciliationConvergesPostgres(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Reconcile Owner", Email: "reconcile-postgres@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Reconcile Postgres", Slug: "reconcile-postgres"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := store.ReconcileManagedChannelInput{
+		WorkspaceID:      workspace.ID,
+		UserID:           owner.ID,
+		ExternalProvider: "github",
+		ExternalRef:      "repo:42:pull:125",
+		Name:             "pr-125",
+		ExternalURL:      "https://github.com/openclaw/clickclack/pull/125",
+		SidebarSection:   "Pull requests",
+	}
+	const callers = 6
+	results := make(chan store.ReconcileManagedChannelResult, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := st.ReconcileManagedChannel(ctx, input)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- result
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	var channelID string
+	created := 0
+	unchanged := 0
+	for result := range results {
+		if channelID == "" {
+			channelID = result.Channel.ID
+		}
+		if result.Channel.ID != channelID {
+			t.Fatalf("reconcile produced multiple channels: %s and %s", channelID, result.Channel.ID)
+		}
+		switch result.Action {
+		case store.ManagedChannelActionCreated:
+			created++
+		case store.ManagedChannelActionUnchanged:
+			unchanged++
+		default:
+			t.Fatalf("unexpected reconcile action: %#v", result)
+		}
+	}
+	if created != 1 || unchanged != callers-1 {
+		t.Fatalf("expected one create and %d unchanged results, got create=%d unchanged=%d", callers-1, created, unchanged)
+	}
+	changed := input
+	changed.Archived = true
+	changed.Name = "pr-125-review"
+	updated, err := st.ReconcileManagedChannel(ctx, changed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Channel.ID != channelID || updated.Channel.ArchivedAt == nil || updated.Action != store.ManagedChannelActionUpdated {
+		t.Fatalf("unexpected changed reconciliation: %#v", updated)
 	}
 }
 

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -570,16 +570,17 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 		}
 		ch.RouteID = routeID
 		if err := s.q.WithTx(tx).InsertChannel(ctx, storedb.InsertChannelParams{
-			ID:              ch.ID,
-			RouteID:         sqlText(ch.RouteID),
-			WorkspaceID:     ch.WorkspaceID,
-			Name:            ch.Name,
-			Kind:            ch.Kind,
-			CreatedAt:       ch.CreatedAt,
-			ExternalManaged: databaseBool(ch.ExternalManaged),
-			ExternalRef:     nullFromPtr(ch.ExternalRef),
-			ExternalUrl:     nullFromPtr(ch.ExternalURL),
-			SidebarSection:  nullFromPtr(ch.SidebarSection),
+			ID:               ch.ID,
+			RouteID:          sqlText(ch.RouteID),
+			WorkspaceID:      ch.WorkspaceID,
+			Name:             ch.Name,
+			Kind:             ch.Kind,
+			CreatedAt:        ch.CreatedAt,
+			ExternalManaged:  databaseBool(ch.ExternalManaged),
+			ExternalProvider: sql.NullString{},
+			ExternalRef:      nullFromPtr(ch.ExternalRef),
+			ExternalUrl:      nullFromPtr(ch.ExternalURL),
+			SidebarSection:   nullFromPtr(ch.SidebarSection),
 		}); err != nil {
 			if isRouteIDConflict(err) {
 				continue

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -500,12 +500,12 @@ INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at)
 VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), 'general', 'public', sqlc.arg(created_at));
 
 -- name: InsertChannel :exec
-INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_ref, external_url, sidebar_section)
-VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), sqlc.arg(name), sqlc.arg(kind), sqlc.arg(created_at), sqlc.arg(external_managed), sqlc.arg(external_ref), sqlc.arg(external_url), sqlc.arg(sidebar_section));
+INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_provider, external_ref, external_url, sidebar_section)
+VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), sqlc.arg(name), sqlc.arg(kind), sqlc.arg(created_at), sqlc.arg(external_managed), sqlc.arg(external_provider), sqlc.arg(external_ref), sqlc.arg(external_url), sqlc.arg(sidebar_section));
 
 -- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
-       c.external_managed, c.external_ref, c.external_url, c.sidebar_section,
+       c.external_managed, c.external_provider, c.external_ref, c.external_url, c.sidebar_section,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS BIGINT) AS last_seq,
        CAST(COALESCE((SELECT cr.last_read_seq FROM channel_reads cr WHERE cr.channel_id = c.id AND cr.user_id = sqlc.arg(reader_user_id)), 0) AS BIGINT) AS last_read_seq,
        CAST(COALESCE((
@@ -1243,20 +1243,29 @@ VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(channel_id), sqlc.arg(dir
 
 -- name: GetChannel :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE id = sqlc.arg(id);
 
+-- name: GetManagedChannelByIdentity :one
+SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
+       external_managed, external_provider, external_ref, external_url, sidebar_section
+FROM channels
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND external_provider = sqlc.arg(external_provider)
+  AND external_ref = sqlc.arg(external_ref)
+FOR UPDATE;
+
 -- name: GetChannelByIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND id = sqlc.arg(id);
 
 -- name: GetChannelByRouteIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND route_id = sqlc.arg(route_id);
@@ -1300,6 +1309,7 @@ SET name = sqlc.arg(name),
     kind = sqlc.arg(kind),
     archived_at = sqlc.arg(archived_at),
     external_managed = sqlc.arg(external_managed),
+    external_provider = sqlc.arg(external_provider),
     external_ref = sqlc.arg(external_ref),
     external_url = sqlc.arg(external_url),
     sidebar_section = sqlc.arg(sidebar_section)

--- a/apps/api/internal/store/postgres/sqlc/schema.sql
+++ b/apps/api/internal/store/postgres/sqlc/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE channels (
   archived_at TEXT,
   route_id TEXT,
   external_managed INTEGER NOT NULL DEFAULT 0,
+  external_provider TEXT,
   external_ref TEXT,
   external_url TEXT,
   sidebar_section TEXT,
@@ -82,6 +83,9 @@ CREATE TABLE channels (
 );
 
 CREATE UNIQUE INDEX idx_channels_workspace_route_id ON channels(workspace_id, route_id) WHERE route_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_channels_managed_identity
+  ON channels(workspace_id, external_provider, external_ref)
+  WHERE external_provider IS NOT NULL AND external_ref IS NOT NULL;
 
 CREATE TABLE direct_conversations (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/postgres/sqlc_adapters.go
+++ b/apps/api/internal/store/postgres/sqlc_adapters.go
@@ -46,6 +46,13 @@ func optionalTrimmedString(value string) *string {
 	return &trimmed
 }
 
+func equalOptionalString(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
 func databaseBool(value bool) int32 {
 	if value {
 		return 1
@@ -187,36 +194,55 @@ func storeUploadFromGetUploadByOwnerNonce(row storedb.GetUploadByOwnerNonceRow) 
 
 func storeChannelFromGetChannel(row storedb.GetChannelRow) store.Channel {
 	return store.Channel{
-		ID:              row.ID,
-		RouteID:         row.RouteID,
-		WorkspaceID:     row.WorkspaceID,
-		Name:            row.Name,
-		Kind:            row.Kind,
-		CreatedAt:       row.CreatedAt,
-		ArchivedAt:      ptrFromNull(row.ArchivedAt),
-		ExternalManaged: row.ExternalManaged == 1,
-		ExternalRef:     ptrFromNull(row.ExternalRef),
-		ExternalURL:     ptrFromNull(row.ExternalUrl),
-		SidebarSection:  ptrFromNull(row.SidebarSection),
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
 	}
 }
 
 func storeChannelFromListChannels(row storedb.ListChannelsRow) store.Channel {
 	return store.Channel{
-		ID:              row.ID,
-		RouteID:         row.RouteID,
-		WorkspaceID:     row.WorkspaceID,
-		Name:            row.Name,
-		Kind:            row.Kind,
-		CreatedAt:       row.CreatedAt,
-		ArchivedAt:      ptrFromNull(row.ArchivedAt),
-		ExternalManaged: row.ExternalManaged == 1,
-		ExternalRef:     ptrFromNull(row.ExternalRef),
-		ExternalURL:     ptrFromNull(row.ExternalUrl),
-		SidebarSection:  ptrFromNull(row.SidebarSection),
-		LastSeq:         row.LastSeq,
-		LastReadSeq:     row.LastReadSeq,
-		UnreadCount:     row.UnreadCount,
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
+		LastSeq:          row.LastSeq,
+		LastReadSeq:      row.LastReadSeq,
+		UnreadCount:      row.UnreadCount,
+	}
+}
+
+func storeChannelFromGetManagedChannelByIdentity(row storedb.GetManagedChannelByIdentityRow) store.Channel {
+	return store.Channel{
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
 	}
 }
 

--- a/apps/api/internal/store/postgres/storedb/models.go
+++ b/apps/api/internal/store/postgres/storedb/models.go
@@ -104,17 +104,18 @@ type BotTombstone struct {
 }
 
 type Channel struct {
-	ID              string         `json:"id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	RouteID         sql.NullString `json:"route_id"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	RouteID          sql.NullString `json:"route_id"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 type ChannelRead struct {

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1043,23 +1043,24 @@ func (q *Queries) GetBotTokenAuth(ctx context.Context, tokenHash string) (GetBot
 
 const getChannel = `-- name: GetChannel :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE id = $1
 `
 
 type GetChannelRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, error) {
@@ -1074,6 +1075,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, err
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1083,7 +1085,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, err
 
 const getChannelByIDAndWorkspace = `-- name: GetChannelByIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = $1
   AND id = $2
@@ -1095,17 +1097,18 @@ type GetChannelByIDAndWorkspaceParams struct {
 }
 
 type GetChannelByIDAndWorkspaceRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannelByIDAndWorkspaceParams) (GetChannelByIDAndWorkspaceRow, error) {
@@ -1120,6 +1123,7 @@ func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannel
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1129,7 +1133,7 @@ func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannel
 
 const getChannelByRouteIDAndWorkspace = `-- name: GetChannelByRouteIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = $1
   AND route_id = $2
@@ -1141,17 +1145,18 @@ type GetChannelByRouteIDAndWorkspaceParams struct {
 }
 
 type GetChannelByRouteIDAndWorkspaceRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannelByRouteIDAndWorkspace(ctx context.Context, arg GetChannelByRouteIDAndWorkspaceParams) (GetChannelByRouteIDAndWorkspaceRow, error) {
@@ -1166,6 +1171,7 @@ func (q *Queries) GetChannelByRouteIDAndWorkspace(ctx context.Context, arg GetCh
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1453,6 +1459,57 @@ func (q *Queries) GetMagicLinkByToken(ctx context.Context, tokenHash string) (Au
 		&i.CreatedAt,
 		&i.ExpiresAt,
 		&i.UsedAt,
+	)
+	return i, err
+}
+
+const getManagedChannelByIdentity = `-- name: GetManagedChannelByIdentity :one
+SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
+       external_managed, external_provider, external_ref, external_url, sidebar_section
+FROM channels
+WHERE workspace_id = $1
+  AND external_provider = $2
+  AND external_ref = $3
+FOR UPDATE
+`
+
+type GetManagedChannelByIdentityParams struct {
+	WorkspaceID      string         `json:"workspace_id"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+}
+
+type GetManagedChannelByIdentityRow struct {
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+}
+
+func (q *Queries) GetManagedChannelByIdentity(ctx context.Context, arg GetManagedChannelByIdentityParams) (GetManagedChannelByIdentityRow, error) {
+	row := q.db.QueryRowContext(ctx, getManagedChannelByIdentity, arg.WorkspaceID, arg.ExternalProvider, arg.ExternalRef)
+	var i GetManagedChannelByIdentityRow
+	err := row.Scan(
+		&i.ID,
+		&i.RouteID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Kind,
+		&i.CreatedAt,
+		&i.ArchivedAt,
+		&i.ExternalManaged,
+		&i.ExternalProvider,
+		&i.ExternalRef,
+		&i.ExternalUrl,
+		&i.SidebarSection,
 	)
 	return i, err
 }
@@ -2144,21 +2201,22 @@ func (q *Queries) InsertBotUser(ctx context.Context, arg InsertBotUserParams) er
 }
 
 const insertChannel = `-- name: InsertChannel :exec
-INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_ref, external_url, sidebar_section)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_provider, external_ref, external_url, sidebar_section)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 `
 
 type InsertChannelParams struct {
-	ID              string         `json:"id"`
-	RouteID         sql.NullString `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          sql.NullString `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) InsertChannel(ctx context.Context, arg InsertChannelParams) error {
@@ -2170,6 +2228,7 @@ func (q *Queries) InsertChannel(ctx context.Context, arg InsertChannelParams) er
 		arg.Kind,
 		arg.CreatedAt,
 		arg.ExternalManaged,
+		arg.ExternalProvider,
 		arg.ExternalRef,
 		arg.ExternalUrl,
 		arg.SidebarSection,
@@ -3153,7 +3212,7 @@ func (q *Queries) ListBotsOwnedBy(ctx context.Context, ownerUserID sql.NullStrin
 
 const listChannels = `-- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
-       c.external_managed, c.external_ref, c.external_url, c.sidebar_section,
+       c.external_managed, c.external_provider, c.external_ref, c.external_url, c.sidebar_section,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS BIGINT) AS last_seq,
        CAST(COALESCE((SELECT cr.last_read_seq FROM channel_reads cr WHERE cr.channel_id = c.id AND cr.user_id = $1), 0) AS BIGINT) AS last_read_seq,
        CAST(COALESCE((
@@ -3176,20 +3235,21 @@ type ListChannelsParams struct {
 }
 
 type ListChannelsRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
-	LastSeq         int64          `json:"last_seq"`
-	LastReadSeq     int64          `json:"last_read_seq"`
-	UnreadCount     int64          `json:"unread_count"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+	LastSeq          int64          `json:"last_seq"`
+	LastReadSeq      int64          `json:"last_read_seq"`
+	UnreadCount      int64          `json:"unread_count"`
 }
 
 func (q *Queries) ListChannels(ctx context.Context, arg ListChannelsParams) ([]ListChannelsRow, error) {
@@ -3210,6 +3270,7 @@ func (q *Queries) ListChannels(ctx context.Context, arg ListChannelsParams) ([]L
 			&i.CreatedAt,
 			&i.ArchivedAt,
 			&i.ExternalManaged,
+			&i.ExternalProvider,
 			&i.ExternalRef,
 			&i.ExternalUrl,
 			&i.SidebarSection,
@@ -5066,21 +5127,23 @@ SET name = $1,
     kind = $2,
     archived_at = $3,
     external_managed = $4,
-    external_ref = $5,
-    external_url = $6,
-    sidebar_section = $7
-WHERE id = $8
+    external_provider = $5,
+    external_ref = $6,
+    external_url = $7,
+    sidebar_section = $8
+WHERE id = $9
 `
 
 type UpdateChannelParams struct {
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int32          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
-	ID              string         `json:"id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int32          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
 }
 
 func (q *Queries) UpdateChannel(ctx context.Context, arg UpdateChannelParams) error {
@@ -5089,6 +5152,7 @@ func (q *Queries) UpdateChannel(ctx context.Context, arg UpdateChannelParams) er
 		arg.Kind,
 		arg.ArchivedAt,
 		arg.ExternalManaged,
+		arg.ExternalProvider,
 		arg.ExternalRef,
 		arg.ExternalUrl,
 		arg.SidebarSection,

--- a/apps/api/internal/store/sqlite/managed_channels.go
+++ b/apps/api/internal/store/sqlite/managed_channels.go
@@ -1,0 +1,208 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
+)
+
+const managedChannelReconcileAttempts = 5
+
+func (s *Store) ReconcileManagedChannel(ctx context.Context, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	provider, ref, err := store.NormalizeManagedChannelIdentity(input.ExternalProvider, input.ExternalRef)
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	input.ExternalProvider = provider
+	input.ExternalRef = ref
+	for attempt := 0; attempt < managedChannelReconcileAttempts; attempt++ {
+		result, err := s.reconcileManagedChannelOnce(ctx, input)
+		if err == nil {
+			return result, nil
+		}
+		if !isManagedChannelReconcileConflict(err) {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+		time.Sleep(time.Duration(attempt+1) * 5 * time.Millisecond)
+	}
+	return store.ReconcileManagedChannelResult{}, errors.New("could not reconcile managed channel after concurrent updates")
+}
+
+func (s *Store) reconcileManagedChannelOnce(ctx context.Context, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	defer tx.Rollback()
+	if err := requireNonGuestTx(ctx, tx, input.WorkspaceID, input.UserID); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if err := requireNoModerationBlockTx(ctx, tx, input.WorkspaceID, input.UserID); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+
+	qtx := s.q.WithTx(tx)
+	row, err := qtx.GetManagedChannelByIdentity(ctx, storedb.GetManagedChannelByIdentityParams{
+		WorkspaceID:      input.WorkspaceID,
+		ExternalProvider: sqlText(input.ExternalProvider),
+		ExternalRef:      sqlText(input.ExternalRef),
+	})
+	switch {
+	case err == nil:
+		return reconcileExistingManagedChannel(ctx, tx, qtx, storeChannelFromGetManagedChannelByIdentity(row), input)
+	case !errors.Is(err, sql.ErrNoRows):
+		return store.ReconcileManagedChannelResult{}, err
+	}
+
+	name := slug(input.Name)
+	if name == "" {
+		return store.ReconcileManagedChannelResult{}, errors.New("managed channel name is required")
+	}
+	if name == store.GuestChannelName {
+		return store.ReconcileManagedChannelResult{}, errors.New("guest channel name is reserved")
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = "public"
+	}
+	provider := input.ExternalProvider
+	ref := input.ExternalRef
+	channel := store.Channel{
+		ID:               newID("chn"),
+		WorkspaceID:      input.WorkspaceID,
+		Name:             name,
+		Kind:             kind,
+		CreatedAt:        now(),
+		ExternalManaged:  true,
+		ExternalProvider: &provider,
+		ExternalRef:      &ref,
+		ExternalURL:      optionalTrimmedString(input.ExternalURL),
+		SidebarSection:   optionalTrimmedString(input.SidebarSection),
+	}
+	if input.Archived {
+		value := now()
+		channel.ArchivedAt = &value
+	}
+	routeID, err := newRouteID('C')
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	channel.RouteID = routeID
+	if err := qtx.InsertChannel(ctx, storedb.InsertChannelParams{
+		ID:               channel.ID,
+		RouteID:          sqlText(channel.RouteID),
+		WorkspaceID:      channel.WorkspaceID,
+		Name:             channel.Name,
+		Kind:             channel.Kind,
+		CreatedAt:        channel.CreatedAt,
+		ExternalManaged:  databaseBool(true),
+		ExternalProvider: sqlText(input.ExternalProvider),
+		ExternalRef:      sqlText(input.ExternalRef),
+		ExternalUrl:      nullFromPtr(channel.ExternalURL),
+		SidebarSection:   nullFromPtr(channel.SidebarSection),
+	}); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if channel.ArchivedAt != nil {
+		if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
+			Name:             channel.Name,
+			Kind:             channel.Kind,
+			ArchivedAt:       nullFromPtr(channel.ArchivedAt),
+			ExternalManaged:  databaseBool(true),
+			ExternalProvider: sqlText(input.ExternalProvider),
+			ExternalRef:      sqlText(input.ExternalRef),
+			ExternalUrl:      nullFromPtr(channel.ExternalURL),
+			SidebarSection:   nullFromPtr(channel.SidebarSection),
+			ID:               channel.ID,
+		}); err != nil {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+	}
+	event, err := insertEvent(ctx, tx, channel.WorkspaceID, channel.ID, "channel.created", nil, map[string]string{"channel_id": channel.ID})
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionCreated, Event: &event}, nil
+}
+
+func reconcileExistingManagedChannel(ctx context.Context, tx *sql.Tx, qtx *storedb.Queries, channel store.Channel, input store.ReconcileManagedChannelInput) (store.ReconcileManagedChannelResult, error) {
+	name := slug(input.Name)
+	if name == "" {
+		return store.ReconcileManagedChannelResult{}, errors.New("managed channel name is required")
+	}
+	if name == store.GuestChannelName {
+		return store.ReconcileManagedChannelResult{}, errors.New("guest channel name is reserved")
+	}
+	kind := strings.TrimSpace(input.Kind)
+	if kind == "" {
+		kind = "public"
+	}
+	archivedAt := channel.ArchivedAt
+	if input.Archived && archivedAt == nil {
+		value := now()
+		archivedAt = &value
+	}
+	if !input.Archived {
+		archivedAt = nil
+	}
+	externalURL := optionalTrimmedString(input.ExternalURL)
+	sidebarSection := optionalTrimmedString(input.SidebarSection)
+	changed := !channel.ExternalManaged ||
+		channel.Name != name ||
+		channel.Kind != kind ||
+		(channel.ArchivedAt == nil) != (archivedAt == nil) ||
+		!equalOptionalString(channel.ExternalURL, externalURL) ||
+		!equalOptionalString(channel.SidebarSection, sidebarSection)
+	if !changed {
+		if err := tx.Commit(); err != nil {
+			return store.ReconcileManagedChannelResult{}, err
+		}
+		return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionUnchanged}, nil
+	}
+	if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
+		Name:             name,
+		Kind:             kind,
+		ArchivedAt:       nullFromPtr(archivedAt),
+		ExternalManaged:  databaseBool(true),
+		ExternalProvider: nullFromPtr(channel.ExternalProvider),
+		ExternalRef:      nullFromPtr(channel.ExternalRef),
+		ExternalUrl:      nullFromPtr(externalURL),
+		SidebarSection:   nullFromPtr(sidebarSection),
+		ID:               channel.ID,
+	}); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	event, err := insertEvent(ctx, tx, channel.WorkspaceID, channel.ID, "channel.updated", nil, map[string]any{"channel_id": channel.ID, "archived": archivedAt != nil})
+	if err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	channel.Name = name
+	channel.Kind = kind
+	channel.ArchivedAt = archivedAt
+	channel.ExternalManaged = true
+	channel.ExternalURL = externalURL
+	channel.SidebarSection = sidebarSection
+	if err := tx.Commit(); err != nil {
+		return store.ReconcileManagedChannelResult{}, err
+	}
+	return store.ReconcileManagedChannelResult{Channel: channel, Action: store.ManagedChannelActionUpdated, Event: &event}, nil
+}
+
+func isManagedChannelReconcileConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := err.Error()
+	return strings.Contains(message, "idx_channels_managed_identity") ||
+		strings.Contains(message, "channels.workspace_id, channels.external_provider, channels.external_ref") ||
+		strings.Contains(message, "route_id") ||
+		strings.Contains(message, "database is locked")
+}

--- a/apps/api/internal/store/sqlite/managed_channels.go
+++ b/apps/api/internal/store/sqlite/managed_channels.go
@@ -203,6 +203,7 @@ func isManagedChannelReconcileConflict(err error) bool {
 	message := err.Error()
 	return strings.Contains(message, "idx_channels_managed_identity") ||
 		strings.Contains(message, "channels.workspace_id, channels.external_provider, channels.external_ref") ||
+		strings.Contains(message, "channels.workspace_id, channels.name") ||
 		strings.Contains(message, "route_id") ||
 		strings.Contains(message, "database is locked")
 }

--- a/apps/api/internal/store/sqlite/migrations/0040_managed_channel_reconciliation.sql
+++ b/apps/api/internal/store/sqlite/migrations/0040_managed_channel_reconciliation.sql
@@ -1,0 +1,5 @@
+ALTER TABLE channels ADD COLUMN external_provider TEXT;
+
+CREATE UNIQUE INDEX idx_channels_managed_identity
+  ON channels(workspace_id, external_provider, external_ref)
+  WHERE external_provider IS NOT NULL AND external_ref IS NOT NULL;

--- a/apps/api/internal/store/sqlite/mutations.go
+++ b/apps/api/internal/store/sqlite/mutations.go
@@ -259,6 +259,11 @@ func (s *Store) UpdateChannel(ctx context.Context, input store.UpdateChannelInpu
 	if input.ExternalRef != nil {
 		externalRef = optionalTrimmedString(*input.ExternalRef)
 	}
+	if ch.ExternalProvider != nil &&
+		((input.ExternalManaged != nil && !externalManaged) ||
+			(input.ExternalRef != nil && !equalOptionalString(externalRef, ch.ExternalRef))) {
+		return store.Channel{}, store.Event{}, store.ErrManagedChannelIdentityImmutable
+	}
 	externalURL := ch.ExternalURL
 	if input.ExternalURL != nil {
 		externalURL = optionalTrimmedString(*input.ExternalURL)
@@ -268,14 +273,15 @@ func (s *Store) UpdateChannel(ctx context.Context, input store.UpdateChannelInpu
 		sidebarSection = optionalTrimmedString(*input.SidebarSection)
 	}
 	if err := qtx.UpdateChannel(ctx, storedb.UpdateChannelParams{
-		Name:            name,
-		Kind:            kind,
-		ArchivedAt:      nullFromPtr(archivedValue),
-		ExternalManaged: databaseBool(externalManaged),
-		ExternalRef:     nullFromPtr(externalRef),
-		ExternalUrl:     nullFromPtr(externalURL),
-		SidebarSection:  nullFromPtr(sidebarSection),
-		ID:              ch.ID,
+		Name:             name,
+		Kind:             kind,
+		ArchivedAt:       nullFromPtr(archivedValue),
+		ExternalManaged:  databaseBool(externalManaged),
+		ExternalProvider: nullFromPtr(ch.ExternalProvider),
+		ExternalRef:      nullFromPtr(externalRef),
+		ExternalUrl:      nullFromPtr(externalURL),
+		SidebarSection:   nullFromPtr(sidebarSection),
+		ID:               ch.ID,
 	}); err != nil {
 		return store.Channel{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/sqlite/mutations_test.go
+++ b/apps/api/internal/store/sqlite/mutations_test.go
@@ -320,6 +320,13 @@ func TestManagedChannelReconciliationConverges(t *testing.T) {
 	}
 }
 
+func TestManagedChannelReconcileRetriesConcurrentNameConflict(t *testing.T) {
+	t.Parallel()
+	if !isManagedChannelReconcileConflict(errors.New("UNIQUE constraint failed: channels.workspace_id, channels.name")) {
+		t.Fatal("expected concurrent channel-name collision to be retried")
+	}
+}
+
 func TestGuestChannelNameIsReserved(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/apps/api/internal/store/sqlite/mutations_test.go
+++ b/apps/api/internal/store/sqlite/mutations_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -193,6 +194,129 @@ func TestManagedChannelFieldsRoundTripAndClear(t *testing.T) {
 	payload, ok := event.Payload.(map[string]any)
 	if !ok || payload["archived"] != true || payload["channel_id"] != channel.ID {
 		t.Fatalf("channel.updated archive metadata missing: %#v", event.Payload)
+	}
+}
+
+func TestManagedChannelReconciliationConverges(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+	owner, err := st.EnsureBootstrap(ctx, "Reconcile Owner", "reconcile-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceID := workspaces[0].ID
+	input := store.ReconcileManagedChannelInput{
+		WorkspaceID:      workspaceID,
+		UserID:           owner.ID,
+		ExternalProvider: "github",
+		ExternalRef:      "repo:42:pull:125",
+		Name:             "pr-125",
+		ExternalURL:      "https://github.com/openclaw/clickclack/pull/125",
+		SidebarSection:   "Pull requests",
+	}
+
+	const callers = 6
+	results := make(chan store.ReconcileManagedChannelResult, callers)
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result, err := st.ReconcileManagedChannel(ctx, input)
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- result
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	var channelID string
+	created := 0
+	unchanged := 0
+	for result := range results {
+		if channelID == "" {
+			channelID = result.Channel.ID
+		}
+		if result.Channel.ID != channelID {
+			t.Fatalf("reconcile produced multiple channels: %s and %s", channelID, result.Channel.ID)
+		}
+		switch result.Action {
+		case store.ManagedChannelActionCreated:
+			created++
+			if result.Event == nil || result.Event.Type != "channel.created" {
+				t.Fatalf("created result missing event: %#v", result)
+			}
+		case store.ManagedChannelActionUnchanged:
+			unchanged++
+			if result.Event != nil {
+				t.Fatalf("unchanged result emitted event: %#v", result)
+			}
+		default:
+			t.Fatalf("unexpected reconcile action: %#v", result)
+		}
+	}
+	if created != 1 || unchanged != callers-1 {
+		t.Fatalf("expected one create and %d unchanged results, got create=%d unchanged=%d", callers-1, created, unchanged)
+	}
+
+	archivedInput := input
+	archivedInput.Name = "pr-125-review"
+	archivedInput.Archived = true
+	updated, err := st.ReconcileManagedChannel(ctx, archivedInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Action != store.ManagedChannelActionUpdated || updated.Channel.ID != channelID || updated.Channel.ArchivedAt == nil || updated.Event == nil || updated.Event.Type != "channel.updated" {
+		t.Fatalf("unexpected changed reconciliation: %#v", updated)
+	}
+	reopenedInput := archivedInput
+	reopenedInput.Archived = false
+	reopened, err := st.ReconcileManagedChannel(ctx, reopenedInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reopened.Channel.ID != channelID || reopened.Channel.ArchivedAt != nil || reopened.Action != store.ManagedChannelActionUpdated {
+		t.Fatalf("unexpected reopened reconciliation: %#v", reopened)
+	}
+
+	clear := ""
+	notManaged := false
+	if _, _, err := st.UpdateChannel(ctx, store.UpdateChannelInput{
+		ChannelID:       channelID,
+		UserID:          owner.ID,
+		ExternalManaged: &notManaged,
+	}); !errors.Is(err, store.ErrManagedChannelIdentityImmutable) {
+		t.Fatalf("expected managed identity protection, got %v", err)
+	}
+	if _, _, err := st.UpdateChannel(ctx, store.UpdateChannelInput{
+		ChannelID:   channelID,
+		UserID:      owner.ID,
+		ExternalRef: &clear,
+	}); !errors.Is(err, store.ErrManagedChannelIdentityImmutable) {
+		t.Fatalf("expected external ref protection, got %v", err)
+	}
+
+	otherProvider := input
+	otherProvider.ExternalProvider = "gitlab"
+	otherProvider.Name = "gitlab-pr-125"
+	isolated, err := st.ReconcileManagedChannel(ctx, otherProvider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isolated.Channel.ID == channelID {
+		t.Fatalf("provider namespaces were not isolated: %#v", isolated)
 	}
 }
 

--- a/apps/api/internal/store/sqlite/mutations_test.go
+++ b/apps/api/internal/store/sqlite/mutations_test.go
@@ -320,6 +320,65 @@ func TestManagedChannelReconciliationConverges(t *testing.T) {
 	}
 }
 
+func TestManagedChannelReconciliationMigrationPreservesLegacyChannels(t *testing.T) {
+	ctx := context.Background()
+	st, err := Open("sqlite://" + filepath.Join(t.TempDir(), "managed-channel-upgrade.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	applySQLiteMigrationsBefore(t, ctx, st, "0040_managed_channel_reconciliation.sql")
+
+	owner, err := st.EnsureBootstrap(ctx, "Upgrade Owner", "upgrade-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const legacyID = "chn_legacy_managed"
+	if _, err := st.db.ExecContext(ctx, `
+		INSERT INTO channels (id, workspace_id, name, kind, created_at, external_managed, external_ref)
+		VALUES (?, ?, 'legacy-managed', 'public', ?, 1, 'repo:42:pull:125')`,
+		legacyID, workspaces[0].ID, now(),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var migrated store.Channel
+	for _, channel := range channels {
+		if channel.ID == legacyID {
+			migrated = channel
+			break
+		}
+	}
+	if migrated.ID == "" || !migrated.ExternalManaged || migrated.ExternalProvider != nil || migrated.ExternalRef == nil || *migrated.ExternalRef != "repo:42:pull:125" {
+		t.Fatalf("legacy managed channel was not preserved: %#v", migrated)
+	}
+
+	result, err := st.ReconcileManagedChannel(ctx, store.ReconcileManagedChannelInput{
+		WorkspaceID:      workspaces[0].ID,
+		UserID:           owner.ID,
+		ExternalProvider: "github",
+		ExternalRef:      "repo:42:pull:125",
+		Name:             "provider-managed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Action != store.ManagedChannelActionCreated || result.Channel.ID == legacyID {
+		t.Fatalf("provider identity should not capture a legacy unnamespaced channel: %#v", result)
+	}
+}
+
 func TestManagedChannelReconcileRetriesConcurrentNameConflict(t *testing.T) {
 	t.Parallel()
 	if !isManagedChannelReconcileConflict(errors.New("UNIQUE constraint failed: channels.workspace_id, channels.name")) {

--- a/apps/api/internal/store/sqlite/search_pages_test.go
+++ b/apps/api/internal/store/sqlite/search_pages_test.go
@@ -305,11 +305,15 @@ func TestSearchWorkspaceFTSMigrationPreservesAndScopesRows(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = st.Close() })
 	applySQLiteMigrationsBefore(t, ctx, st, "0033_search_workspace_fts.sql")
-	// Current channel queries include the managed-channel columns. Apply that
-	// independent schema addition early while leaving the FTS migration under
-	// test unapplied, and record it so Migrate does not run it twice below.
+	// Current channel queries include the managed-channel columns. Apply those
+	// independent schema additions early while leaving the FTS migration under
+	// test unapplied, and record them so Migrate does not run them twice below.
 	applySQLiteMigrations(t, ctx, st, "0037_managed_channels.sql")
 	if _, err := st.db.ExecContext(ctx, `INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`, "0037_managed_channels.sql", now()); err != nil {
+		t.Fatal(err)
+	}
+	applySQLiteMigrations(t, ctx, st, "0040_managed_channel_reconciliation.sql")
+	if _, err := st.db.ExecContext(ctx, `INSERT INTO schema_migrations (name, applied_at) VALUES (?, ?)`, "0040_managed_channel_reconciliation.sql", now()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -482,12 +482,12 @@ INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at)
 VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), 'general', 'public', sqlc.arg(created_at));
 
 -- name: InsertChannel :exec
-INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_ref, external_url, sidebar_section)
-VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), sqlc.arg(name), sqlc.arg(kind), sqlc.arg(created_at), sqlc.arg(external_managed), sqlc.arg(external_ref), sqlc.arg(external_url), sqlc.arg(sidebar_section));
+INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_provider, external_ref, external_url, sidebar_section)
+VALUES (sqlc.arg(id), sqlc.arg(route_id), sqlc.arg(workspace_id), sqlc.arg(name), sqlc.arg(kind), sqlc.arg(created_at), sqlc.arg(external_managed), sqlc.arg(external_provider), sqlc.arg(external_ref), sqlc.arg(external_url), sqlc.arg(sidebar_section));
 
 -- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
-       c.external_managed, c.external_ref, c.external_url, c.sidebar_section,
+       c.external_managed, c.external_provider, c.external_ref, c.external_url, c.sidebar_section,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS INTEGER) AS last_seq,
        CAST(COALESCE((SELECT cr.last_read_seq FROM channel_reads cr WHERE cr.channel_id = c.id AND cr.user_id = sqlc.arg(reader_user_id)), 0) AS INTEGER) AS last_read_seq,
        CAST(COALESCE((
@@ -1216,20 +1216,28 @@ VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(channel_id), sqlc.arg(dir
 
 -- name: GetChannel :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE id = sqlc.arg(id);
 
+-- name: GetManagedChannelByIdentity :one
+SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
+       external_managed, external_provider, external_ref, external_url, sidebar_section
+FROM channels
+WHERE workspace_id = sqlc.arg(workspace_id)
+  AND external_provider = sqlc.arg(external_provider)
+  AND external_ref = sqlc.arg(external_ref);
+
 -- name: GetChannelByIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND id = sqlc.arg(id);
 
 -- name: GetChannelByRouteIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = sqlc.arg(workspace_id)
   AND route_id = sqlc.arg(route_id);
@@ -1273,6 +1281,7 @@ SET name = sqlc.arg(name),
     kind = sqlc.arg(kind),
     archived_at = sqlc.arg(archived_at),
     external_managed = sqlc.arg(external_managed),
+    external_provider = sqlc.arg(external_provider),
     external_ref = sqlc.arg(external_ref),
     external_url = sqlc.arg(external_url),
     sidebar_section = sqlc.arg(sidebar_section)

--- a/apps/api/internal/store/sqlite/sqlc/schema.sql
+++ b/apps/api/internal/store/sqlite/sqlc/schema.sql
@@ -75,6 +75,7 @@ CREATE TABLE channels (
   archived_at TEXT,
   route_id TEXT,
   external_managed INTEGER NOT NULL DEFAULT 0,
+  external_provider TEXT,
   external_ref TEXT,
   external_url TEXT,
   sidebar_section TEXT,
@@ -82,6 +83,9 @@ CREATE TABLE channels (
 );
 
 CREATE UNIQUE INDEX idx_channels_workspace_route_id ON channels(workspace_id, route_id) WHERE route_id IS NOT NULL;
+CREATE UNIQUE INDEX idx_channels_managed_identity
+  ON channels(workspace_id, external_provider, external_ref)
+  WHERE external_provider IS NOT NULL AND external_ref IS NOT NULL;
 
 CREATE TABLE direct_conversations (
   id TEXT PRIMARY KEY,

--- a/apps/api/internal/store/sqlite/sqlc_adapters.go
+++ b/apps/api/internal/store/sqlite/sqlc_adapters.go
@@ -46,6 +46,13 @@ func optionalTrimmedString(value string) *string {
 	return &trimmed
 }
 
+func equalOptionalString(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
 func databaseBool(value bool) int64 {
 	if value {
 		return 1
@@ -187,36 +194,55 @@ func storeUploadFromGetUploadByOwnerNonce(row storedb.GetUploadByOwnerNonceRow) 
 
 func storeChannelFromGetChannel(row storedb.GetChannelRow) store.Channel {
 	return store.Channel{
-		ID:              row.ID,
-		RouteID:         row.RouteID,
-		WorkspaceID:     row.WorkspaceID,
-		Name:            row.Name,
-		Kind:            row.Kind,
-		CreatedAt:       row.CreatedAt,
-		ArchivedAt:      ptrFromNull(row.ArchivedAt),
-		ExternalManaged: row.ExternalManaged == 1,
-		ExternalRef:     ptrFromNull(row.ExternalRef),
-		ExternalURL:     ptrFromNull(row.ExternalUrl),
-		SidebarSection:  ptrFromNull(row.SidebarSection),
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
 	}
 }
 
 func storeChannelFromListChannels(row storedb.ListChannelsRow) store.Channel {
 	return store.Channel{
-		ID:              row.ID,
-		RouteID:         row.RouteID,
-		WorkspaceID:     row.WorkspaceID,
-		Name:            row.Name,
-		Kind:            row.Kind,
-		CreatedAt:       row.CreatedAt,
-		ArchivedAt:      ptrFromNull(row.ArchivedAt),
-		ExternalManaged: row.ExternalManaged == 1,
-		ExternalRef:     ptrFromNull(row.ExternalRef),
-		ExternalURL:     ptrFromNull(row.ExternalUrl),
-		SidebarSection:  ptrFromNull(row.SidebarSection),
-		LastSeq:         row.LastSeq,
-		LastReadSeq:     row.LastReadSeq,
-		UnreadCount:     row.UnreadCount,
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
+		LastSeq:          row.LastSeq,
+		LastReadSeq:      row.LastReadSeq,
+		UnreadCount:      row.UnreadCount,
+	}
+}
+
+func storeChannelFromGetManagedChannelByIdentity(row storedb.GetManagedChannelByIdentityRow) store.Channel {
+	return store.Channel{
+		ID:               row.ID,
+		RouteID:          row.RouteID,
+		WorkspaceID:      row.WorkspaceID,
+		Name:             row.Name,
+		Kind:             row.Kind,
+		CreatedAt:        row.CreatedAt,
+		ArchivedAt:       ptrFromNull(row.ArchivedAt),
+		ExternalManaged:  row.ExternalManaged == 1,
+		ExternalProvider: ptrFromNull(row.ExternalProvider),
+		ExternalRef:      ptrFromNull(row.ExternalRef),
+		ExternalURL:      ptrFromNull(row.ExternalUrl),
+		SidebarSection:   ptrFromNull(row.SidebarSection),
 	}
 }
 

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -584,16 +584,17 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 		}
 		ch.RouteID = routeID
 		if err := s.q.WithTx(tx).InsertChannel(ctx, storedb.InsertChannelParams{
-			ID:              ch.ID,
-			RouteID:         sqlText(ch.RouteID),
-			WorkspaceID:     ch.WorkspaceID,
-			Name:            ch.Name,
-			Kind:            ch.Kind,
-			CreatedAt:       ch.CreatedAt,
-			ExternalManaged: databaseBool(ch.ExternalManaged),
-			ExternalRef:     nullFromPtr(ch.ExternalRef),
-			ExternalUrl:     nullFromPtr(ch.ExternalURL),
-			SidebarSection:  nullFromPtr(ch.SidebarSection),
+			ID:               ch.ID,
+			RouteID:          sqlText(ch.RouteID),
+			WorkspaceID:      ch.WorkspaceID,
+			Name:             ch.Name,
+			Kind:             ch.Kind,
+			CreatedAt:        ch.CreatedAt,
+			ExternalManaged:  databaseBool(ch.ExternalManaged),
+			ExternalProvider: sql.NullString{},
+			ExternalRef:      nullFromPtr(ch.ExternalRef),
+			ExternalUrl:      nullFromPtr(ch.ExternalURL),
+			SidebarSection:   nullFromPtr(ch.SidebarSection),
 		}); err != nil {
 			if isRouteIDConflict(err) {
 				continue

--- a/apps/api/internal/store/sqlite/storedb/models.go
+++ b/apps/api/internal/store/sqlite/storedb/models.go
@@ -104,17 +104,18 @@ type BotTombstone struct {
 }
 
 type Channel struct {
-	ID              string         `json:"id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	RouteID         sql.NullString `json:"route_id"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	RouteID          sql.NullString `json:"route_id"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 type ChannelRead struct {

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1038,23 +1038,24 @@ func (q *Queries) GetBotTokenAuth(ctx context.Context, tokenHash string) (GetBot
 
 const getChannel = `-- name: GetChannel :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE id = ?1
 `
 
 type GetChannelRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, error) {
@@ -1069,6 +1070,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, err
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1078,7 +1080,7 @@ func (q *Queries) GetChannel(ctx context.Context, id string) (GetChannelRow, err
 
 const getChannelByIDAndWorkspace = `-- name: GetChannelByIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = ?1
   AND id = ?2
@@ -1090,17 +1092,18 @@ type GetChannelByIDAndWorkspaceParams struct {
 }
 
 type GetChannelByIDAndWorkspaceRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannelByIDAndWorkspaceParams) (GetChannelByIDAndWorkspaceRow, error) {
@@ -1115,6 +1118,7 @@ func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannel
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1124,7 +1128,7 @@ func (q *Queries) GetChannelByIDAndWorkspace(ctx context.Context, arg GetChannel
 
 const getChannelByRouteIDAndWorkspace = `-- name: GetChannelByRouteIDAndWorkspace :one
 SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
-       external_managed, external_ref, external_url, sidebar_section
+       external_managed, external_provider, external_ref, external_url, sidebar_section
 FROM channels
 WHERE workspace_id = ?1
   AND route_id = ?2
@@ -1136,17 +1140,18 @@ type GetChannelByRouteIDAndWorkspaceParams struct {
 }
 
 type GetChannelByRouteIDAndWorkspaceRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) GetChannelByRouteIDAndWorkspace(ctx context.Context, arg GetChannelByRouteIDAndWorkspaceParams) (GetChannelByRouteIDAndWorkspaceRow, error) {
@@ -1161,6 +1166,7 @@ func (q *Queries) GetChannelByRouteIDAndWorkspace(ctx context.Context, arg GetCh
 		&i.CreatedAt,
 		&i.ArchivedAt,
 		&i.ExternalManaged,
+		&i.ExternalProvider,
 		&i.ExternalRef,
 		&i.ExternalUrl,
 		&i.SidebarSection,
@@ -1447,6 +1453,56 @@ func (q *Queries) GetMagicLinkByToken(ctx context.Context, tokenHash string) (Au
 		&i.CreatedAt,
 		&i.ExpiresAt,
 		&i.UsedAt,
+	)
+	return i, err
+}
+
+const getManagedChannelByIdentity = `-- name: GetManagedChannelByIdentity :one
+SELECT id, COALESCE(route_id, '') AS route_id, workspace_id, name, kind, created_at, archived_at,
+       external_managed, external_provider, external_ref, external_url, sidebar_section
+FROM channels
+WHERE workspace_id = ?1
+  AND external_provider = ?2
+  AND external_ref = ?3
+`
+
+type GetManagedChannelByIdentityParams struct {
+	WorkspaceID      string         `json:"workspace_id"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+}
+
+type GetManagedChannelByIdentityRow struct {
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+}
+
+func (q *Queries) GetManagedChannelByIdentity(ctx context.Context, arg GetManagedChannelByIdentityParams) (GetManagedChannelByIdentityRow, error) {
+	row := q.db.QueryRowContext(ctx, getManagedChannelByIdentity, arg.WorkspaceID, arg.ExternalProvider, arg.ExternalRef)
+	var i GetManagedChannelByIdentityRow
+	err := row.Scan(
+		&i.ID,
+		&i.RouteID,
+		&i.WorkspaceID,
+		&i.Name,
+		&i.Kind,
+		&i.CreatedAt,
+		&i.ArchivedAt,
+		&i.ExternalManaged,
+		&i.ExternalProvider,
+		&i.ExternalRef,
+		&i.ExternalUrl,
+		&i.SidebarSection,
 	)
 	return i, err
 }
@@ -2137,21 +2193,22 @@ func (q *Queries) InsertBotUser(ctx context.Context, arg InsertBotUserParams) er
 }
 
 const insertChannel = `-- name: InsertChannel :exec
-INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_ref, external_url, sidebar_section)
-VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+INSERT INTO channels (id, route_id, workspace_id, name, kind, created_at, external_managed, external_provider, external_ref, external_url, sidebar_section)
+VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
 `
 
 type InsertChannelParams struct {
-	ID              string         `json:"id"`
-	RouteID         sql.NullString `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
+	RouteID          sql.NullString `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
 }
 
 func (q *Queries) InsertChannel(ctx context.Context, arg InsertChannelParams) error {
@@ -2163,6 +2220,7 @@ func (q *Queries) InsertChannel(ctx context.Context, arg InsertChannelParams) er
 		arg.Kind,
 		arg.CreatedAt,
 		arg.ExternalManaged,
+		arg.ExternalProvider,
 		arg.ExternalRef,
 		arg.ExternalUrl,
 		arg.SidebarSection,
@@ -3144,7 +3202,7 @@ func (q *Queries) ListBotsOwnedBy(ctx context.Context, ownerUserID sql.NullStrin
 
 const listChannels = `-- name: ListChannels :many
 SELECT c.id, COALESCE(c.route_id, '') AS route_id, c.workspace_id, c.name, c.kind, c.created_at, c.archived_at,
-       c.external_managed, c.external_ref, c.external_url, c.sidebar_section,
+       c.external_managed, c.external_provider, c.external_ref, c.external_url, c.sidebar_section,
        CAST(COALESCE((SELECT MAX(channel_seq) FROM messages WHERE channel_id = c.id AND parent_message_id IS NULL), 0) AS INTEGER) AS last_seq,
        CAST(COALESCE((SELECT cr.last_read_seq FROM channel_reads cr WHERE cr.channel_id = c.id AND cr.user_id = ?1), 0) AS INTEGER) AS last_read_seq,
        CAST(COALESCE((
@@ -3167,20 +3225,21 @@ type ListChannelsParams struct {
 }
 
 type ListChannelsRow struct {
-	ID              string         `json:"id"`
-	RouteID         string         `json:"route_id"`
-	WorkspaceID     string         `json:"workspace_id"`
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	CreatedAt       string         `json:"created_at"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
-	LastSeq         int64          `json:"last_seq"`
-	LastReadSeq     int64          `json:"last_read_seq"`
-	UnreadCount     int64          `json:"unread_count"`
+	ID               string         `json:"id"`
+	RouteID          string         `json:"route_id"`
+	WorkspaceID      string         `json:"workspace_id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	CreatedAt        string         `json:"created_at"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+	LastSeq          int64          `json:"last_seq"`
+	LastReadSeq      int64          `json:"last_read_seq"`
+	UnreadCount      int64          `json:"unread_count"`
 }
 
 func (q *Queries) ListChannels(ctx context.Context, arg ListChannelsParams) ([]ListChannelsRow, error) {
@@ -3201,6 +3260,7 @@ func (q *Queries) ListChannels(ctx context.Context, arg ListChannelsParams) ([]L
 			&i.CreatedAt,
 			&i.ArchivedAt,
 			&i.ExternalManaged,
+			&i.ExternalProvider,
 			&i.ExternalRef,
 			&i.ExternalUrl,
 			&i.SidebarSection,
@@ -4968,21 +5028,23 @@ SET name = ?1,
     kind = ?2,
     archived_at = ?3,
     external_managed = ?4,
-    external_ref = ?5,
-    external_url = ?6,
-    sidebar_section = ?7
-WHERE id = ?8
+    external_provider = ?5,
+    external_ref = ?6,
+    external_url = ?7,
+    sidebar_section = ?8
+WHERE id = ?9
 `
 
 type UpdateChannelParams struct {
-	Name            string         `json:"name"`
-	Kind            string         `json:"kind"`
-	ArchivedAt      sql.NullString `json:"archived_at"`
-	ExternalManaged int64          `json:"external_managed"`
-	ExternalRef     sql.NullString `json:"external_ref"`
-	ExternalUrl     sql.NullString `json:"external_url"`
-	SidebarSection  sql.NullString `json:"sidebar_section"`
-	ID              string         `json:"id"`
+	Name             string         `json:"name"`
+	Kind             string         `json:"kind"`
+	ArchivedAt       sql.NullString `json:"archived_at"`
+	ExternalManaged  int64          `json:"external_managed"`
+	ExternalProvider sql.NullString `json:"external_provider"`
+	ExternalRef      sql.NullString `json:"external_ref"`
+	ExternalUrl      sql.NullString `json:"external_url"`
+	SidebarSection   sql.NullString `json:"sidebar_section"`
+	ID               string         `json:"id"`
 }
 
 func (q *Queries) UpdateChannel(ctx context.Context, arg UpdateChannelParams) error {
@@ -4991,6 +5053,7 @@ func (q *Queries) UpdateChannel(ctx context.Context, arg UpdateChannelParams) er
 		arg.Kind,
 		arg.ArchivedAt,
 		arg.ExternalManaged,
+		arg.ExternalProvider,
 		arg.ExternalRef,
 		arg.ExternalUrl,
 		arg.SidebarSection,

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -213,20 +213,21 @@ type Workspace struct {
 }
 
 type Channel struct {
-	ID              string  `json:"id"`
-	RouteID         string  `json:"route_id"`
-	WorkspaceID     string  `json:"workspace_id"`
-	Name            string  `json:"name"`
-	Kind            string  `json:"kind"`
-	CreatedAt       string  `json:"created_at"`
-	ArchivedAt      *string `json:"archived_at,omitempty"`
-	ExternalManaged bool    `json:"external_managed"`
-	ExternalRef     *string `json:"external_ref,omitempty"`
-	ExternalURL     *string `json:"external_url,omitempty"`
-	SidebarSection  *string `json:"sidebar_section,omitempty"`
-	LastSeq         int64   `json:"last_seq"`
-	LastReadSeq     int64   `json:"last_read_seq"`
-	UnreadCount     int64   `json:"unread_count"`
+	ID               string  `json:"id"`
+	RouteID          string  `json:"route_id"`
+	WorkspaceID      string  `json:"workspace_id"`
+	Name             string  `json:"name"`
+	Kind             string  `json:"kind"`
+	CreatedAt        string  `json:"created_at"`
+	ArchivedAt       *string `json:"archived_at,omitempty"`
+	ExternalManaged  bool    `json:"external_managed"`
+	ExternalProvider *string `json:"external_provider,omitempty"`
+	ExternalRef      *string `json:"external_ref,omitempty"`
+	ExternalURL      *string `json:"external_url,omitempty"`
+	SidebarSection   *string `json:"sidebar_section,omitempty"`
+	LastSeq          int64   `json:"last_seq"`
+	LastReadSeq      int64   `json:"last_read_seq"`
+	UnreadCount      int64   `json:"unread_count"`
 }
 
 type ReactionSummary struct {
@@ -1087,6 +1088,7 @@ type Store interface {
 	ListChannels(ctx context.Context, workspaceID, userID string) ([]Channel, error)
 	GetChannel(ctx context.Context, channelID, userID string) (Channel, error)
 	CreateChannel(ctx context.Context, input CreateChannelInput) (Channel, Event, error)
+	ReconcileManagedChannel(ctx context.Context, input ReconcileManagedChannelInput) (ReconcileManagedChannelResult, error)
 	UpdateChannel(ctx context.Context, input UpdateChannelInput) (Channel, Event, error)
 	ListTopics(ctx context.Context, workspaceID, requesterID string) ([]Topic, error)
 	CreateTopic(ctx context.Context, input CreateTopicInput) (Topic, error)

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -50,6 +50,7 @@ export type Channel = {
   created_at: string;
   archived_at?: string;
   external_managed: boolean;
+  external_provider?: string;
   external_ref?: string;
   external_url?: string;
   sidebar_section?: string;

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -45,7 +45,7 @@ The value is not stored on message rows or exported as a metrics label.
 | Audit log     | `/api/workspaces/{id}/audit-log` | [integrations](../features/integrations.md) |
 | Connected accounts | `/api/workspaces/{id}/connected-accounts`, `/api/connected-accounts/{id}/revoke` | [integrations](../features/integrations.md) |
 | Topics        | `/api/workspaces/{id}/topics` | [messages](../features/messages.md) |
-| Channels      | `/api/workspaces/{id}/channels`, `/api/channels/{id}` | [workspaces](../features/workspaces.md) |
+| Channels      | `/api/workspaces/{id}/channels`, `/api/workspaces/{id}/managed-channels/reconcile`, `/api/channels/{id}` | [workspaces](../features/workspaces.md) |
 | Messages      | `/api/channels/{id}/messages`, `/api/messages/by-nonce`, `/api/messages/{id}` | [messages](../features/messages.md) |
 | Threads       | `/api/messages/{id}/thread`, `/api/messages/{id}/thread/replies` | [threads](../features/threads.md) |
 | Replies       | `quoted_message_id` on any message-create endpoint | [replies](../features/replies.md) |

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -84,6 +84,14 @@ Nested replies are forbidden — the API rejects replies to non-root messages.
 - `events.cursor`: globally sortable opaque cursor used by realtime
   recovery.
 
+## Externally managed channel identity
+
+Reconciled managed channels have an immutable
+`(workspace_id, external_provider, external_ref)` identity. A partial unique
+index enforces that identity when both external fields are present. Legacy
+managed channels have no `external_provider`, so they retain their existing
+behavior and are outside the reconciliation namespace.
+
 ## Private durable events
 
 `events.is_private` is the durable privacy bit for replay filtering.

--- a/docs/features/bots.md
+++ b/docs/features/bots.md
@@ -170,7 +170,8 @@ MVP endpoint mapping:
 - `GET /api/me`: `profile:read`
 - `GET /api/workspaces*`: `workspaces:read`
 - `GET /api/workspaces/{id}/channels`: `channels:read`
-- `POST/PATCH channel endpoints`: `channels:write`
+- `POST/PATCH channel endpoints`, including managed-channel reconciliation:
+  `channels:write`
 - `GET channel/DM/thread messages`: matching read scope
 - `POST channel/DM/thread messages`: matching write scope
 - Durable `agent_commentary` and `agent_tool` channel/DM messages additionally

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -52,6 +52,7 @@ directory does not include moderation state.
 ```http
 GET  /api/workspaces/{workspace_id}/channels  # list, ordered by name
 POST /api/workspaces/{workspace_id}/channels  # create
+POST /api/workspaces/{workspace_id}/managed-channels/reconcile
 PATCH /api/channels/{channel_id}              # rename, change kind, archive
 ```
 
@@ -61,10 +62,23 @@ sidebar_section?}`. `name` is slugified to keep `(workspace_id, name)` unique.
 channel authorization: it records an opaque identity and optional deep link for
 the application that owns the channel lifecycle.
 
+External integrations that need replay-safe provisioning use the managed
+channel reconcile endpoint with a complete desired representation:
+`{external_provider, external_ref, name, kind?, archived?, external_url?,
+sidebar_section?}`. `external_provider` is a lowercase integration namespace;
+the provider/reference pair is immutable and unique within one workspace.
+Reconciliation returns `action` as `created`, `updated`, or `unchanged`, plus
+the canonical `channel`. A create returns HTTP `201`; updates and exact replays
+return `200`. Only creates and changed state emit the normal durable channel
+event, so exact webhook replay does not add realtime churn.
+
 `PATCH` accepts any subset of `{name, kind, archived, external_managed,
 external_ref, external_url, sidebar_section}`. Setting `archived=true` fills
 `archived_at`; `archived=false` clears it. Sending an empty string for any of
-the nullable external or sidebar fields clears that field.
+the nullable external or sidebar fields clears that field. Once a channel has
+an `external_provider`, ordinary PATCH cannot clear external management or
+retarget its provider/reference identity; integrations reconcile mutable state
+through the provider identity instead.
 
 Archived channels remain addressable and readable, but the web sidebar removes
 them from the normal channel list and places them in a collapsed Archived group.
@@ -83,6 +97,9 @@ Channel write endpoints emit a durable `channel.created` or `channel.updated`
 event into the workspace event stream so connected clients see the change
 without polling. `channel.updated` includes the resulting `archived` boolean in
 its payload so consumers can update visibility without refetching the channel.
+Provider labels are namespacing metadata, not trusted identity or
+authorization. Reconciliation uses the same `channels:write` scope and
+workspace binding as normal channel creation.
 
 ## Web routes
 

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -67,6 +67,9 @@ channel reconcile endpoint with a complete desired representation:
 `{external_provider, external_ref, name, kind?, archived?, external_url?,
 sidebar_section?}`. `external_provider` is a lowercase integration namespace;
 the provider/reference pair is immutable and unique within one workspace.
+Omitted mutable fields reconcile to their defaults: `kind` becomes `public`,
+`archived` becomes `false`, and `external_url` or `sidebar_section` are
+cleared. This is desired-state replacement, not a partial PATCH.
 Reconciliation returns `action` as `created`, `updated`, or `unchanged`, plus
 the canonical `channel`. A create returns HTTP `201`; updates and exact replays
 return `200`. Only creates and changed state emit the normal durable channel

--- a/docs/proof/managed-channel-reconciliation-proof.md
+++ b/docs/proof/managed-channel-reconciliation-proof.md
@@ -1,0 +1,34 @@
+# Managed channel reconciliation proof
+
+This proof exercises the production HTTP handler against the real SQLite store
+and separately stresses the store identity constraint with concurrent callers.
+
+## Reproduction
+
+```sh
+go test -count=1 -v ./apps/api/internal/httpapi \
+  -run 'TestManagedChannelReconciliationBotAuthorization|TestMutationAndEphemeralEndpoints'
+
+go test -count=1 -v ./apps/api/internal/store/sqlite \
+  -run TestManagedChannelReconciliationConverges
+```
+
+The HTTP scenarios verify:
+
+- the first desired-state request returns `201 created` with a
+  `channel.created` event;
+- an exact replay returns `200 unchanged`, the same channel ID, and no event;
+- changed desired state returns `200 updated` with one `channel.updated` event;
+- archived channels can be reopened through reconciliation;
+- normal channel updates cannot clear the reconciled identity;
+- a bot with `channels:write` can reconcile in its bound workspace; and
+- the same bot token is rejected in another workspace, even when the bot is a
+  member there.
+
+The store scenario sends six concurrent requests for one provider identity. It
+asserts that they converge on one channel, with exactly one `created` result
+and five `unchanged` results. It also verifies provider namespace isolation,
+archive/reopen behavior, and immutable identity protection.
+
+Postgres runs the equivalent convergence and changed-state scenario whenever
+the repository's Postgres test environment is configured.

--- a/docs/proof/managed-channel-reconciliation-proof.md
+++ b/docs/proof/managed-channel-reconciliation-proof.md
@@ -19,6 +19,7 @@ The HTTP scenarios verify:
   `channel.created` event;
 - an exact replay returns `200 unchanged`, the same channel ID, and no event;
 - changed desired state returns `200 updated` with one `channel.updated` event;
+- omitted mutable desired fields reconcile to documented defaults or clearing;
 - archived channels can be reopened through reconciliation;
 - normal channel updates cannot clear the reconciled identity;
 - a bot with `channels:write` can reconcile in its bound workspace; and

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -74,7 +74,7 @@ See [features/auth.md](features/auth.md).
 | `eventTypes`  | `list` |
 | `auditLog`     | `list` |
 | `connectedAccounts` | `list`, `create`, `revoke` |
-| `channels`    | `list`, `create`, `update`, `messages`, `sendMessage`, `markRead` |
+| `channels`    | `list`, `create`, `reconcile`, `update`, `messages`, `sendMessage`, `markRead` |
 | `messages`    | `get`, `findByNonce(workspaceId, nonce)`, `update`, `delete` |
 | `threads`     | `get`, `reply` |
 | `search(workspaceId, q, options?)` | paginated workspace, channel, or direct-message search |

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -466,6 +466,30 @@ paths:
       responses:
         "201":
           description: Created channel
+  /api/workspaces/{workspace_id}/managed-channels/reconcile:
+    post:
+      operationId: reconcileManagedChannel
+      parameters:
+        - $ref: "#/components/parameters/workspace_id"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReconcileManagedChannelRequest"
+      responses:
+        "200":
+          description: Existing managed channel updated or unchanged
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconcileManagedChannelResponse"
+        "201":
+          description: Managed channel created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReconcileManagedChannelResponse"
   /api/workspaces/{workspace_id}/topics:
     get:
       operationId: listTopics
@@ -2517,6 +2541,45 @@ components:
         sidebar_section:
           type: string
           description: Optional client sidebar grouping label.
+    ReconcileManagedChannelRequest:
+      type: object
+      required: [external_provider, external_ref, name]
+      properties:
+        external_provider:
+          type: string
+          pattern: "^[a-z0-9][a-z0-9._-]{0,63}$"
+          description: Lowercase namespace for the external managing integration.
+        external_ref:
+          type: string
+          minLength: 1
+          maxLength: 512
+          description: Opaque identity within the external provider namespace.
+        name:
+          type: string
+        kind:
+          type: string
+          default: public
+        archived:
+          type: boolean
+          default: false
+        external_url:
+          type: string
+          format: uri
+          description: Deep link into the external managing application.
+        sidebar_section:
+          type: string
+          description: Optional client sidebar grouping label.
+    ReconcileManagedChannelResponse:
+      type: object
+      required: [channel, action]
+      properties:
+        channel:
+          $ref: "#/components/schemas/Channel"
+        action:
+          type: string
+          enum: [created, updated, unchanged]
+        event:
+          $ref: "#/components/schemas/Event"
     Topic:
       type: object
       required: [id, workspace_id, name, created_at]
@@ -2557,6 +2620,9 @@ components:
           type: boolean
         external_managed:
           type: boolean
+        external_provider:
+          type: string
+          description: Immutable provider namespace for reconciled managed channels.
         external_ref:
           type: string
           description: Opaque external identity. Send an empty string to clear it.

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -2559,16 +2559,18 @@ components:
         kind:
           type: string
           default: public
+          description: Desired channel kind. Omission reconciles to public.
         archived:
           type: boolean
           default: false
+          description: Desired archive state. Omission reconciles to open.
         external_url:
           type: string
           format: uri
-          description: Deep link into the external managing application.
+          description: Deep link into the external managing application. Omission clears it.
         sidebar_section:
           type: string
-          description: Optional client sidebar grouping label.
+          description: Optional client sidebar grouping label. Omission clears it.
     ReconcileManagedChannelResponse:
       type: object
       required: [channel, action]
@@ -2620,9 +2622,6 @@ components:
           type: boolean
         external_managed:
           type: boolean
-        external_provider:
-          type: string
-          description: Immutable provider namespace for reconciled managed channels.
         external_ref:
           type: string
           description: Opaque external identity. Send an empty string to clear it.
@@ -2857,6 +2856,9 @@ components:
           format: date-time
         external_managed:
           type: boolean
+        external_provider:
+          type: string
+          description: Immutable provider namespace for reconciled managed channels.
         external_ref:
           type: string
           description: Opaque identity in the external managing system.

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "generate": "openapi-typescript openapi.yaml -o ../sdk-ts/src/generated/openapi.d.ts"
+    "generate": "openapi-typescript openapi.yaml --default-non-nullable false -o ../sdk-ts/src/generated/openapi.d.ts"
   },
   "devDependencies": {
     "openapi-typescript": "^7.13.0"

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -1574,7 +1574,7 @@ export interface components {
     CreateChannelRequest: {
       name: string;
       /** @default public */
-      kind: string;
+      kind?: string;
       external_managed?: boolean;
       /** @description Opaque identity in the external managing system. */
       external_ref?: string;
@@ -1596,12 +1596,12 @@ export interface components {
        * @description Desired channel kind. Omission reconciles to public.
        * @default public
        */
-      kind: string;
+      kind?: string;
       /**
        * @description Desired archive state. Omission reconciles to open.
        * @default false
        */
-      archived: boolean;
+      archived?: boolean;
       /**
        * Format: uri
        * @description Deep link into the external managing application. Omission clears it.
@@ -1649,7 +1649,7 @@ export interface components {
        * @default markdown
        * @enum {string}
        */
-      body_format: "markdown";
+      body_format?: "markdown";
       /**
        * @description Optional ID of a message to quote. The quoted message must live in
        *     the same channel, DM conversation, or thread as the new message;

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -1592,16 +1592,22 @@ export interface components {
       /** @description Opaque identity within the external provider namespace. */
       external_ref: string;
       name: string;
-      /** @default public */
+      /**
+       * @description Desired channel kind. Omission reconciles to public.
+       * @default public
+       */
       kind: string;
-      /** @default false */
+      /**
+       * @description Desired archive state. Omission reconciles to open.
+       * @default false
+       */
       archived: boolean;
       /**
        * Format: uri
-       * @description Deep link into the external managing application.
+       * @description Deep link into the external managing application. Omission clears it.
        */
       external_url?: string;
-      /** @description Optional client sidebar grouping label. */
+      /** @description Optional client sidebar grouping label. Omission clears it. */
       sidebar_section?: string;
     };
     ReconcileManagedChannelResponse: {
@@ -1630,8 +1636,6 @@ export interface components {
       kind?: string;
       archived?: boolean;
       external_managed?: boolean;
-      /** @description Immutable provider namespace for reconciled managed channels. */
-      external_provider?: string;
       /** @description Opaque external identity. Send an empty string to clear it. */
       external_ref?: string;
       /** @description External deep link. Send an empty string to clear it. */
@@ -1770,6 +1774,8 @@ export interface components {
       /** Format: date-time */
       archived_at?: string;
       external_managed: boolean;
+      /** @description Immutable provider namespace for reconciled managed channels. */
+      external_provider?: string;
       /** @description Opaque identity in the external managing system. */
       external_ref?: string;
       /**

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -327,6 +327,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/api/workspaces/{workspace_id}/managed-channels/reconcile": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["reconcileManagedChannel"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/workspaces/{workspace_id}/topics": {
     parameters: {
       query?: never;
@@ -1570,6 +1586,30 @@ export interface components {
       /** @description Optional client sidebar grouping label. */
       sidebar_section?: string;
     };
+    ReconcileManagedChannelRequest: {
+      /** @description Lowercase namespace for the external managing integration. */
+      external_provider: string;
+      /** @description Opaque identity within the external provider namespace. */
+      external_ref: string;
+      name: string;
+      /** @default public */
+      kind: string;
+      /** @default false */
+      archived: boolean;
+      /**
+       * Format: uri
+       * @description Deep link into the external managing application.
+       */
+      external_url?: string;
+      /** @description Optional client sidebar grouping label. */
+      sidebar_section?: string;
+    };
+    ReconcileManagedChannelResponse: {
+      channel: components["schemas"]["Channel"];
+      /** @enum {string} */
+      action: "created" | "updated" | "unchanged";
+      event?: components["schemas"]["Event"];
+    };
     Topic: {
       id: string;
       workspace_id: string;
@@ -1590,6 +1630,8 @@ export interface components {
       kind?: string;
       archived?: boolean;
       external_managed?: boolean;
+      /** @description Immutable provider namespace for reconciled managed channels. */
+      external_provider?: string;
       /** @description Opaque external identity. Send an empty string to clear it. */
       external_ref?: string;
       /** @description External deep link. Send an empty string to clear it. */
@@ -2738,6 +2780,41 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  reconcileManagedChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspace_id: components["parameters"]["workspace_id"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ReconcileManagedChannelRequest"];
+      };
+    };
+    responses: {
+      /** @description Existing managed channel updated or unchanged */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ReconcileManagedChannelResponse"];
+        };
+      };
+      /** @description Managed channel created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ReconcileManagedChannelResponse"];
+        };
       };
     };
   };

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -265,6 +265,7 @@ export type Channel = {
   created_at: string;
   archived_at?: string;
   external_managed: boolean;
+  external_provider?: string;
   external_ref?: string;
   external_url?: string;
   sidebar_section?: string;
@@ -299,6 +300,8 @@ export type MessageInput = MessageInputBase &
 
 export type ReactionSummary = components["schemas"]["ReactionSummary"];
 export type ReactionMutationResponse = components["schemas"]["ReactionMutationResponse"];
+export type ReconcileManagedChannelResponse =
+  components["schemas"]["ReconcileManagedChannelResponse"];
 
 export type Message = {
   id: string;
@@ -975,6 +978,25 @@ export class ClickClackClient {
       );
       return data.channel;
     },
+    reconcile: async (
+      workspaceId: string,
+      input: {
+        external_provider: string;
+        external_ref: string;
+        name: string;
+        kind?: string;
+        archived?: boolean;
+        external_url?: string;
+        sidebar_section?: string;
+      },
+    ): Promise<ReconcileManagedChannelResponse> =>
+      this.request<ReconcileManagedChannelResponse>(
+        `/api/workspaces/${workspaceId}/managed-channels/reconcile`,
+        {
+          method: "POST",
+          body: JSON.stringify(input),
+        },
+      ),
     update: async (
       channelId: string,
       input: {

--- a/packages/sdk-ts/src/openapi_contract.d.ts
+++ b/packages/sdk-ts/src/openapi_contract.d.ts
@@ -1,8 +1,27 @@
 import type { components } from "./generated/openapi";
 
 type Assert<T extends true> = T;
+type CreateChannelRequest = components["schemas"]["CreateChannelRequest"];
+type CreateMessageRequest = components["schemas"]["CreateMessageRequest"];
 type RevokeAppInstallationRequest = components["schemas"]["RevokeAppInstallationRequest"];
+type ReconcileManagedChannelRequest = components["schemas"]["ReconcileManagedChannelRequest"];
 
+type CreateChannelDefaultsStayOptional = Assert<
+  { name: string } extends CreateChannelRequest ? true : false
+>;
+type CreateMessageDefaultsStayOptional = Assert<
+  { body: string } extends CreateMessageRequest ? true : false
+>;
 type RevokeAppInstallationOptionsStayOptional = Assert<
   {} extends RevokeAppInstallationRequest ? true : false
+>;
+
+type ReconcileManagedChannelDefaultsStayOptional = Assert<
+  {
+    external_provider: string;
+    external_ref: string;
+    name: string;
+  } extends ReconcileManagedChannelRequest
+    ? true
+    : false
 >;


### PR DESCRIPTION
Closes #125

## What Problem This Solves

External integrations cannot safely ensure that one durable ClickClack channel
exists for one external work item. Retried webhooks or concurrent workers can
create duplicates, while later lifecycle changes have no stable provider
identity to target.

## Why This Change Was Made

This adds full desired-state reconciliation by immutable
`(workspace, external_provider, external_ref)` identity across SQLite and
Postgres, with matching HTTP, OpenAPI, and TypeScript SDK support. Exact replays
return the existing channel without another durable event; changed state emits
one normal channel update. Provider adapters, credentials, and external
workflow authority remain outside ClickClack core.

This is the first infrastructure step toward the project goal: an integration
can keep one dedicated ClickClack channel per work item—such as a pull
request—synchronized while ClickClack owns the durable collaboration record.

## User Impact

Bots and integrations with `channels:write` can now create, update, archive,
and reopen one managed channel idempotently. Concurrent requests converge on
one channel, provider namespaces remain isolated, and ordinary channel PATCH
requests cannot detach or retarget reconciled identity.

## Evidence

Exact proof head: `5c0f2629aa623884d22225229138bcb29ee946b0`

- `pnpm check` passes: Go, web, SDK, desktop, FakeCo, builds, typechecks, lint,
  and formatting.
- The generated TypeScript contract now follows the OpenAPI required arrays:
  defaulted-but-optional request fields remain optional. Compile-time contract
  assertions cover channel creation, message creation, and managed-channel
  reconciliation.
- Focused HTTP proof uses a real `httptest` server with a migrated temporary
  SQLite database—no mocked store—and covers create/replay/update/defaulting,
  archive/reopen, immutable identity, bot scope, and workspace binding.
- Six concurrent reconciliations converge on one identity in both SQLite and a
  real local PostgreSQL 17 server.
- Upgrade tests start from the schema immediately before the reconciliation
  migration in each dialect, insert a legacy managed channel, run the current
  migrator, verify the legacy row is preserved without a provider, and verify a
  namespaced reconciliation creates its own identity.
- Independent Codex review at the exact head reported no actionable
  correctness issues.

Redacted command transcript:

```text
$ git rev-parse HEAD
5c0f2629aa623884d22225229138bcb29ee946b0

$ go test -count=1 -v ./apps/api/internal/httpapi \
    -run 'TestManagedChannelReconciliationBotAuthorization|TestMutationAndEphemeralEndpoints'
... reconcile status=201
... replay/update status=200
... cross-workspace bot request status=403
--- PASS: TestManagedChannelReconciliationBotAuthorization
--- PASS: TestMutationAndEphemeralEndpoints
PASS

$ go test -count=1 -v ./apps/api/internal/store/sqlite \
    -run 'TestManagedChannelReconciliation(MigrationPreservesLegacyChannels|Converges)$'
--- PASS: TestManagedChannelReconciliationMigrationPreservesLegacyChannels
--- PASS: TestManagedChannelReconciliationConverges
PASS

$ CLICKCLACK_POSTGRES_TEST_DSN='<local PostgreSQL 17; redacted>' \
    go test -count=1 -v ./apps/api/internal/store/postgres \
    -run 'TestManagedChannelReconciliation(MigrationPreservesLegacyChannelsPostgres|ConvergesPostgres)$'
--- PASS: TestManagedChannelReconciliationConvergesPostgres
--- PASS: TestManagedChannelReconciliationMigrationPreservesLegacyChannelsPostgres
PASS

$ pnpm --filter @clickclack/sdk-ts typecheck
$ tsc --noEmit -p tsconfig.json
```

The earlier proof narrative remains available in
`docs/proof/managed-channel-reconciliation-proof.md`.
