### PR TITLE
fix: enforce bot topic workspace scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
+- Fixed bot topic endpoints accepting cross-workspace list and create operations by enforcing the token workspace scope. Thanks @ShiroKSH.
 - Added optional human-readable channel display titles while preserving slug-based routing and uniqueness.
 - Added agent-friendly CLI commands for adding and removing message reactions through the existing public APIs, with exact JSON output and terminal-safe human output. Thanks @PollyBot13.
 - Removed the redundant "Open in ClickClack" link from embedded channel headers, leaving external navigation to the host's own control.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.2.2 - Unreleased
 
-- Prevented workspace-scoped bot tokens from listing or creating message topics in a different workspace where the bot also has membership.
 - Added optional human-readable channel display titles while preserving slug-based routing and uniqueness.
 - Added agent-friendly CLI commands for adding and removing message reactions through the existing public APIs, with exact JSON output and terminal-safe human output. Thanks @PollyBot13.
 - Removed the redundant "Open in ClickClack" link from embedded channel headers, leaving external navigation to the host's own control.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.2.2 - Unreleased
 
+- Prevented workspace-scoped bot tokens from listing or creating message topics in a different workspace where the bot also has membership.
 - Added optional human-readable channel display titles while preserving slug-based routing and uniqueness.
 - Added agent-friendly CLI commands for adding and removing message reactions through the existing public APIs, with exact JSON output and terminal-safe human output. Thanks @PollyBot13.
 - Removed the redundant "Open in ClickClack" link from embedded channel headers, leaving external navigation to the host's own control.

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -214,6 +214,15 @@ func TestHTTPBotTokenWorkspaceIsolation(t *testing.T) {
 	expectStatusWithBearer(t, token.Token, http.MethodGet, server.URL+"/api/workspaces/"+otherWorkspace.ID, nil, http.StatusForbidden)
 	expectStatusWithBearer(t, token.Token, http.MethodGet, server.URL+"/api/workspaces/"+otherWorkspace.ID+"/channels", nil, http.StatusForbidden)
 	expectStatusWithBearer(t, token.Token, http.MethodPost, server.URL+"/api/workspaces/"+otherWorkspace.ID+"/channels", strings.NewReader(`{"name":"hidden"}`), http.StatusForbidden)
+	expectStatusWithBearer(t, token.Token, http.MethodGet, server.URL+"/api/workspaces/"+otherWorkspace.ID+"/topics", nil, http.StatusForbidden)
+	expectStatusWithBearer(t, token.Token, http.MethodPost, server.URL+"/api/workspaces/"+otherWorkspace.ID+"/topics", strings.NewReader(`{"channel_id":"`+otherChannel.ID+`","name":"hidden"}`), http.StatusForbidden)
+	otherTopics, err := st.ListTopics(ctx, otherWorkspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(otherTopics) != 0 {
+		t.Fatalf("bot token created a topic outside its workspace scope: %#v", otherTopics)
+	}
 	expectStatusWithBearer(t, token.Token, http.MethodGet, server.URL+"/api/search?workspace_id="+otherWorkspace.ID+"&q=scope", nil, http.StatusForbidden)
 	expectStatusWithBearer(t, token.Token, http.MethodGet, server.URL+"/api/realtime/events?workspace_id="+otherWorkspace.ID, nil, http.StatusForbidden)
 	expectStatusWithBearer(t, token.Token, http.MethodPost, server.URL+"/api/dms", strings.NewReader(`{"workspace_id":"`+otherWorkspace.ID+`","member_ids":[]}`), http.StatusForbidden)

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -901,7 +901,12 @@ func (s *Server) listTopics(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
-	topics, err := s.store.ListTopics(r.Context(), chi.URLParam(r, "workspace_id"), act.user.ID)
+	workspaceID := chi.URLParam(r, "workspace_id")
+	if err := act.requireWorkspace(workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
+	topics, err := s.store.ListTopics(r.Context(), workspaceID, act.user.ID)
 	writeResult(w, map[string]any{"topics": topics}, err)
 }
 
@@ -915,6 +920,11 @@ func (s *Server) createTopic(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
+	workspaceID := chi.URLParam(r, "workspace_id")
+	if err := act.requireWorkspace(workspaceID); err != nil {
+		writeError(w, http.StatusForbidden, err)
+		return
+	}
 	var body struct {
 		ChannelID string `json:"channel_id"`
 		Name      string `json:"name"`
@@ -923,7 +933,7 @@ func (s *Server) createTopic(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	topic, err := s.store.CreateTopic(r.Context(), store.CreateTopicInput{WorkspaceID: chi.URLParam(r, "workspace_id"), ChannelID: body.ChannelID, Name: body.Name, CreatedBy: act.user.ID})
+	topic, err := s.store.CreateTopic(r.Context(), store.CreateTopicInput{WorkspaceID: workspaceID, ChannelID: body.ChannelID, Name: body.Name, CreatedBy: act.user.ID})
 	writeResultStatus(w, http.StatusCreated, map[string]any{"topic": topic}, err)
 }
 


### PR DESCRIPTION
## Summary

- Enforce a bot token's workspace scope before topic reads and creates.
- Cover a bot that belongs to another workspace but is authorized only for its issuing workspace.

## Root cause

Topic handlers checked token scopes, while the store checked only membership. A bot that also belonged to another workspace could therefore list or create that workspace's topics.

## Validation

- go test ./...

## Runtime verification

Ran a local `clickclack serve` process against an isolated ephemeral SQLite database. The bot was a member of both workspaces, but its bearer token was issued for only one; the requests below were made over loopback HTTP. Token and workspace identifiers redacted.

```text
in_scope_topics_list=200 topics-array
cross_workspace_topics_list=403 bot token cannot access this workspace
cross_workspace_topics_create=403 bot token cannot access this workspace
```
