### PR TITLE
fix(security): block Azure platform callback target

### DIFF
--- a/apps/api/internal/httpapi/callback_http.go
+++ b/apps/api/internal/httpapi/callback_http.go
@@ -17,6 +17,9 @@ const callbackTimeout = 3 * time.Second
 var blockedCallbackPrefixes = []netip.Prefix{
 	netip.MustParsePrefix("0.0.0.0/8"),
 	netip.MustParsePrefix("100.64.0.0/10"),
+	// Azure reserves this public-looking virtual IP for platform services
+	// inside every virtual network, including health and DHCP endpoints.
+	netip.MustParsePrefix("168.63.129.16/32"),
 	netip.MustParsePrefix("192.0.0.0/24"),
 	netip.MustParsePrefix("192.0.2.0/24"),
 	netip.MustParsePrefix("192.31.196.0/24"),

--- a/apps/api/internal/httpapi/integration_security_test.go
+++ b/apps/api/internal/httpapi/integration_security_test.go
@@ -157,6 +157,7 @@ func TestCallbackAddressPolicy(t *testing.T) {
 		"127.0.0.1":            false,
 		"10.0.0.1":             false,
 		"169.254.169.254":      false,
+		"168.63.129.16":        false,
 		"100.64.0.1":           false,
 		"198.18.0.1":           false,
 		"192.0.2.1":            false,
@@ -181,6 +182,27 @@ func TestCallbackAddressPolicy(t *testing.T) {
 		if got := isPublicCallbackAddr(address); got != want {
 			t.Errorf("isPublicCallbackAddr(%s) = %v, want %v", address, got, want)
 		}
+	}
+}
+
+func TestCallbackDialerRejectsAzurePlatformVIPBeforeDial(t *testing.T) {
+	t.Parallel()
+	var dialed atomic.Bool
+	dialer := &callbackDialer{
+		lookupNetIP: func(context.Context, string, string) ([]netip.Addr, error) {
+			t.Fatal("literal callback address unexpectedly triggered DNS resolution")
+			return nil, nil
+		},
+		dialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed.Store(true)
+			return nil, errors.New("unexpected dial")
+		},
+	}
+	if _, err := dialer.DialContext(context.Background(), "tcp", "168.63.129.16:80"); err == nil {
+		t.Fatal("expected Azure platform virtual IP to be rejected")
+	}
+	if dialed.Load() {
+		t.Fatal("callback dialer connected to the Azure platform virtual IP")
 	}
 }
 
@@ -266,6 +288,37 @@ func TestCallbackDeliveryBlocksLoopbackForBothCallbackTypes(t *testing.T) {
 	}
 	if got := requests.Load(); got != 0 {
 		t.Fatalf("loopback callback server received %d requests", got)
+	}
+}
+
+func TestCallbackDeliveryBlocksAzurePlatformVIPForBothCallbackTypes(t *testing.T) {
+	t.Parallel()
+	var dialed atomic.Bool
+	policyDialer := &callbackDialer{
+		lookupNetIP: net.DefaultResolver.LookupNetIP,
+		dialContext: func(context.Context, string, string) (net.Conn, error) {
+			dialed.Store(true)
+			return nil, errors.New("unexpected dial")
+		},
+	}
+	server := &Server{callbackClient: &http.Client{
+		Transport: &http.Transport{DialContext: policyDialer.DialContext},
+		Timeout:   callbackTimeout,
+	}}
+	if _, _, err := server.postSlashCallback(context.Background(), store.SlashCommand{
+		CallbackURL:   "http://168.63.129.16/slash",
+		SigningSecret: "slash-secret",
+	}, []byte(`{"command":"/probe"}`)); err == nil {
+		t.Fatal("slash callback accepted the Azure platform virtual IP")
+	}
+	if _, _, err := server.postEventCallback(context.Background(), store.EventSubscription{
+		CallbackURL:   "http://168.63.129.16/event",
+		SigningSecret: "event-secret",
+	}, store.Event{ID: "evt_probe"}, []byte(`{"event":"probe"}`)); err == nil {
+		t.Fatal("event callback accepted the Azure platform virtual IP")
+	}
+	if dialed.Load() {
+		t.Fatal("callback delivery connected to the Azure platform virtual IP")
 	}
 }
 


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #145. The callback address classifier still treated
`168.63.129.16` as a public destination. Azure reserves that public-looking
virtual IP for platform services inside every virtual network, so callbacks
must not be allowed to reach it from the ClickClack host.

## What Changed

- Block `168.63.129.16/32` in the shared callback egress policy.
- Cover literal classification and rejection before any socket dial.
- Verify both registered slash-command and event-subscription delivery paths
  fail closed for the platform VIP.

## Verification

- `go test ./... -count=1`
- `go vet ./...`
- `pnpm fmt:go:check`
- Focused classifier, pre-dial, slash-delivery, and event-delivery regressions

## Real behavior proof

**Behavior addressed:** A registered slash-command or event-subscription
callback must reject Azure's `168.63.129.16` platform VIP before opening an
outbound connection.

**Real environment tested:** PR HEAD
`b3f58ec245128b7056d55e0d3b8c2fe5052612b3`, built with Go 1.26.5 and run as
the real ClickClack API with SQLite and development bootstrap enabled. The API
ran at `168.63.129.17` and a Python HTTP sentinel ran at `168.63.129.16` on an
isolated Docker bridge.

**Exact steps run after this patch:**

```bash
git rev-parse HEAD
proof_dir=$(mktemp -d)
mkdir -p "$proof_dir/data"
docker run --rm -v "$PWD:/src:ro" -v "$proof_dir:/out" -w /src \
  golang:1.26.5 go build -buildvcs=false -trimpath \
  -o /out/clickclack ./apps/api/cmd/clickclack

docker network create --driver bridge --internal \
  --subnet 168.63.129.0/24 --gateway 168.63.129.1 cc-pr147-proof
docker run -d --name cc-pr147-sentinel --network cc-pr147-proof \
  --ip 168.63.129.16 golang:1.26.5 python3 -u -c $'import http.server\nclass Handler(http.server.BaseHTTPRequestHandler):\n    def do_GET(self):\n        self.send_response(200); self.end_headers()\n    def do_POST(self):\n        self.send_response(204); self.end_headers()\nclass Server(http.server.ThreadingHTTPServer):\n    def get_request(self):\n        sock, addr = super().get_request()\n        print(f"TCP_ACCEPT {addr[0]}:{addr[1]}", flush=True)\n        return sock, addr\nServer(("0.0.0.0", 80), Handler).serve_forever()'
docker run -d --name cc-pr147-api --network cc-pr147-proof \
  --ip 168.63.129.17 -v "$proof_dir/clickclack:/usr/local/bin/clickclack:ro" \
  -v "$proof_dir/data:/data" golang:1.26.5 \
  /usr/local/bin/clickclack serve --addr 0.0.0.0:8080 \
  --data /data --dev-bootstrap=true
docker inspect -f '{{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
  cc-pr147-api cc-pr147-sentinel

api=http://127.0.0.1:8080
wsp=$(docker exec cc-pr147-api curl -fsS "$api/api/workspaces" | jq -r '.workspaces[0].id')
chn=$(docker exec cc-pr147-api curl -fsS "$api/api/workspaces/$wsp/channels" | jq -r '.channels[0].id')
bot_json=$(docker exec cc-pr147-api curl -fsS -X POST "$api/api/workspaces/$wsp/bots" \
  -H 'Content-Type: application/json' \
  --data '{"display_name":"PR 147 Proof Bot","handle":"pr-147-proof","token_name":"proof","scopes":["bot:read"]}')
bot=$(jq -r '.bot.id' <<<"$bot_json")
install_json=$(docker exec cc-pr147-api curl -fsS -X POST \
  "$api/api/workspaces/$wsp/app-installations" -H 'Content-Type: application/json' \
  --data "{\"app_slug\":\"pr-147-proof\",\"display_name\":\"PR 147 Proof\",\"bot_user_id\":\"$bot\",\"config\":{\"default_channel_id\":\"$chn\"}}")
install=$(jq -r '.app_installation.id' <<<"$install_json")
slash_json=$(docker exec cc-pr147-api curl -fsS -X POST \
  "$api/api/workspaces/$wsp/slash-commands" -H 'Content-Type: application/json' \
  --data "{\"app_installation_id\":\"$install\",\"command\":\"/vip-proof\",\"description\":\"PR 147 runtime proof\",\"callback_url\":\"http://168.63.129.16/slash\",\"bot_user_id\":\"$bot\"}")
sub_json=$(docker exec cc-pr147-api curl -fsS -X POST \
  "$api/api/workspaces/$wsp/event-subscriptions" -H 'Content-Type: application/json' \
  --data "{\"app_installation_id\":\"$install\",\"event_types\":[\"message.created\"],\"callback_url\":\"http://168.63.129.16/events\"}")
sub=$(jq -r '.event_subscription.id' <<<"$sub_json")

# Positive reachability control from the actual API container.
docker exec cc-pr147-api curl -sS -o /dev/null -w '%{http_code}\n' \
  http://168.63.129.16/

# Exercise both registered callback workflows through the real API.
docker exec cc-pr147-api curl -sS -X POST "$api/api/hooks/slash/$chn" \
  -H 'Content-Type: application/x-www-form-urlencoded' \
  --data-urlencode 'command=/vip-proof' --data-urlencode 'text=runtime-boundary-check'
docker exec cc-pr147-api curl -fsS -X POST "$api/api/channels/$chn/messages" \
  -H 'Content-Type: application/json' \
  --data '{"body":"PR 147 event callback runtime boundary check"}'
docker exec cc-pr147-api curl -fsS \
  "$api/api/event-subscriptions/$sub/deliveries" | jq '.deliveries[0] | {response_status,error}'
docker logs cc-pr147-sentinel

docker run --rm -v "$PWD:/src:ro" -w /src golang:1.26.5 \
  go test -buildvcs=false ./apps/api/internal/httpapi \
  -run 'TestCallback(AddressPolicy|DialerRejectsAzurePlatformVIPBeforeDial|DeliveryBlocksAzurePlatformVIPForBothCallbackTypes)$' \
  -count=1 -v
```

The registration and invocation requests used ClickClack's real HTTP API. All
one-time signing secrets and bot credentials were excluded from the captured
output.

**Evidence after fix:**

```text
HEAD
b3f58ec245128b7056d55e0d3b8c2fe5052612b3

NETWORK CONTROL
ClickClack API: 168.63.129.17
HTTP sentinel:  168.63.129.16
control_http=200 remote=168.63.129.16 connect=0.000259s total=0.001575s

SLASH CALLBACK
status=502
error=Post "http://168.63.129.16/slash": callback host resolves to a non-public address

EVENT TRIGGER
event_type=message.created

EVENT DELIVERY RECORD
response_status=0
error=Post "http://168.63.129.16/events": callback host resolves to a non-public address

ACCEPT-LEVEL SENTIN LOG AFTER BOTH CALLBACKS
"GET / HTTP/1.1" 200
TCP_ACCEPT 168.63.129.17:43316
# Exactly one TCP connection: the explicit control. Neither callback connected.

FOCUSED REGRESSIONS
--- PASS: TestCallbackAddressPolicy (0.00s)
--- PASS: TestCallbackDialerRejectsAzurePlatformVIPBeforeDial (0.00s)
--- PASS: TestCallbackDeliveryBlocksAzurePlatformVIPForBothCallbackTypes (0.00s)
PASS
```

**Observed result after fix:** The control request proves that
`168.63.129.16:80` was reachable from the real ClickClack runtime. The slash
workflow returned the pre-dial policy error, the event workflow persisted the
same policy error with no HTTP response status, and the accept-level sentinel
recorded exactly the explicit control connection with no connection from
either callback. The focused pre-dial regression also passed with a dial
function that fails the test if called. Together, the real runtime and no-dial
evidence show both workflows reject the VIP before opening a callback
connection.

**What was not tested:** This disposable proof did not run inside an Azure VNet
or contact Azure platform services. It exercised the exact literal platform
VIP through both real callback workflows. Hostname resolution and TLS callback
behavior were not part of this `/32` policy change.
