### PR TITLE
docs: rewrite README to house standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,209 +1,77 @@
-# 💬 ClickClack
+# ClickClack 🦞 — Tiny chat. Big claws.
+
+[![CI](https://img.shields.io/github/actions/workflow/status/openclaw/clickclack/ci.yml?branch=main&style=flat-square&label=ci)](https://github.com/openclaw/clickclack/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/openclaw/clickclack?style=flat-square)](https://github.com/openclaw/clickclack/releases/latest)
+[![License](https://img.shields.io/github/license/openclaw/clickclack?style=flat-square)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-clickclack.chat-5b5bd6?style=flat-square)](https://docs.clickclack.chat)
 
 ![ClickClack banner](docs/assets/readme-banner.jpg)
 
-Realtime team chat for OpenClaw agents and humans.
+ClickClack is self-hostable team chat for people, bots, and agents. It combines a Go server, Svelte web app, scriptable CLI, and TypeScript SDK behind one API-first chat service.
 
-Self-hostable, API-first chat. Slack-style threads, Discord-ish warmth, and a
-light clawed theme. Ships as a single Go binary with embedded SQLite and an
-embedded Svelte SPA.
+![ClickClack chat](docs/proof/switchboard-after-chat-light.png)
 
-```sh
-pnpm install
-pnpm build
-go run ./apps/api/cmd/clickclack serve
-# open http://localhost:8080
-```
+## Install
 
-## What's in the box
+The smallest path is the hosted service: open **[app.clickclack.chat](https://app.clickclack.chat)** in a browser.
 
-- One Go binary. Embedded Svelte SPA, embedded SQL migrations, embedded
-  static assets — no separate web server, no extra services.
-- SQLite first-class storage with WAL, FTS5 search, and an online backup
-  command. Postgres is available behind the same store interface for hosted
-  deployments that need external durable storage.
-- Realtime over WebSocket with a durable event log. Reconnect with a cursor
-  to recover anything you missed; HTTP `/api/realtime/events` works as a
-  pull-style fallback.
-- Channels with Slack-style threads (one level, no nesting), message editing,
-  reactions, uploads, direct messages, and a guest waiting-room path with
-  moderator approvals, timeouts, and blocks.
-- CLI-managed bootstrap, magic-link auth, optional GitHub OAuth, and an
-  agent-friendly client mode for sending/listing/replying from scripts.
-- Framework-neutral [TypeScript SDK](packages/sdk-ts) and a tiny
-  [bot example](examples/bot-ts).
-- Mattermost-shaped incoming webhook and slash command surfaces for drop-in
-  scripts.
+For a desktop client or self-hosted server, download the matching artifact from the **[latest GitHub release](https://github.com/openclaw/clickclack/releases/latest)**. Releases contain desktop installers for macOS, Windows, and Linux, plus server archives or packages for macOS, Linux, Windows, and FreeBSD.
 
-## Documentation
-
-Product domain: **[clickclack.chat](https://clickclack.chat)**. App domain:
-**[app.clickclack.chat](https://app.clickclack.chat)**, with `/app` as the
-local path. Docs domain:
-**[docs.clickclack.chat](https://docs.clickclack.chat)**, built from `docs/`
-by `pnpm docs:site`. The [docs/](docs/) tree is organised so each file has a
-short `read_when` hint at the top — open the one that matches your change.
-
-- **Start here:** [docs/README.md](docs/README.md) — landing page + index.
-- [Architecture](docs/architecture/overview.md) — process layout, durable vs
-  realtime split.
-- [FakeCo staging](docs/fakeco.md) — isolated Docker/VM deployment, guarded FakeCo AWS owner, deterministic synthetic data, and OpenClaw round-trip canary.
-- [API overview](docs/api/overview.md) — REST/WebSocket surface and where to
-  find each endpoint.
-- [Data model](docs/data-model.md) — tables, IDs, invariants.
-- [CLI](docs/cli.md), [Agent-friendly CLI](docs/agent-friendly-cli.md),
-  [Configuration](docs/configuration.md),
-  [Deployment](docs/deployment.md), [Development](docs/development.md),
-  [Releasing](docs/releasing.md).
-- [TypeScript SDK](docs/sdk.md).
-
-Per-feature docs:
-
-| Feature          | Doc |
-|------------------|-----|
-| Auth             | [docs/features/auth.md](docs/features/auth.md) |
-| Moderation       | [docs/features/moderation.md](docs/features/moderation.md) |
-| Workspaces       | [docs/features/workspaces.md](docs/features/workspaces.md) |
-| Messages, topics, pins, and channel attention | [docs/features/messages.md](docs/features/messages.md) |
-| Threads          | [docs/features/threads.md](docs/features/threads.md) |
-| Reactions        | [docs/features/reactions.md](docs/features/reactions.md) |
-| Realtime         | [docs/features/realtime.md](docs/features/realtime.md) |
-| Search           | [docs/features/search.md](docs/features/search.md) |
-| Uploads          | [docs/features/uploads.md](docs/features/uploads.md) |
-| Direct messages  | [docs/features/dms.md](docs/features/dms.md) |
-| Bots             | [docs/features/bots.md](docs/features/bots.md) |
-| Integrations     | [docs/features/integrations.md](docs/features/integrations.md) |
-
-The product spec — locked decisions, milestones, and open questions — lives
-in [SPEC.md](SPEC.md).
+For source builds and package details, see the [install guide](docs/install.md).
 
 ## Quick start
 
-```sh
-pnpm install                                        # JS deps for SPA + SDK
-pnpm build                                          # builds SPA, copies dist into the Go binary
-go run ./apps/api/cmd/clickclack serve --dev-bootstrap=true
-```
-
-For a fresh local checkout, `--dev-bootstrap=true` boots a default user,
-workspace, and channel so the SPA loads into something useful at `/app`. The
-root path is the public product website. Production and Docker defaults leave
-dev auth disabled.
-
-### Two-process dev loop
+After downloading the `clickclack` server binary, start a local instance:
 
 ```sh
-pnpm dev:api                                        # Go server with dev bootstrap enabled
-pnpm dev:web                                        # Vite dev server proxied to /api
+./clickclack serve --dev-bootstrap=true
 ```
 
-### CLI
+Open [http://localhost:8080/app](http://localhost:8080/app). On an empty data directory, development bootstrap creates a local owner, workspace, and channel; data stays in `./data` by default.
+
+The [full quickstart](docs/quickstart.md) continues with real accounts, sessions, channels, and a bot.
+
+## What runs where
+
+The server is one Go binary with the web app, SQLite migrations, and static assets embedded. SQLite and local uploads are the defaults; Postgres and Cloudflare R2 are available for deployments that need external storage.
+
+Durable chat state and the event log live in the database. WebSockets carry live updates, and clients recover missed events with cursors after reconnecting.
+
+| Surface | Use it for | Guide |
+| --- | --- | --- |
+| Web and desktop | Channels, threads, search, uploads, direct messages, and moderation | [Feature index](docs/README.md#whats-in-the-box) |
+| CLI | Server administration, backups, exports, and scripted chat | [CLI reference](docs/cli.md) |
+| TypeScript SDK | Typed HTTP and realtime clients for bots and integrations | [SDK guide](docs/sdk.md) |
+| REST and WebSocket API | Clients in other languages and direct integrations | [API overview](docs/api/overview.md) |
+
+## Self-hosting
+
+ClickClack can run from a release binary, a multi-stage Docker image built from this repository, or a source build. Production deployments disable development bootstrap and configure authentication, storage, TLS termination, and backups explicitly.
+
+Start with the [deployment guide](docs/deployment.md), then use the [configuration reference](docs/configuration.md) for flag, environment, and file precedence. The [architecture overview](docs/architecture/overview.md) describes the server, storage, realtime, and embedded frontend boundaries.
+
+## Documentation
+
+The complete documentation is at **[docs.clickclack.chat](https://docs.clickclack.chat)** and in [`docs/`](docs/).
+
+- [Features and operations](docs/README.md)
+- [Authentication](docs/features/auth.md)
+- [Bots and integrations](docs/features/bots.md)
+- [Desktop apps](docs/desktop.md)
+- [Data model](docs/data-model.md)
+- [Development](docs/development.md)
+
+## Development
+
+Source builds require Go 1.26.5, Node.js 24 or newer, and pnpm 11.19.0.
 
 ```sh
-go run ./apps/api/cmd/clickclack admin bootstrap \
-  --name "Peter" --email steipete@gmail.com
-
-go run ./apps/api/cmd/clickclack admin magic-link create \
-  --email steipete@gmail.com --name "Peter"
-
-go run ./apps/api/cmd/clickclack login --magic-token mgt_...
-go run ./apps/api/cmd/clickclack whoami
-go run ./apps/api/cmd/clickclack send --channel general "click clack"
-go run ./apps/api/cmd/clickclack messages list --channel general
-go run ./apps/api/cmd/clickclack threads reply msg_... --stdin <reply.md
-
-go run ./apps/api/cmd/clickclack backup --out ./data/backup.db
-go run ./apps/api/cmd/clickclack export --out ./data/export.json
+pnpm install --frozen-lockfile
+pnpm build
+pnpm check
 ```
 
-See [docs/cli.md](docs/cli.md) for the implemented command reference and
-[docs/agent-friendly-cli.md](docs/agent-friendly-cli.md) for the target
-script/agent contract.
-
-### Bot example
-
-```sh
-CLICKCLACK_URL=http://localhost:8080 \
-CLICKCLACK_TOKEN=ccb_... \
-CLICKCLACK_CHANNEL_ID=chn_... \
-CLICKCLACK_TEXT="clack from bot" \
-pnpm --filter @clickclack/example-bot start
-```
-
-Create bot tokens with `clickclack admin bot create`. See
-[docs/features/bots.md](docs/features/bots.md),
-[docs/bot-installs.md](docs/bot-installs.md), and [docs/sdk.md](docs/sdk.md).
-
-## Auth
-
-ClickClack accepts, in order: an `Authorization: Bearer` session or bot token,
-the configured session cookie (`cc_session` by default), an
-`X-ClickClack-User` header, or a dev fallback to the first user in the DB.
-Magic-link tokens are mintable from the CLI today; the HTTP endpoint also
-exists. GitHub OAuth is opt-in via:
-
-```sh
-CLICKCLACK_PUBLIC_URL=https://chat.example.com
-# Optional split API origin or normalized base path; defaults to PUBLIC_URL:
-# CLICKCLACK_PUBLIC_API_URL=https://api.example.com/services/clickclack
-# Optional for multiple trusted instances on one hostname:
-# CLICKCLACK_COOKIE_NAMESPACE=production
-CLICKCLACK_GITHUB_CLIENT_ID=...
-CLICKCLACK_GITHUB_CLIENT_SECRET=...
-# Optional org gate:
-# CLICKCLACK_GITHUB_ALLOWED_ORG=openclaw
-# Optional moderator org for open guest login:
-# CLICKCLACK_GITHUB_MODERATOR_ORG=openclaw
-```
-
-Without the org gate, GitHub users land in an isolated `Guests` workspace. When
-`CLICKCLACK_GITHUB_MODERATOR_ORG` is set, matching org members become
-moderators and non-members start as waiting-room guests with a three-post daily
-budget until a moderator approves them; if it is unset, open-login users join
-as normal members. See [docs/features/moderation.md](docs/features/moderation.md).
-
-Details and trade-offs in [docs/features/auth.md](docs/features/auth.md).
-For the CLI, stored session tokens, workspace defaults, and channel defaults
-are scoped to their saved server URL. Stored tokens are also skipped when
-`--user` / `CLICKCLACK_USER_ID` is set, unless `--token` is explicitly
-provided.
-
-## Tooling
-
-- TypeScript: stable TypeScript 7 native `tsc` from `@typescript/native`.
-- Lint/format: `oxlint` and `oxfmt`.
-- Tests: `go test ./...` for the backend, Playwright (`pnpm test:e2e`) for
-  the SPA.
-- Coverage gate: `pnpm coverage` fails under 85% Go line coverage.
-
-```sh
-pnpm check        # go test + root/workspace typecheck + lint + format check
-pnpm coverage     # Go coverage with 85% gate
-pnpm test:e2e     # Playwright
-pnpm fmt          # gofmt + oxfmt write
-pnpm fmt:check    # gofmt + oxfmt check, CI-compatible
-goreleaser release --snapshot --clean  # local release smoke test
-```
-
-## Deployment
-
-Single binary or Docker image. The repo `Dockerfile` is multi-stage and
-produces a small Alpine image with the SPA baked in:
-
-```sh
-docker build -t clickclack .
-docker run --rm -p 8080:8080 -v clickclack-data:/app/data clickclack
-```
-
-Full deployment notes — data layout, reverse proxy, backups, OAuth setup —
-are in [docs/deployment.md](docs/deployment.md).
-
-## Status
-
-V1 is in-flight. The vertical slice (workspaces, channels, Markdown
-messages, threads, realtime, reactions, search, uploads, DMs, magic-link
-auth, GitHub OAuth, guest-room moderation, Postgres, R2 uploads, Docker) is
-implemented. See [SPEC.md](SPEC.md) for what is still open.
+See the [development guide](docs/development.md) for the two-process web loop, repository layout, focused scripts, and test details.
 
 ## License
 


### PR DESCRIPTION
## Summary

Before, the 210-line README mixed the project pitch with a feature wall, a full documentation index, CLI and authentication reference, tooling details, deployment commands, and a forward-looking status section.

After, the 78-line README is a front door: dynamic CI/release/license badges, the existing banner and an existing app screenshot, real hosted/release install paths, a tested one-command local quickstart, a short architecture summary, and progressively deeper links.

## Content routing

No new docs files were needed. The removed detail already lives in the existing docs tree:

- features and product surfaces: `docs/README.md` and `docs/features/`
- CLI and automation: `docs/cli.md` and `docs/agent-friendly-cli.md`
- authentication and configuration: `docs/features/auth.md` and `docs/configuration.md`
- deployment and Docker: `docs/deployment.md`
- development commands and repository layout: `docs/development.md`
- SDK and API reference: `docs/sdk.md` and `docs/api/overview.md`

The stale, changelog-style "V1 is in-flight" status paragraph and subjective marketing phrasing were dropped. No factual material was removed without an existing documentation home.

## Verification

- Confirmed the repository is public, active, and uses `main`.
- Confirmed GitHub Releases publish server binaries/packages and desktop installers; the workspace SDK is not on npm, and no ClickClack formula/cask exists in the checked Homebrew taps.
- Ran `pnpm install --frozen-lockfile`, `pnpm build`, and `go build -o ./clickclack ./apps/api/cmd/clickclack` successfully.
- Ran `./clickclack --help` and `./clickclack serve --help` to validate the documented flags and defaults.
- Ran the exact quickstart command, `./clickclack serve --dev-bootstrap=true`; both `/app` and `/` returned HTTP 200.
- Ran `pnpm check`; Go/web/FakeCo/desktop tests, TypeScript checks, lint, and formatting all passed.
- Verified all 17 relative targets exist. Every external URL and badge returned HTTP 200; Shields SVGs contained no invalid/not-found card.
- No code sample was added; the shell quickstart was executed directly.
- Ran autoreview on the local diff with Codex (`gpt-5.6-sol`, high): clean, with no accepted/actionable findings.
