### PR TITLE
Add a lightweight health endpoint

### DIFF
--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -79,6 +79,9 @@ func (s *Server) Handler() http.Handler {
 	r.Use(middleware.RequestLogger(&pathOnlyLogFormatter{}))
 	r.Use(middleware.Recoverer)
 
+	r.Get("/health", s.health)
+	r.Head("/health", s.health)
+
 	r.Route("/api", func(r chi.Router) {
 		r.Use(s.requireCookieCSRF)
 		r.Post("/auth/magic/request", s.requestMagicLink)
@@ -150,6 +153,14 @@ func (s *Server) Handler() http.Handler {
 	r.Head("/*", s.serveSPA)
 	r.Get("/*", s.serveSPA)
 	return r
+}
+
+func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Cache-Control", "no-store")
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":      true,
+		"service": "clickclack",
+	})
 }
 
 func (s *Server) requireCookieCSRF(next http.Handler) http.Handler {

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -707,6 +707,25 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
 	t.Cleanup(server.Close)
 
+	healthResp, err := http.Get(server.URL + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer healthResp.Body.Close()
+	if healthResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected health status 200, got %d", healthResp.StatusCode)
+	}
+	if contentType := healthResp.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "application/json") {
+		t.Fatalf("expected health JSON, got content type %q", contentType)
+	}
+	var health map[string]any
+	if err := json.NewDecoder(healthResp.Body).Decode(&health); err != nil {
+		t.Fatal(err)
+	}
+	if health["ok"] != true || health["service"] != "clickclack" {
+		t.Fatalf("unexpected health response: %#v", health)
+	}
+
 	index := getBody(t, server.URL+"/")
 	if !strings.Contains(index, "ClickClack") {
 		t.Fatalf("expected embedded app shell, got %q", index)


### PR DESCRIPTION
## Summary
- add GET and HEAD /health
- return no-store JSON with service identity
- cover the endpoint in the HTTP API test suite

## Validation
- go test ./apps/api/internal/httpapi
- deployed local binary returns HTTP 200 with {ok:true,service:" clickclack\}