### PR TITLE
fix: prevent blank embedded views and misleading API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.3.0 - Unreleased
 
+- Fixed blank embedded views caused by stale browser assets and returned proper JSON errors for unknown API routes while preserving app deep links.
 - Hardened integration callbacks against server-side requests to non-public networks and enforced guest visibility, moderation, and write limits for topics and registered slash commands. Thanks @jason-allen-oneal.
 - Updated web font packages and the Cloudflare Wrangler toolchain.
 - Added coherent conversation organization and attention tools: topic selection and filtered timelines, channel-wide pins with a visible 100-message ceiling, per-channel all/mentions/muted notification preferences, resolved mention highlighting whose current-user emphasis follows that preference, and workspace-visible responding-agent identity beside channel and thread composers. Thanks @PollyBot13 and @jjjhenriksen.

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -1182,6 +1182,74 @@ func TestHTTPServesEmbeddedAsset(t *testing.T) {
 	}
 }
 
+func TestHTTPNotFoundPreservesAPIAndAssetBoundaries(t *testing.T) {
+	t.Parallel()
+	handler := New(nil, nil, Options{}).Handler()
+
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		bearer      bool
+		wantStatus  int
+		wantType    string
+		wantAPIJSON bool
+	}{
+		{name: "api root", method: http.MethodGet, path: "/api", wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "api root slash", method: http.MethodGet, path: "/api/", wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "missing api get", method: http.MethodGet, path: "/api/does-not-exist", wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "missing api post", method: http.MethodPost, path: "/api/does-not-exist", wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "missing api patch", method: http.MethodPatch, path: "/api/does-not-exist", wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "missing api head", method: http.MethodHead, path: "/api/does-not-exist", wantStatus: http.StatusNotFound, wantType: "application/json"},
+		{name: "missing api with bearer", method: http.MethodGet, path: "/api/does-not-exist", bearer: true, wantStatus: http.StatusNotFound, wantType: "application/json", wantAPIJSON: true},
+		{name: "missing javascript chunk", method: http.MethodGet, path: "/_app/immutable/chunks/missing.js", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing javascript chunk head", method: http.MethodHead, path: "/_app/immutable/chunks/missing.js", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing stylesheet", method: http.MethodGet, path: "/_app/immutable/assets/missing.css", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing extensionless app asset", method: http.MethodGet, path: "/_app/immutable/missing", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing extensionless asset", method: http.MethodGet, path: "/assets/missing", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing javascript worker", method: http.MethodGet, path: "/service-worker.js", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing javascript module", method: http.MethodGet, path: "/workers/missing.mjs", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing source map", method: http.MethodGet, path: "/scripts/missing.js.map", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing font", method: http.MethodGet, path: "/fonts/missing.woff2", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing icon", method: http.MethodGet, path: "/icons/missing.svg", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing favicon", method: http.MethodGet, path: "/favicon.ico", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing image", method: http.MethodGet, path: "/images/missing.webp", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "missing web manifest", method: http.MethodGet, path: "/manifest.webmanifest", wantStatus: http.StatusNotFound, wantType: "text/plain"},
+		{name: "existing embedded favicon", method: http.MethodGet, path: "/favicon.svg", wantStatus: http.StatusOK, wantType: "image/svg+xml"},
+		{name: "api lookalike remains spa", method: http.MethodGet, path: "/apiary/deep-link", wantStatus: http.StatusOK, wantType: "text/html"},
+		{name: "app deep link remains spa", method: http.MethodGet, path: "/app/TEXAMPLE/CEXAMPLE", wantStatus: http.StatusOK, wantType: "text/html"},
+		{name: "embed deep link remains spa", method: http.MethodGet, path: "/embed/channel/TEXAMPLE/CEXAMPLE", wantStatus: http.StatusOK, wantType: "text/html"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Accept", "application/json")
+			if tc.bearer {
+				req.Header.Set("Authorization", "Bearer invalid")
+			}
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, req)
+			if response.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; content type = %q", response.Code, tc.wantStatus, response.Header().Get("Content-Type"))
+			}
+			if got := response.Header().Get("Content-Type"); !strings.HasPrefix(got, tc.wantType) {
+				t.Fatalf("content type = %q, want prefix %q", got, tc.wantType)
+			}
+			if tc.wantAPIJSON {
+				var body struct {
+					Error string `json:"error"`
+				}
+				if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil {
+					t.Fatalf("API response is not JSON: %v", err)
+				}
+				if body.Error != "route not found" {
+					t.Fatalf("API error = %q, want %q", body.Error, "route not found")
+				}
+			}
+		})
+	}
+}
+
 func TestListenAndServeStopsWithContext(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -1597,6 +1598,11 @@ func (a actor) requireWorkspace(workspaceID string) error {
 }
 
 func (s *Server) serveSPA(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api" || strings.HasPrefix(r.URL.Path, "/api/") {
+		writeError(w, http.StatusNotFound, errors.New("route not found"))
+		return
+	}
+
 	dist, err := fs.Sub(webassets.Dist, "dist")
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err)
@@ -1608,6 +1614,10 @@ func (s *Server) serveSPA(w http.ResponseWriter, r *http.Request) {
 			http.FileServer(http.FS(dist)).ServeHTTP(w, r)
 			return
 		}
+	}
+	if isMissingBrowserAssetPath(r.URL.Path) {
+		http.NotFound(w, r)
+		return
 	}
 	fallback := "index.html"
 	if r.URL.Path != "/" {
@@ -1631,6 +1641,20 @@ func (s *Server) serveSPA(w http.ResponseWriter, r *http.Request) {
 	}
 	index = s.injectRuntimeConfig(index)
 	_, _ = w.Write(index)
+}
+
+func isMissingBrowserAssetPath(urlPath string) bool {
+	if strings.HasPrefix(urlPath, "/_app/") || strings.HasPrefix(urlPath, "/assets/") {
+		return true
+	}
+	switch strings.ToLower(path.Ext(urlPath)) {
+	case ".avif", ".css", ".gif", ".ico", ".jpeg", ".jpg", ".js", ".json",
+		".map", ".mjs", ".otf", ".png", ".svg", ".ttf", ".wasm", ".webmanifest",
+		".webp", ".woff", ".woff2":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Server) injectRuntimeConfig(index []byte) []byte {

--- a/tests/e2e/artifact-viewer.spec.ts
+++ b/tests/e2e/artifact-viewer.spec.ts
@@ -13,6 +13,7 @@ import {
   PDF_CANVAS_PIXEL_LIMIT,
 } from "../../apps/web/src/lib/pdf";
 import type { Upload } from "../../apps/web/src/lib/types";
+import { waitForAppReady } from "./app-ready";
 
 type Fixture = { filename: string; contentType: string; body: Buffer };
 type ZipCompression = 0 | 8;
@@ -686,6 +687,7 @@ test("opens spreadsheets and slide decks with navigation", async ({ page }) => {
     },
   ]);
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   const viewer = page.getByRole("complementary", { name: "Artifact viewer" });
   const closeViewer = async () => {
@@ -888,6 +890,7 @@ test("opens safe code, Markdown, PDF, and HTML previews with DOCX download-only"
   const { channel } = await seedArtifacts(page, fixtures);
 
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
 
   await page.getByRole("button", { name: "Open viewer-proof.ts" }).click();
@@ -1017,10 +1020,12 @@ test("falls back to source before structured previews can exhaust the DOM", asyn
     },
   ]);
   await page.goto("/app");
+  await waitForAppReady(page);
   const channelHref = await page
     .getByRole("link", { name: `# ${channel.name}` })
     .getAttribute("href");
   await page.goto(channelHref!);
+  await waitForAppReady(page);
 
   await page.getByRole("button", { name: "Open complex.html" }).click();
   let viewer = page.getByRole("complementary", { name: "Artifact viewer" });
@@ -1052,10 +1057,12 @@ test("makes a viewer opened at the mobile breakpoint modal immediately", async (
     },
   ]);
   await page.goto("/app");
+  await waitForAppReady(page);
   const channelHref = await page
     .getByRole("link", { name: `# ${channel.name}` })
     .getAttribute("href");
   await page.goto(channelHref!);
+  await waitForAppReady(page);
   await page.getByRole("button", { name: "Open mobile.md" }).click();
 
   const viewer = page.getByRole("dialog", { name: "Artifact viewer" });
@@ -1111,6 +1118,7 @@ test("shows local fallbacks for oversized and malformed artifacts", async ({ pag
   ];
   const { channel } = await seedArtifacts(page, fixtures);
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   const viewer = page.getByRole("complementary", { name: "Artifact viewer" });
 
@@ -1193,6 +1201,7 @@ test("near-limit code remains interruptible and falls back to escaped source", a
     },
   ]);
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
 
   await page.getByRole("button", { name: "Open near-limit.ts" }).click();
@@ -1228,6 +1237,7 @@ test("enforces the actual streamed byte limit instead of trusting upload metadat
     });
   });
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   await page.getByRole("button", { name: "Open metadata-lie.txt" }).click();
 
@@ -1243,6 +1253,7 @@ test("adds an attachment from message.updated without reloading", async ({ page 
   });
   const { message } = (await messageResponse.json()) as { message: { id: string } };
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
   await expect(page.getByText("Realtime artifact delivery")).toBeVisible();
 
@@ -1274,6 +1285,7 @@ test("returns to the routed thread after closing an artifact", async ({ page }) 
     },
   ]);
   await page.goto("/app");
+  await waitForAppReady(page);
   await page.getByRole("link", { name: `# ${channel.name}` }).click();
 
   const message = page.locator(`[data-message-id="${messages["thread-proof.md"]}"]`);

--- a/tests/e2e/sidebar-channel-order.spec.ts
+++ b/tests/e2e/sidebar-channel-order.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import { randomUUID } from "node:crypto";
+import { waitForAppReady } from "./app-ready";
 
 type Workspace = { id: string; route_id: string };
 
@@ -34,6 +35,7 @@ test("channel ordering supports drag, keyboard, touch actions, and collapsed sec
 }) => {
   const { workspace, names } = await createWorkspaceWithChannels(page, "Channel order");
   await page.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(page);
 
   await expect.poll(() => visibleChannelNames(page)).toEqual(names);
 
@@ -43,6 +45,7 @@ test("channel ordering supports drag, keyboard, touch actions, and collapsed sec
   await expect.poll(() => visibleChannelNames(page)).toEqual([names[2], names[0], names[1]]);
 
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => visibleChannelNames(page)).toEqual([names[2], names[0], names[1]]);
 
   await page.getByRole("button", { name: `Move #${names[2]}` }).focus();
@@ -76,6 +79,7 @@ test("channel ordering supports drag, keyboard, touch actions, and collapsed sec
   });
   expect(addedResponse.ok()).toBe(true);
   await page.reload();
+  await waitForAppReady(page);
   await expect
     .poll(() => visibleChannelNames(page))
     .toEqual([names[2], names[0], names[1], addedName]);
@@ -89,6 +93,7 @@ test("channel ordering is isolated by workspace", async ({ page }) => {
   const { user } = (await meResponse.json()) as { user: { id: string } };
 
   await page.goto(`/app/${first.workspace.route_id}`);
+  await waitForAppReady(page);
   await page.getByRole("button", { name: `Move #${first.names[0]}` }).click();
   await page
     .getByRole("menu", { name: `Move #${first.names[0]}` })
@@ -99,6 +104,7 @@ test("channel ordering is isolated by workspace", async ({ page }) => {
     .toEqual([first.names[1], first.names[0], first.names[2]]);
 
   await page.goto(`/app/${second.workspace.route_id}`);
+  await waitForAppReady(page);
   await expect.poll(() => visibleChannelNames(page)).toEqual(second.names);
   const secondStorageKey = `clickclack:sidebar-channel-order:v1:${user.id}:${second.workspace.id}`;
   await expect
@@ -106,6 +112,7 @@ test("channel ordering is isolated by workspace", async ({ page }) => {
     .toBeNull();
 
   await page.goto(`/app/${first.workspace.route_id}`);
+  await waitForAppReady(page);
   await expect
     .poll(() => visibleChannelNames(page))
     .toEqual([first.names[1], first.names[0], first.names[2]]);
@@ -122,6 +129,7 @@ test("invalid saved channel ordering falls back to server order", async ({ page 
   }, storageKey);
 
   await page.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(page);
   await expect.poll(() => visibleChannelNames(page)).toEqual(names);
 });
 
@@ -142,6 +150,7 @@ test("unavailable channel order storage keeps session reordering functional", as
   });
 
   await page.goto(`/app/${workspace.route_id}`);
+  await waitForAppReady(page);
   await expect.poll(() => visibleChannelNames(page)).toEqual(names);
   await page.getByRole("button", { name: `Move #${names[0]}` }).click();
   await page
@@ -151,5 +160,6 @@ test("unavailable channel order storage keeps session reordering functional", as
   await expect.poll(() => visibleChannelNames(page)).toEqual([names[1], names[0], names[2]]);
 
   await page.reload();
+  await waitForAppReady(page);
   await expect.poll(() => visibleChannelNames(page)).toEqual(names);
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening embedded conversations after an update could see a blank view when their browser requested an old JavaScript or stylesheet asset. API clients also received successful HTML responses for nonexistent endpoints, obscuring the actual failure and producing JSON parsing errors.

## Why This Change Was Made

Keep the SPA fallback exclusively for browser navigation: return structured JSON 404s for unknown API routes and ordinary 404s for missing browser assets, while continuing to serve real embedded assets and existing app/embed deep links unchanged.

## User Impact

Embedded views fail transparently when a cached frontend bundle no longer exists, and API clients receive a truthful machine-readable error instead of interpreting the application shell as a successful operation. Existing navigation, embedded conversations, icons, and valid asset URLs continue to work.

## Evidence

- Reproduced 20 incorrect HTTP-200 responses before the fix; the new 24-case regression matrix now passes across GET, POST, PATCH, HEAD, bearer-authenticated requests, static assets, and SPA navigation.
- `go test ./apps/api/... -count=1` passes across all 11 backend packages, including current callback-security and guest-authorization coverage.
- Browser unit tests: 25 passing; desktop contract/release tests: 17 passing.
- Root, browser, desktop, and SDK TypeScript typechecks pass.
- Live HTTP verification confirms unknown API routes return JSON 404, stale assets return ordinary 404, current frontend assets remain available, and app/embed deep links still render.
- Independent structured review completed with zero actionable findings.
