### PR TITLE
fix(embed): match custom host colors before first paint

### DIFF
--- a/apps/api/internal/webassets/dist/200.html
+++ b/apps/api/internal/webassets/dist/200.html
@@ -13,8 +13,72 @@
       try {
         var ccMode;
         if (/^\/embed\/(?:channel|thread)\//.test(location.pathname)) {
-          var ccHostMode = new URLSearchParams(location.search).get("theme");
+          var ccEmbedParams = new URLSearchParams(location.search);
+          var ccHostMode = ccEmbedParams.get("theme");
           if (ccHostMode === "light" || ccHostMode === "dark") ccMode = ccHostMode;
+          var ccInitialTokens = ccEmbedParams.get("themeTokens");
+          if (ccMode && ccInitialTokens && ccInitialTokens.length <= 16384) {
+            var ccTokens;
+            try {
+              ccTokens = JSON.parse(ccInitialTokens);
+            } catch (e) {
+              ccTokens = null;
+            }
+            if (ccTokens && typeof ccTokens === "object" && !Array.isArray(ccTokens)) {
+              var ccColorTargets = {
+                surface: ["--bg", "--rail"],
+                card: ["--panel"],
+                elevated: ["--panel-2", "--panel-3"],
+                text: ["--text"],
+                "text-strong": ["--text-strong"],
+                muted: ["--muted", "--muted-2"],
+                border: ["--line"],
+                "border-strong": ["--line-strong"],
+                accent: ["--accent", "--brand-a"],
+                "accent-fill": ["--accent-hover", "--brand-b"],
+                "accent-fg": ["--accent-contrast", "--brand-contrast"],
+                ok: ["--success"],
+                warn: ["--warn"],
+                danger: ["--danger"],
+                info: ["--info"],
+              };
+              Object.keys(ccColorTargets).forEach(function (ccToken) {
+                var ccValue = ccTokens[ccToken];
+                if (
+                  typeof ccValue !== "string" ||
+                  ccValue.length > 512 ||
+                  !CSS.supports("color", ccValue)
+                ) {
+                  return;
+                }
+                ccColorTargets[ccToken].forEach(function (ccProperty) {
+                  document.documentElement.style.setProperty(ccProperty, ccValue);
+                });
+              });
+              if (
+                typeof ccTokens.radius === "string" &&
+                ccTokens.radius.length <= 512 &&
+                CSS.supports("border-radius", ccTokens.radius) &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 0.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 1.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 2.33)")
+              ) {
+                document.documentElement.style.setProperty("--radius", ccTokens.radius);
+                document.documentElement.style.setProperty(
+                  "--radius-sm",
+                  "calc(" + ccTokens.radius + " * 0.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-lg",
+                  "calc(" + ccTokens.radius + " * 1.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-xl",
+                  "calc(" + ccTokens.radius + " * 2.33)",
+                );
+              }
+            }
+          }
         }
         if (!ccMode) ccMode = localStorage.getItem("clickclack:color-mode:v1");
         if (ccMode === "light" || ccMode === "dark") {

--- a/apps/api/internal/webassets/dist/index.html
+++ b/apps/api/internal/webassets/dist/index.html
@@ -13,8 +13,72 @@
       try {
         var ccMode;
         if (/^\/embed\/(?:channel|thread)\//.test(location.pathname)) {
-          var ccHostMode = new URLSearchParams(location.search).get("theme");
+          var ccEmbedParams = new URLSearchParams(location.search);
+          var ccHostMode = ccEmbedParams.get("theme");
           if (ccHostMode === "light" || ccHostMode === "dark") ccMode = ccHostMode;
+          var ccInitialTokens = ccEmbedParams.get("themeTokens");
+          if (ccMode && ccInitialTokens && ccInitialTokens.length <= 16384) {
+            var ccTokens;
+            try {
+              ccTokens = JSON.parse(ccInitialTokens);
+            } catch (e) {
+              ccTokens = null;
+            }
+            if (ccTokens && typeof ccTokens === "object" && !Array.isArray(ccTokens)) {
+              var ccColorTargets = {
+                surface: ["--bg", "--rail"],
+                card: ["--panel"],
+                elevated: ["--panel-2", "--panel-3"],
+                text: ["--text"],
+                "text-strong": ["--text-strong"],
+                muted: ["--muted", "--muted-2"],
+                border: ["--line"],
+                "border-strong": ["--line-strong"],
+                accent: ["--accent", "--brand-a"],
+                "accent-fill": ["--accent-hover", "--brand-b"],
+                "accent-fg": ["--accent-contrast", "--brand-contrast"],
+                ok: ["--success"],
+                warn: ["--warn"],
+                danger: ["--danger"],
+                info: ["--info"],
+              };
+              Object.keys(ccColorTargets).forEach(function (ccToken) {
+                var ccValue = ccTokens[ccToken];
+                if (
+                  typeof ccValue !== "string" ||
+                  ccValue.length > 512 ||
+                  !CSS.supports("color", ccValue)
+                ) {
+                  return;
+                }
+                ccColorTargets[ccToken].forEach(function (ccProperty) {
+                  document.documentElement.style.setProperty(ccProperty, ccValue);
+                });
+              });
+              if (
+                typeof ccTokens.radius === "string" &&
+                ccTokens.radius.length <= 512 &&
+                CSS.supports("border-radius", ccTokens.radius) &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 0.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 1.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 2.33)")
+              ) {
+                document.documentElement.style.setProperty("--radius", ccTokens.radius);
+                document.documentElement.style.setProperty(
+                  "--radius-sm",
+                  "calc(" + ccTokens.radius + " * 0.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-lg",
+                  "calc(" + ccTokens.radius + " * 1.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-xl",
+                  "calc(" + ccTokens.radius + " * 2.33)",
+                );
+              }
+            }
+          }
         }
         if (!ccMode) ccMode = localStorage.getItem("clickclack:color-mode:v1");
         if (ccMode === "light" || ccMode === "dark") {

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -13,8 +13,72 @@
       try {
         var ccMode;
         if (/^\/embed\/(?:channel|thread)\//.test(location.pathname)) {
-          var ccHostMode = new URLSearchParams(location.search).get("theme");
+          var ccEmbedParams = new URLSearchParams(location.search);
+          var ccHostMode = ccEmbedParams.get("theme");
           if (ccHostMode === "light" || ccHostMode === "dark") ccMode = ccHostMode;
+          var ccInitialTokens = ccEmbedParams.get("themeTokens");
+          if (ccMode && ccInitialTokens && ccInitialTokens.length <= 16384) {
+            var ccTokens;
+            try {
+              ccTokens = JSON.parse(ccInitialTokens);
+            } catch (e) {
+              ccTokens = null;
+            }
+            if (ccTokens && typeof ccTokens === "object" && !Array.isArray(ccTokens)) {
+              var ccColorTargets = {
+                surface: ["--bg", "--rail"],
+                card: ["--panel"],
+                elevated: ["--panel-2", "--panel-3"],
+                text: ["--text"],
+                "text-strong": ["--text-strong"],
+                muted: ["--muted", "--muted-2"],
+                border: ["--line"],
+                "border-strong": ["--line-strong"],
+                accent: ["--accent", "--brand-a"],
+                "accent-fill": ["--accent-hover", "--brand-b"],
+                "accent-fg": ["--accent-contrast", "--brand-contrast"],
+                ok: ["--success"],
+                warn: ["--warn"],
+                danger: ["--danger"],
+                info: ["--info"],
+              };
+              Object.keys(ccColorTargets).forEach(function (ccToken) {
+                var ccValue = ccTokens[ccToken];
+                if (
+                  typeof ccValue !== "string" ||
+                  ccValue.length > 512 ||
+                  !CSS.supports("color", ccValue)
+                ) {
+                  return;
+                }
+                ccColorTargets[ccToken].forEach(function (ccProperty) {
+                  document.documentElement.style.setProperty(ccProperty, ccValue);
+                });
+              });
+              if (
+                typeof ccTokens.radius === "string" &&
+                ccTokens.radius.length <= 512 &&
+                CSS.supports("border-radius", ccTokens.radius) &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 0.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 1.67)") &&
+                CSS.supports("border-radius", "calc(" + ccTokens.radius + " * 2.33)")
+              ) {
+                document.documentElement.style.setProperty("--radius", ccTokens.radius);
+                document.documentElement.style.setProperty(
+                  "--radius-sm",
+                  "calc(" + ccTokens.radius + " * 0.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-lg",
+                  "calc(" + ccTokens.radius + " * 1.67)",
+                );
+                document.documentElement.style.setProperty(
+                  "--radius-xl",
+                  "calc(" + ccTokens.radius + " * 2.33)",
+                );
+              }
+            }
+          }
         }
         if (!ccMode) ccMode = localStorage.getItem("clickclack:color-mode:v1");
         if (ccMode === "light" || ccMode === "dark") {

--- a/docs/features/embedding.md
+++ b/docs/features/embedding.md
@@ -61,6 +61,13 @@ of the parent window, without a path or trailing slash. The color mode applies
 before the first paint and continues to take precedence when ClickClack loads the
 user's account preferences.
 
+For a custom palette, add `themeTokens` containing the JSON-encoded semantic
+token object shown below. Set the parameter with
+`url.searchParams.set("themeTokens", JSON.stringify(tokens))` so it is encoded
+correctly. ClickClack validates each initial CSS value and applies its colors,
+surfaces, borders, and corner radius before the first paint; snapshots larger
+than 16 KiB are ignored.
+
 After the iframe loads, the host can keep its full palette synchronized by
 sending a complete `openclaw:widget-theme` snapshot to the ClickClack origin:
 

--- a/tests/e2e/embed-theme.spec.ts
+++ b/tests/e2e/embed-theme.spec.ts
@@ -80,6 +80,7 @@ test("embedded channels follow the exact cross-origin host theme without changin
   );
   embedUrl.searchParams.set("theme", "light");
   embedUrl.searchParams.set("hostOrigin", hostOrigin);
+  embedUrl.searchParams.set("themeTokens", JSON.stringify(lightTokens));
 
   const embedResponse = await page.request.get(embedUrl.href);
   expect(embedResponse.ok()).toBe(true);
@@ -123,6 +124,15 @@ test("embedded channels follow the exact cross-origin host theme without changin
   await expect(embeddedPage.locator("html")).toHaveAttribute("data-color-mode", "light");
   const frame = page.frames().find((candidate) => candidate.url().startsWith(clickClackOrigin));
   expect(frame).toBeDefined();
+  await expect
+    .poll(() =>
+      frame!.evaluate(() => ({
+        background: getComputedStyle(document.documentElement).getPropertyValue("--bg").trim(),
+        panel: getComputedStyle(document.documentElement).getPropertyValue("--panel").trim(),
+        accent: getComputedStyle(document.documentElement).getPropertyValue("--accent").trim(),
+      })),
+    )
+    .toEqual({ background: "#faf9f7", panel: "#ffffff", accent: "#bd4531" });
 
   const storedAppearance = await frame!.evaluate(() => ({
     colorMode: localStorage.getItem("clickclack:color-mode:v1"),
@@ -235,5 +245,37 @@ test("embedded channels follow the exact cross-origin host theme without changin
   await postTheme("light", { ...lightTokens, surface: "#ff0000" });
   await expect
     .poll(() => frame!.evaluate(() => document.documentElement.style.getPropertyValue("--bg")))
+    .toBe("");
+
+  await postTheme("dark", customTokens);
+  const firstPaintCustomUrl = new URL(embedUrl.href);
+  firstPaintCustomUrl.searchParams.set("theme", "dark");
+  firstPaintCustomUrl.searchParams.set("themeTokens", JSON.stringify(customTokens));
+  await frame!.goto(firstPaintCustomUrl.href);
+  await expect
+    .poll(() =>
+      frame!.evaluate(() => ({
+        mode: document.documentElement.dataset.colorMode,
+        background: getComputedStyle(document.documentElement).getPropertyValue("--bg").trim(),
+        panel: getComputedStyle(document.documentElement).getPropertyValue("--panel").trim(),
+        accent: getComputedStyle(document.documentElement).getPropertyValue("--accent").trim(),
+      })),
+    )
+    .toEqual({ mode: "dark", background: "#171229", panel: "#211a36", accent: "#c084fc" });
+  await captureProof(page, "04-custom-first-paint");
+
+  const malformedTokensUrl = new URL(embedUrl.href);
+  malformedTokensUrl.searchParams.set("theme", "dark");
+  malformedTokensUrl.searchParams.set("themeTokens", "{");
+  await frame!.goto(malformedTokensUrl.href);
+  await expect
+    .poll(() => frame!.evaluate(() => document.documentElement.dataset.colorMode))
+    .toBe("dark");
+
+  const invalidRadiusUrl = new URL(embedUrl.href);
+  invalidRadiusUrl.searchParams.set("themeTokens", JSON.stringify({ radius: "8px 16px" }));
+  await frame!.goto(invalidRadiusUrl.href);
+  await expect
+    .poll(() => frame!.evaluate(() => document.documentElement.style.getPropertyValue("--radius")))
     .toBe("");
 });


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/114795

Follow-up to https://github.com/openclaw/clickclack/pull/133

## What Problem This Solves

A ClickClack sidebar could briefly render default colors before receiving the first custom host palette, even when the embedding application already knew the exact custom colors.

## Why This Change Was Made

Allow the existing authenticated embed contract to carry a bounded JSON `themeTokens` snapshot alongside `theme` and `hostOrigin`. Validate every initial CSS color and each derived corner radius before applying the palette in the pre-paint document script. Ignore malformed snapshots while retaining the valid light or dark mode. Keep live exact-origin parent messaging and standalone account appearance unchanged.

## User Impact

Custom host backgrounds, panels, text, borders, accents, and corner radii match before the discussion first paints; malformed input cannot override or break account appearance.

## Evidence

- Remote `pnpm fmt:ts:check`, `pnpm lint`, `pnpm typecheck`, `pnpm --filter @clickclack/web typecheck`, and `pnpm build`: passed.
- `node --test apps/web/src/lib/embed-theme.test.ts apps/web/src/lib/realtime-bootstrap.test.ts apps/web/src/lib/realtime-queue.test.ts`: 16 passed.
- `CLICKCLACK_CAPTURE_UI_PROOF=1 pnpm exec playwright test tests/e2e/embed-theme.spec.ts --reporter=line`: 1 passed (28.9s), against the actual Go application, real second HTTP origin, and production frame-ancestor policy.
- The browser scenario verifies initial light tokens, custom first-paint colors, live dark and purple palette switching, spoof rejection, unchanged account preferences, host-theme revocation on navigation, malformed JSON fallback, and invalid scalable radius rejection.
- Captured and visually inspected full-page light, dark, custom, and custom-first-paint screenshots.
- Exact production assets were generated from the passing browser build and checked in.
- Fresh independent first-paint security review: clean, zero accepted or actionable findings.

AI-assisted implementation and review.