### PR TITLE
chore: prepare 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 ## 0.3.0 - 2026-08-02
 
 - Added coherent conversation organization and attention tools: topic selection and filtered timelines, channel-wide pins with a visible 100-message ceiling, per-channel all/mentions/muted notification preferences, resolved mention highlighting whose current-user emphasis follows that preference, and workspace-visible responding-agent identity beside channel and thread composers. Thanks @PollyBot13 and @jjjhenriksen.
-
-## 0.2.2 - 2026-08-01
-
 - Updated Go, web, desktop, Cloudflare, CI action, package-manager, and container-base dependencies.
 - Fixed bot topic endpoints accepting cross-workspace list and create operations by enforcing the token workspace scope. Thanks @ShiroKSH.
 - Fixed right-aligned messages rendering Markdown lists and blockquotes outside the message bubble. Thanks @jjjhenriksen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0 - Unreleased
+## 0.3.0 - 2026-08-02
 
 - Added coherent conversation organization and attention tools: topic selection and filtered timelines, channel-wide pins with a visible 100-message ceiling, per-channel all/mentions/muted notification preferences, resolved mention highlighting whose current-user emphasis follows that preference, and workspace-visible responding-agent identity beside channel and thread composers. Thanks @PollyBot13 and @jjjhenriksen.
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickclack/desktop",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "private": true,
   "author": "OpenClaw contributors",
   "description": "Native ClickClack desktop shell for macOS, Windows, and Linux",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickclack/web",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickclack/protocol",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "scripts": {

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickclack/sdk-ts",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- date the approved 0.3.0 changelog entry for 2026-08-02
- fold the never-tagged, never-published 0.2.2 maintenance notes into 0.3.0 so the release covers every change since v0.2.1
- align the private desktop, web, protocol, and TypeScript SDK product manifests at 0.3.0

## Validation

- final integrated Playwright suite on post-coherence main: 146 passed
- `pnpm check`
- `goreleaser check`
- `CLICKCLACK_WEB_VERSION=0.3.0-prep goreleaser release --snapshot --clean` (all Go archives, Linux packages, and checksums built; publish skipped)
- real release-shaped CLI binary: `clickclack 0.3.0 (00888558eac1, 2026-08-02T22:34:33Z)`
- unsigned arm64 Electron directory package built with `CFBundleShortVersionString` and `CFBundleVersion` both 0.3.0
- local release-freeze Codex autoreview: clean, no accepted/actionable findings

## Publication blocker

Do not tag, dispatch the current legacy release workflow, or publish this release yet. ClickClack needs the shared `openclaw/release-workflows@v1` Electron release variant being built in the separate lane. This PR contains release metadata only and is ready for that lane to unblock the canonical workflow.
