### PR TITLE
fix: prevent integrations from crossing network and guest boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 - Unreleased
 
+- Hardened integration callbacks against server-side requests to non-public networks and enforced guest visibility, moderation, and write limits for topics and registered slash commands. Thanks @jason-allen-oneal.
 - Updated web font packages and the Cloudflare Wrangler toolchain.
 - Added coherent conversation organization and attention tools: topic selection and filtered timelines, channel-wide pins with a visible 100-message ceiling, per-channel all/mentions/muted notification preferences, resolved mention highlighting whose current-user emphasis follows that preference, and workspace-visible responding-agent identity beside channel and thread composers. Thanks @PollyBot13 and @jjjhenriksen.
 

--- a/apps/api/internal/httpapi/callback_http.go
+++ b/apps/api/internal/httpapi/callback_http.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"net/http"
 	"net/netip"
 	"time"
 )
@@ -44,25 +43,6 @@ var publicIPv6Prefix = netip.MustParsePrefix("2000::/3")
 type callbackDialer struct {
 	lookupNetIP func(context.Context, string, string) ([]netip.Addr, error)
 	dialContext func(context.Context, string, string) (net.Conn, error)
-}
-
-func newCallbackHTTPClient() *http.Client {
-	resolver := net.DefaultResolver
-	dialer := &net.Dialer{Timeout: callbackTimeout}
-	policyDialer := &callbackDialer{
-		lookupNetIP: resolver.LookupNetIP,
-		dialContext: dialer.DialContext,
-	}
-	transport := http.DefaultTransport.(*http.Transport).Clone()
-	transport.Proxy = nil
-	transport.DialContext = policyDialer.DialContext
-	return &http.Client{
-		Transport: transport,
-		Timeout:   callbackTimeout,
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
 }
 
 func (d *callbackDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {

--- a/apps/api/internal/httpapi/callback_http.go
+++ b/apps/api/internal/httpapi/callback_http.go
@@ -1,0 +1,121 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+)
+
+const callbackTimeout = 3 * time.Second
+
+// These ranges are globally routable in Go's broad sense but are reserved for
+// protocols, documentation, benchmarking, or other special-purpose use. Keep
+// this policy aligned with the IANA IPv4 and IPv6 special-purpose registries.
+var blockedCallbackPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.31.196.0/24"),
+	netip.MustParsePrefix("192.52.193.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("192.175.48.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("2620:4f:8000::/48"),
+	netip.MustParsePrefix("3ffe::/16"),
+	netip.MustParsePrefix("3fff::/20"),
+}
+
+// Public IPv6 unicast allocations currently come from 2000::/3. Rejecting
+// other space by default keeps future or transition ranges closed until their
+// callback safety is understood.
+var publicIPv6Prefix = netip.MustParsePrefix("2000::/3")
+
+type callbackDialer struct {
+	lookupNetIP func(context.Context, string, string) ([]netip.Addr, error)
+	dialContext func(context.Context, string, string) (net.Conn, error)
+}
+
+func newCallbackHTTPClient() *http.Client {
+	resolver := net.DefaultResolver
+	dialer := &net.Dialer{Timeout: callbackTimeout}
+	policyDialer := &callbackDialer{
+		lookupNetIP: resolver.LookupNetIP,
+		dialContext: dialer.DialContext,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = policyDialer.DialContext
+	return &http.Client{
+		Transport: transport,
+		Timeout:   callbackTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (d *callbackDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	if network != "tcp" && network != "tcp4" && network != "tcp6" {
+		return nil, fmt.Errorf("callback network %q is not allowed", network)
+	}
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("invalid callback address: %w", err)
+	}
+	var addresses []netip.Addr
+	if literal, parseErr := netip.ParseAddr(host); parseErr == nil {
+		addresses = []netip.Addr{literal}
+	} else {
+		addresses, err = d.lookupNetIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("resolve callback host: %w", err)
+		}
+	}
+	if len(addresses) == 0 {
+		return nil, errors.New("callback host resolved to no addresses")
+	}
+	for _, address := range addresses {
+		if !isPublicCallbackAddr(address) {
+			return nil, errors.New("callback host resolves to a non-public address")
+		}
+	}
+	var dialErrors []error
+	for _, address := range addresses {
+		conn, dialErr := d.dialContext(ctx, network, net.JoinHostPort(address.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		dialErrors = append(dialErrors, dialErr)
+	}
+	return nil, fmt.Errorf("connect to callback host: %w", errors.Join(dialErrors...))
+}
+
+func isPublicCallbackAddr(address netip.Addr) bool {
+	if address.Zone() != "" {
+		return false
+	}
+	address = address.Unmap()
+	if !address.IsValid() || !address.IsGlobalUnicast() || address.IsPrivate() || address.IsLoopback() || address.IsLinkLocalUnicast() || address.IsLinkLocalMulticast() || address.IsMulticast() || address.IsUnspecified() {
+		return false
+	}
+	if address.Is6() && !publicIPv6Prefix.Contains(address) {
+		return false
+	}
+	for _, prefix := range blockedCallbackPrefixes {
+		if prefix.Contains(address) {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/api/internal/httpapi/callback_http_client_default.go
+++ b/apps/api/internal/httpapi/callback_http_client_default.go
@@ -1,0 +1,27 @@
+//go:build !clickclack_e2e_unsafe_callbacks
+
+package httpapi
+
+import (
+	"net"
+	"net/http"
+)
+
+func newCallbackHTTPClient() *http.Client {
+	resolver := net.DefaultResolver
+	dialer := &net.Dialer{Timeout: callbackTimeout}
+	policyDialer := &callbackDialer{
+		lookupNetIP: resolver.LookupNetIP,
+		dialContext: dialer.DialContext,
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	transport.DialContext = policyDialer.DialContext
+	return &http.Client{
+		Transport: transport,
+		Timeout:   callbackTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/apps/api/internal/httpapi/callback_http_client_e2e.go
+++ b/apps/api/internal/httpapi/callback_http_client_e2e.go
@@ -1,0 +1,21 @@
+//go:build clickclack_e2e_unsafe_callbacks
+
+package httpapi
+
+import (
+	"log"
+	"net/http"
+)
+
+func newCallbackHTTPClient() *http.Client {
+	log.Print("WARNING: E2E build allows loopback callback destinations")
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+	return &http.Client{
+		Transport: transport,
+		Timeout:   callbackTimeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -1576,6 +1576,10 @@ func (s *Server) slashCommand(w http.ResponseWriter, r *http.Request) {
 	}
 	registered, err := s.store.GetSlashCommandForChannel(r.Context(), chi.URLParam(r, "channel_id"), command, act.user.ID)
 	if err == nil {
+		if err := s.store.CanPublishEphemeral(r.Context(), registered.WorkspaceID, chi.URLParam(r, "channel_id"), "", act.user.ID); err != nil {
+			writeStoreError(w, err)
+			return
+		}
 		s.invokeRegisteredSlashCommand(w, r, act, registered, text)
 		return
 	}
@@ -1630,7 +1634,7 @@ func (s *Server) invokeRegisteredSlashCommand(w http.ResponseWriter, r *http.Req
 		writeError(w, http.StatusBadRequest, err)
 		return
 	}
-	status, responseBody, callbackErr := postSlashCallback(r.Context(), command, payloadJSON)
+	status, responseBody, callbackErr := s.postSlashCallback(r.Context(), command, payloadJSON)
 	invokeErr := ""
 	if callbackErr != nil {
 		invokeErr = callbackErr.Error()
@@ -1710,7 +1714,7 @@ func (s *Server) deliverEventSubscriptions(ctx context.Context, event store.Even
 		if err != nil {
 			continue
 		}
-		status, responseBody, deliveryErr := postEventCallback(ctx, subscription, event, payload)
+		status, responseBody, deliveryErr := s.postEventCallback(ctx, subscription, event, payload)
 		errorText := ""
 		if deliveryErr != nil {
 			errorText = deliveryErr.Error()
@@ -1728,7 +1732,7 @@ func (s *Server) deliverEventSubscriptions(ctx context.Context, event store.Even
 	}
 }
 
-func postEventCallback(ctx context.Context, subscription store.EventSubscription, event store.Event, payload []byte) (int, string, error) {
+func (s *Server) postEventCallback(ctx context.Context, subscription store.EventSubscription, event store.Event, payload []byte) (int, string, error) {
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, subscription.CallbackURL, bytes.NewReader(payload))
 	if err != nil {
@@ -1738,8 +1742,7 @@ func postEventCallback(ctx context.Context, subscription store.EventSubscription
 	req.Header.Set("X-ClickClack-Timestamp", timestamp)
 	req.Header.Set("X-ClickClack-Event-ID", event.ID)
 	req.Header.Set("X-ClickClack-Signature", signSlashCallback(subscription.SigningSecret, timestamp, payload))
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := s.callbackClient.Do(req)
 	if err != nil {
 		return 0, "", err
 	}
@@ -1754,7 +1757,7 @@ func postEventCallback(ctx context.Context, subscription store.EventSubscription
 	return resp.StatusCode, string(body), nil
 }
 
-func postSlashCallback(ctx context.Context, command store.SlashCommand, payload []byte) (int, string, error) {
+func (s *Server) postSlashCallback(ctx context.Context, command store.SlashCommand, payload []byte) (int, string, error) {
 	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, command.CallbackURL, bytes.NewReader(payload))
 	if err != nil {
@@ -1763,8 +1766,7 @@ func postSlashCallback(ctx context.Context, command store.SlashCommand, payload 
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-ClickClack-Timestamp", timestamp)
 	req.Header.Set("X-ClickClack-Signature", signSlashCallback(command.SigningSecret, timestamp, payload))
-	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := s.callbackClient.Do(req)
 	if err != nil {
 		return 0, "", err
 	}

--- a/apps/api/internal/httpapi/integration_security_test.go
+++ b/apps/api/internal/httpapi/integration_security_test.go
@@ -1,0 +1,290 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestRegisteredSlashCommandHonorsCallerModeration(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	dataDir := t.TempDir()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(dataDir, "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	moderator, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Moderator", Email: "slash-mod@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultGuestWorkspaceMember(ctx, moderator.ID, store.WorkspaceRoleModerator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guest, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Guest", Email: "slash-guest@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, guest.ID, store.WorkspaceRoleGuest); err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "slash-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	bot, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Command Bot", CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	channels, err := st.ListChannels(ctx, workspace.ID, moderator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var guestChannelID, generalChannelID string
+	for _, channel := range channels {
+		switch channel.Name {
+		case "guest":
+			guestChannelID = channel.ID
+		case "general":
+			generalChannelID = channel.ID
+		}
+	}
+	if guestChannelID == "" || generalChannelID == "" {
+		t.Fatalf("expected guest and general channels, got %#v", channels)
+	}
+
+	var callbackCount atomic.Int32
+	callback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callbackCount.Add(1)
+		writeJSON(w, http.StatusOK, map[string]string{"response_type": "ephemeral", "text": "ok"})
+	}))
+	t.Cleanup(callback.Close)
+	if _, err := st.CreateSlashCommand(ctx, store.CreateSlashCommandInput{
+		WorkspaceID: workspace.ID,
+		Command:     "/deploy",
+		CallbackURL: callback.URL,
+		BotUserID:   bot.ID,
+		CreatedBy:   moderator.ID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{
+		UploadDir:      filepath.Join(dataDir, "uploads"),
+		callbackClient: &http.Client{Timeout: callbackTimeout},
+	}).Handler())
+	t.Cleanup(server.Close)
+
+	expectSlashStatusAsUser(t, guest.ID, server.URL+"/api/hooks/slash/"+generalChannelID, http.StatusForbidden)
+	if got := callbackCount.Load(); got != 0 {
+		t.Fatalf("hidden-channel guest invocation reached callback %d times", got)
+	}
+	expectSlashStatusAsUser(t, guest.ID, server.URL+"/api/hooks/slash/"+guestChannelID, http.StatusOK)
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("eligible guest invocation reached callback %d times, want 1", got)
+	}
+
+	timeoutUntil := time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano)
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: guest.ID, TimeoutUntil: &timeoutUntil}); err != nil {
+		t.Fatal(err)
+	}
+	expectSlashStatusAsUser(t, guest.ID, server.URL+"/api/hooks/slash/"+guestChannelID, http.StatusForbidden)
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("timed-out guest invocation reached callback %d times", got)
+	}
+	blocked := true
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: guest.ID, ClearTimeout: true, Blocked: &blocked}); err != nil {
+		t.Fatal(err)
+	}
+	expectSlashStatusAsUser(t, guest.ID, server.URL+"/api/hooks/slash/"+guestChannelID, http.StatusForbidden)
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("blocked guest invocation reached callback %d times", got)
+	}
+	blocked = false
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: guest.ID, ClearTimeout: true, Blocked: &blocked}); err != nil {
+		t.Fatal(err)
+	}
+
+	blocked = true
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: member.ID, Blocked: &blocked}); err != nil {
+		t.Fatal(err)
+	}
+	expectSlashStatusAsUser(t, member.ID, server.URL+"/api/hooks/slash/"+generalChannelID, http.StatusForbidden)
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("blocked member invocation reached callback %d times", got)
+	}
+
+	for i := 0; i < store.GuestPostLimit; i++ {
+		if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: guestChannelID, AuthorID: guest.ID, Body: "budget"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	expectSlashStatusAsUser(t, guest.ID, server.URL+"/api/hooks/slash/"+guestChannelID, http.StatusTooManyRequests)
+	if got := callbackCount.Load(); got != 1 {
+		t.Fatalf("rate-limited guest invocation reached callback %d times", got)
+	}
+}
+
+func TestCallbackAddressPolicy(t *testing.T) {
+	t.Parallel()
+	tests := map[string]bool{
+		"8.8.8.8":              true,
+		"2606:4700:4700::1111": true,
+		"127.0.0.1":            false,
+		"10.0.0.1":             false,
+		"169.254.169.254":      false,
+		"100.64.0.1":           false,
+		"198.18.0.1":           false,
+		"192.0.2.1":            false,
+		"::1":                  false,
+		"fc00::1":              false,
+		"fe80::1":              false,
+		"fe80::1%eth0":         false,
+		"fec0::1":              false,
+		"fec0::1%eth0":         false,
+		"::192.168.1.1":        false,
+		"::ffff:127.0.0.1":     false,
+		"64:ff9b::c0a8:101":    false,
+		"64:ff9b:1::c0a8:101":  false,
+		"2001::7f00:1":         false,
+		"2001:db8::1":          false,
+		"2002:7f00:1::":        false,
+		"3ffe::1":              false,
+		"3fff::1":              false,
+	}
+	for raw, want := range tests {
+		address := netip.MustParseAddr(raw)
+		if got := isPublicCallbackAddr(address); got != want {
+			t.Errorf("isPublicCallbackAddr(%s) = %v, want %v", address, got, want)
+		}
+	}
+}
+
+func TestCallbackDialerRejectsMixedDNSAnswersBeforeDial(t *testing.T) {
+	t.Parallel()
+	var dialed atomic.Bool
+	dialer := &callbackDialer{
+		lookupNetIP: func(context.Context, string, string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("8.8.8.8"), netip.MustParseAddr("127.0.0.1")}, nil
+		},
+		dialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed.Store(true)
+			return nil, errors.New("unexpected dial")
+		},
+	}
+	if _, err := dialer.DialContext(context.Background(), "tcp", "callback.example:443"); err == nil {
+		t.Fatal("expected mixed public/private DNS answer to be rejected")
+	}
+	if dialed.Load() {
+		t.Fatal("callback dialer connected before validating every DNS answer")
+	}
+}
+
+func TestCallbackDialerPinsValidatedAddress(t *testing.T) {
+	t.Parallel()
+	const wantAddress = "8.8.8.8:443"
+	var gotAddress string
+	dialer := &callbackDialer{
+		lookupNetIP: func(context.Context, string, string) ([]netip.Addr, error) {
+			return []netip.Addr{netip.MustParseAddr("8.8.8.8")}, nil
+		},
+		dialContext: func(_ context.Context, _ string, address string) (net.Conn, error) {
+			gotAddress = address
+			return nil, errors.New("sentinel")
+		},
+	}
+	if _, err := dialer.DialContext(context.Background(), "tcp", "callback.example:443"); err == nil {
+		t.Fatal("expected sentinel dial error")
+	}
+	if gotAddress != wantAddress {
+		t.Fatalf("dialed %q, want pinned address %q", gotAddress, wantAddress)
+	}
+}
+
+func TestCallbackClientDisablesRedirectsAndEnvironmentProxy(t *testing.T) {
+	t.Parallel()
+	client := newCallbackHTTPClient()
+	if client.CheckRedirect == nil {
+		t.Fatal("callback client permits default redirects")
+	}
+	if err := client.CheckRedirect(&http.Request{}, nil); !errors.Is(err, http.ErrUseLastResponse) {
+		t.Fatalf("unexpected redirect policy: %v", err)
+	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("unexpected transport type %T", client.Transport)
+	}
+	if transport.Proxy != nil {
+		t.Fatal("callback client inherits environment proxy configuration")
+	}
+}
+
+func TestCallbackDeliveryBlocksLoopbackForBothCallbackTypes(t *testing.T) {
+	t.Parallel()
+	var requests atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		requests.Add(1)
+	}))
+	t.Cleanup(target.Close)
+
+	server := &Server{callbackClient: newCallbackHTTPClient()}
+	if _, _, err := server.postSlashCallback(context.Background(), store.SlashCommand{
+		CallbackURL:   target.URL,
+		SigningSecret: "slash-secret",
+	}, []byte(`{"command":"/probe"}`)); err == nil {
+		t.Fatal("slash callback reached a loopback target")
+	}
+	if _, _, err := server.postEventCallback(context.Background(), store.EventSubscription{
+		CallbackURL:   target.URL,
+		SigningSecret: "event-secret",
+	}, store.Event{ID: "evt_probe"}, []byte(`{"event":"probe"}`)); err == nil {
+		t.Fatal("event callback reached a loopback target")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("loopback callback server received %d requests", got)
+	}
+}
+
+func expectSlashStatusAsUser(t *testing.T, userID, endpoint string, status int) {
+	t.Helper()
+	body := url.Values{"command": {"/deploy"}, "text": {"prod"}}.Encode()
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-ClickClack-User", userID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != status {
+		payload, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST %s as %s: expected %d, got %s %s", endpoint, userID, status, resp.Status, string(payload))
+	}
+}

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -44,6 +44,7 @@ type Server struct {
 	build                 buildMetadata
 	setupCodeClaimLimiter *slidingWindowLimiter
 	realtimeReplayLimit   int
+	callbackClient        *http.Client
 }
 
 const (
@@ -90,6 +91,7 @@ type Options struct {
 	Environment         string
 	Version             string
 	Commit              string
+	callbackClient      *http.Client
 }
 
 func New(st store.Store, hub *realtime.Hub, options Options) *Server {
@@ -104,6 +106,10 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 	cookieNames := options.CookieNames
 	if cookieNames.Session == "" {
 		cookieNames = authpolicy.DefaultCookieNames()
+	}
+	callbackClient := options.callbackClient
+	if callbackClient == nil {
+		callbackClient = newCallbackHTTPClient()
 	}
 	return &Server{
 		store:                 st,
@@ -122,6 +128,7 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 		metrics:               metrics,
 		setupCodeClaimLimiter: newSlidingWindowLimiter(setupCodeClaimLimit, setupCodeClaimWindow),
 		realtimeReplayLimit:   realtimeReplayMaxEvents,
+		callbackClient:        callbackClient,
 		build: buildMetadata{
 			Environment: options.Environment,
 			Version:     options.Version,

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -51,7 +51,10 @@ func TestChatAPIVerticalSlice(t *testing.T) {
 	}
 
 	hub := realtime.NewHub()
-	server := httptest.NewServer(New(st, hub, Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	server := httptest.NewServer(New(st, hub, Options{
+		UploadDir:      filepath.Join(dataDir, "uploads"),
+		callbackClient: &http.Client{Timeout: callbackTimeout},
+	}).Handler())
 	t.Cleanup(server.Close)
 
 	expectStatus(t, http.MethodHead, server.URL+"/", nil, http.StatusOK)
@@ -1313,7 +1316,10 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 		t.Fatal(err)
 	}
 	channel := channels[0]
-	server := httptest.NewServer(New(st, realtime.NewHub(), Options{UploadDir: filepath.Join(dataDir, "uploads")}).Handler())
+	server := httptest.NewServer(New(st, realtime.NewHub(), Options{
+		UploadDir:      filepath.Join(dataDir, "uploads"),
+		callbackClient: &http.Client{Timeout: callbackTimeout},
+	}).Handler())
 	t.Cleanup(server.Close)
 
 	index := getBody(t, server.URL+"/")

--- a/apps/api/internal/store/postgres/topic_authorization_test.go
+++ b/apps/api/internal/store/postgres/topic_authorization_test.go
@@ -1,0 +1,144 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestTopicAuthorizationFollowsGuestChannelVisibility(t *testing.T) {
+	dsn := os.Getenv("CLICKCLACK_POSTGRES_TEST_DSN")
+	if dsn == "" {
+		t.Skip("set CLICKCLACK_POSTGRES_TEST_DSN to run Postgres integration smoke")
+	}
+	ctx := context.Background()
+	st, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	suffix := time.Now().UTC().Format("20060102150405.000000000")
+	moderator, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Topic Moderator", Email: "topic-mod-" + suffix + "@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultGuestWorkspaceMember(ctx, moderator.ID, store.WorkspaceRoleModerator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guest, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Topic Guest", Email: "topic-guest-" + suffix + "@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, guest.ID, store.WorkspaceRoleGuest); err != nil {
+		t.Fatal(err)
+	}
+
+	channels, err := st.ListChannels(ctx, workspace.ID, moderator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var guestChannelID, generalChannelID string
+	for _, channel := range channels {
+		switch channel.Name {
+		case "guest":
+			guestChannelID = channel.ID
+		case "general":
+			generalChannelID = channel.ID
+		}
+	}
+	if guestChannelID == "" || generalChannelID == "" {
+		t.Fatalf("expected guest and general channels, got %#v", channels)
+	}
+
+	global, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, Name: "global-" + suffix, CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	visible, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "visible-" + suffix, CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hidden, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: generalChannelID, Name: "hidden-" + suffix, CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topics, err := st.ListTopics(ctx, workspace.ID, guest.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, topic := range topics {
+		got[topic.ID] = true
+	}
+	if !got[global.ID] || !got[visible.ID] {
+		t.Fatalf("guest lost visible topics: %#v", topics)
+	}
+	if got[hidden.ID] {
+		t.Fatalf("guest enumerated hidden channel topic: %#v", hidden)
+	}
+
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: generalChannelID, Name: "intrusion-" + suffix, CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("guest created hidden channel topic, got %v", err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, Name: "global-intrusion-" + suffix, CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("guest created a workspace-global topic, got %v", err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "guest-visible-" + suffix, CreatedBy: guest.ID}); err != nil {
+		t.Fatalf("guest should retain topic creation in the visible guest channel: %v", err)
+	}
+
+	timeoutUntil := time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano)
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		TimeoutUntil: &timeoutUntil,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "timed-out-" + suffix, CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("timed-out guest created a topic, got %v", err)
+	}
+
+	blocked := true
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		ClearTimeout: true,
+		Blocked:      &blocked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "blocked-" + suffix, CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("blocked guest created a topic, got %v", err)
+	}
+
+	blocked = false
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		Blocked:      &blocked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < store.GuestPostLimit; i++ {
+		if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: guestChannelID, AuthorID: guest.ID, Body: "budget"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "rate-limited-" + suffix, CreatedBy: guest.ID}); !errors.Is(err, store.ErrPostRateLimited) {
+		t.Fatalf("rate-limited guest created a topic, got %v", err)
+	}
+}

--- a/apps/api/internal/store/postgres/topics.go
+++ b/apps/api/internal/store/postgres/topics.go
@@ -14,6 +14,14 @@ func (s *Store) ListTopics(ctx context.Context, workspaceID, requesterID string)
 	if err := s.requireMembership(ctx, workspaceID, requesterID); err != nil {
 		return nil, err
 	}
+	channels, err := s.ListChannels(ctx, workspaceID, requesterID)
+	if err != nil {
+		return nil, err
+	}
+	visibleChannels := make(map[string]struct{}, len(channels))
+	for _, channel := range channels {
+		visibleChannels[channel.ID] = struct{}{}
+	}
 	rows, err := s.db.QueryContext(ctx, topicSelect()+`
 		WHERE workspace_id = $1 AND archived_at IS NULL
 		ORDER BY name`, workspaceID)
@@ -21,7 +29,21 @@ func (s *Store) ListTopics(ctx context.Context, workspaceID, requesterID string)
 		return nil, err
 	}
 	defer rows.Close()
-	return scanTopics(rows)
+	topics, err := scanTopics(rows)
+	if err != nil {
+		return nil, err
+	}
+	visible := topics[:0]
+	for _, topic := range topics {
+		if topic.ChannelID == "" {
+			visible = append(visible, topic)
+			continue
+		}
+		if _, ok := visibleChannels[topic.ChannelID]; ok {
+			visible = append(visible, topic)
+		}
+	}
+	return visible, nil
 }
 
 func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (store.Topic, error) {
@@ -42,6 +64,9 @@ func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (
 	if err := requireMembershipTx(ctx, tx, workspaceID, createdBy); err != nil {
 		return store.Topic{}, err
 	}
+	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, createdBy); err != nil {
+		return store.Topic{}, err
+	}
 	channelID := strings.TrimSpace(input.ChannelID)
 	if channelID != "" {
 		var channelWorkspace string
@@ -51,6 +76,11 @@ func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (
 		if channelWorkspace != workspaceID {
 			return store.Topic{}, errors.New("topic channel is not in workspace")
 		}
+		if err := requireCanPostTx(ctx, tx, workspaceID, channelID, createdBy); err != nil {
+			return store.Topic{}, err
+		}
+	} else if err := requireNonGuestTx(ctx, tx, workspaceID, createdBy); err != nil {
+		return store.Topic{}, err
 	}
 	topic := store.Topic{
 		ID:          newID("top"),

--- a/apps/api/internal/store/sqlite/topic_authorization_test.go
+++ b/apps/api/internal/store/sqlite/topic_authorization_test.go
@@ -1,0 +1,132 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestTopicAuthorizationFollowsGuestChannelVisibility(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	moderator, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Moderator", Email: "topic-mod@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultGuestWorkspaceMember(ctx, moderator.ID, store.WorkspaceRoleModerator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guest, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Guest", Email: "topic-guest@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, guest.ID, store.WorkspaceRoleGuest); err != nil {
+		t.Fatal(err)
+	}
+
+	channels, err := st.ListChannels(ctx, workspace.ID, moderator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var guestChannelID, generalChannelID string
+	for _, channel := range channels {
+		switch channel.Name {
+		case "guest":
+			guestChannelID = channel.ID
+		case "general":
+			generalChannelID = channel.ID
+		}
+	}
+	if guestChannelID == "" || generalChannelID == "" {
+		t.Fatalf("expected guest and general channels, got %#v", channels)
+	}
+
+	global, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, Name: "global", CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	visible, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "visible", CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	hidden, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: generalChannelID, Name: "hidden", CreatedBy: moderator.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	topics, err := st.ListTopics(ctx, workspace.ID, guest.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, topic := range topics {
+		got[topic.ID] = true
+	}
+	if !got[global.ID] || !got[visible.ID] {
+		t.Fatalf("guest lost visible topics: %#v", topics)
+	}
+	if got[hidden.ID] {
+		t.Fatalf("guest enumerated hidden channel topic: %#v", hidden)
+	}
+
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: generalChannelID, Name: "intrusion", CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("guest created hidden channel topic, got %v", err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, Name: "global-intrusion", CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("guest created a workspace-global topic, got %v", err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "guest-visible", CreatedBy: guest.ID}); err != nil {
+		t.Fatalf("guest should retain topic creation in the visible guest channel: %v", err)
+	}
+
+	timeoutUntil := time.Now().Add(time.Hour).UTC().Format(time.RFC3339Nano)
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		TimeoutUntil: &timeoutUntil,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "timed-out", CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("timed-out guest created a topic, got %v", err)
+	}
+
+	blocked := true
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		ClearTimeout: true,
+		Blocked:      &blocked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "blocked", CreatedBy: guest.ID}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("blocked guest created a topic, got %v", err)
+	}
+
+	blocked = false
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{
+		WorkspaceID:  workspace.ID,
+		ActorUserID:  moderator.ID,
+		TargetUserID: guest.ID,
+		Blocked:      &blocked,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < store.GuestPostLimit; i++ {
+		if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: guestChannelID, AuthorID: guest.ID, Body: "budget"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := st.CreateTopic(ctx, store.CreateTopicInput{WorkspaceID: workspace.ID, ChannelID: guestChannelID, Name: "rate-limited", CreatedBy: guest.ID}); !errors.Is(err, store.ErrPostRateLimited) {
+		t.Fatalf("rate-limited guest created a topic, got %v", err)
+	}
+}

--- a/apps/api/internal/store/sqlite/topics.go
+++ b/apps/api/internal/store/sqlite/topics.go
@@ -14,6 +14,14 @@ func (s *Store) ListTopics(ctx context.Context, workspaceID, requesterID string)
 	if err := s.requireMembership(ctx, workspaceID, requesterID); err != nil {
 		return nil, err
 	}
+	channels, err := s.ListChannels(ctx, workspaceID, requesterID)
+	if err != nil {
+		return nil, err
+	}
+	visibleChannels := make(map[string]struct{}, len(channels))
+	for _, channel := range channels {
+		visibleChannels[channel.ID] = struct{}{}
+	}
 	rows, err := s.db.QueryContext(ctx, topicSelect()+`
 		WHERE workspace_id = ? AND archived_at IS NULL
 		ORDER BY name`, workspaceID)
@@ -21,7 +29,21 @@ func (s *Store) ListTopics(ctx context.Context, workspaceID, requesterID string)
 		return nil, err
 	}
 	defer rows.Close()
-	return scanTopics(rows)
+	topics, err := scanTopics(rows)
+	if err != nil {
+		return nil, err
+	}
+	visible := topics[:0]
+	for _, topic := range topics {
+		if topic.ChannelID == "" {
+			visible = append(visible, topic)
+			continue
+		}
+		if _, ok := visibleChannels[topic.ChannelID]; ok {
+			visible = append(visible, topic)
+		}
+	}
+	return visible, nil
 }
 
 func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (store.Topic, error) {
@@ -42,6 +64,9 @@ func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (
 	if err := requireMembershipTx(ctx, tx, workspaceID, createdBy); err != nil {
 		return store.Topic{}, err
 	}
+	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, createdBy); err != nil {
+		return store.Topic{}, err
+	}
 	channelID := strings.TrimSpace(input.ChannelID)
 	if channelID != "" {
 		var channelWorkspace string
@@ -51,6 +76,11 @@ func (s *Store) CreateTopic(ctx context.Context, input store.CreateTopicInput) (
 		if channelWorkspace != workspaceID {
 			return store.Topic{}, errors.New("topic channel is not in workspace")
 		}
+		if err := requireCanPostTx(ctx, tx, workspaceID, channelID, createdBy); err != nil {
+			return store.Topic{}, err
+		}
+	} else if err := requireNonGuestTx(ctx, tx, workspaceID, createdBy); err != nil {
+		return store.Topic{}, err
 	}
 	topic := store.Topic{
 		ID:          newID("top"),

--- a/docs/features/integrations.md
+++ b/docs/features/integrations.md
@@ -123,6 +123,11 @@ Behavior:
   `callback_url` with `X-ClickClack-Timestamp` and
   `X-ClickClack-Signature: sha256=<hex hmac>`, where the signed string is
   `<timestamp>.<raw-json-body>`.
+- Invocation requires the caller's current write authority for the exact
+  channel, including guest-channel, timeout, block, and guest-budget checks.
+- Callback delivery connects directly to public IP addresses only. It rejects
+  private, loopback, link-local, reserved, or mixed public/private DNS answers,
+  does not use environment-configured proxies, and does not follow redirects.
 - If the callback returns `{"response_type":"in_channel","text":"..."}`, the
   server posts that text as the command's bot user. `response_type` defaults to
   `in_channel`.
@@ -188,6 +193,8 @@ Behavior:
   callback URL.
 - Delivery uses the same signature headers as slash commands, plus
   `X-ClickClack-Event-ID`.
+- Delivery uses the same public-address, no-proxy, no-redirect policy as slash
+  command callbacks.
 - Every delivery attempt is stored with response status, response body, error,
   and attempt number.
 - `GET /api/event-subscriptions/{subscription_id}/deliveries` accepts `limit`

--- a/docs/features/moderation.md
+++ b/docs/features/moderation.md
@@ -55,6 +55,11 @@ Guests are deliberately narrow:
 - Guests cannot create channels, rename channels, create DMs, send DMs,
   upload files, attach files, search hidden rooms, resolve hidden routes, or
   receive hidden realtime events.
+- Guests see topics only from `#guest` plus workspace-global topics. They may
+  create topics only in `#guest` while they still have post budget; they cannot
+  create hidden-channel or workspace-global topics.
+- Registered slash commands enforce the same channel, timeout, block, and
+  guest-budget checks as ordinary channel writes before contacting an app.
 - Posts made before a demotion to `guest` are not counted against the guest
   budget. Guest posts that are later deleted still count.
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: `rm -rf data/e2e && pnpm build && go run ./apps/api/cmd/clickclack serve --addr 127.0.0.1:${e2ePort} --data ./data/e2e --dev-bootstrap=true --embed-frame-ancestors ${embedHostOrigin}`,
+      command: `rm -rf data/e2e && pnpm build && go run -tags clickclack_e2e_unsafe_callbacks ./apps/api/cmd/clickclack serve --addr 127.0.0.1:${e2ePort} --data ./data/e2e --dev-bootstrap=true --embed-frame-ancestors ${embedHostOrigin}`,
       url: `http://127.0.0.1:${e2ePort}`,
       reuseExistingServer: process.env.CLICKCLACK_REUSE_E2E_SERVER === "1",
       // A cold production SPA build can exceed two minutes before the Go server starts.

--- a/tests/e2e/topic-web.spec.ts
+++ b/tests/e2e/topic-web.spec.ts
@@ -447,14 +447,11 @@ test("switching topic filters discards delayed pagination from the previous filt
   const releaseDelayed = new Promise<void>((resolve) => {
     releaseDelayedPage = resolve;
   });
-  let releaseRequestSeen: (() => void) | undefined;
-  const releaseRequested = new Promise<void>((resolve) => {
-    releaseRequestSeen = resolve;
-  });
+  let releaseRequestSeen = false;
   await page.route(`**/api/channels/${channel.id}/messages?*`, async (route) => {
     const url = new URL(route.request().url());
     if (url.searchParams.has("before_seq") && url.searchParams.get("topic_id") === release.id) {
-      releaseRequestSeen?.();
+      releaseRequestSeen = true;
       await releaseDelayed;
     }
     await route.continue();
@@ -469,16 +466,17 @@ test("switching topic filters discards delayed pagination from the previous filt
   await expect
     .poll(() => scrollport.evaluate((element) => element.scrollHeight - element.clientHeight))
     .toBeGreaterThan(0);
-  await scrollport.evaluate((element) => {
-    element.scrollTop = element.scrollHeight;
-    element.dispatchEvent(new Event("scroll", { bubbles: true }));
-  });
-  await expect.poll(() => scrollport.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
-  await scrollport.evaluate((element) => {
-    element.scrollTop = 0;
-    element.dispatchEvent(new Event("scroll", { bubbles: true }));
-  });
-  await releaseRequested;
+  await expect
+    .poll(async () => {
+      await scrollport.focus();
+      await page.keyboard.press("Home");
+      await scrollport.evaluate(
+        () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+      );
+      await scrollport.dispatchEvent("scroll");
+      return releaseRequestSeen;
+    })
+    .toBe(true);
 
   await page.getByRole("button", { name: "Clear filter" }).click();
   await expect(page.getByText("Showing topic")).toHaveCount(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where workspace managers could make integration callbacks reach
server-private networks, guests could enumerate or create topics outside their
visible channel boundary, and restricted members could execute registered
slash commands before ClickClack enforced their exact write authority.

Thanks @jason-allen-oneal for the responsible report and reproduction cases.

## Why This Change Was Made

Callback delivery now uses one proxy-free, no-redirect HTTP client for slash
commands and event subscriptions. It resolves destinations at delivery time,
rejects the complete answer set if any address is non-public or special-use,
and dials only a validated numeric address to close DNS-rebinding gaps.

Registered command dispatch now checks the caller's channel visibility,
timeout/block state, and guest budget before recording or delivering an
invocation. Topic listing follows visible channels, while topic creation
enforces moderation and write eligibility in both SQLite and PostgreSQL.

The intentional compatibility change is that callbacks relying on private or
loopback destinations, environment proxies, or HTTP redirects are now rejected.

## Maintainer Decision

The strict callback policy is accepted: production callbacks may reach public
addresses only, without environment proxies or redirect following. Existing
private, loopback, proxy-dependent, or redirect-dependent callback
registrations are intentionally failed closed rather than migrated through a
weaker compatibility path.

## User Impact

Public HTTP and HTTPS integrations retain signed callback delivery. Restricted
guests and moderated members can no longer cross channel or write boundaries
through topics or registered commands, and callback registrations cannot be
used to reach services from the ClickClack host's network position.

## Evidence

Sanitized production-transport proof:

```text
LIVE_PUBLIC_POST status=200 proxy_hits=0
LIVE_REDIRECT status=302 location_present=true
LIVE_LOOPBACK rejected=true callback_hits=0
```

Sanitized reporter-probe proof:

```text
VULNERABLE: both callback sinks reached loopback and returned response bodies
FIXED: both callback sinks rejected loopback before connecting
[FIXED] hidden topic filtered and hidden/global creation denied
[+] direct fourth guest message rejected with 429
[FIXED] registered requests now match moderation denials: 403/403/403/429
[FIXED] callback reached 0 times
```

- The attachment SHA-256 matched the reporter's supplied digest before the
  local probes were run.
- SQLite and live PostgreSQL 17 topic authorization tests passed.
- Full Playwright E2E passed: 146/146, including normal registered callback
  flows under an explicit E2E-only loopback build tag.
- `go test ./...`
- `go vet ./...`
- `pnpm check`
- `pnpm coverage` — 85.3% total statement coverage
- Source-blind behavior validation: all callback, topic, slash moderation, and
  compatibility clauses passed with no blockers.
- Codex autoreview of the complete branch: clean, no accepted/actionable
  findings; overall correctness `patch is correct` (0.98 confidence).
