### PR TITLE
test(web): cover workspace role permission helpers

### DIFF
--- a/apps/web/src/lib/permissions.test.ts
+++ b/apps/web/src/lib/permissions.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { currentRole, isWorkspaceManager } from "./permissions.ts";
+import type { Workspace } from "./types";
+
+const workspace = (id: string, overrides: Partial<Workspace> = {}): Workspace =>
+  ({
+    id,
+    route_id: `route-${id}`,
+    name: id,
+    slug: id,
+    icon_url: "",
+    created_at: "2026-01-01T00:00:00Z",
+    role: "member",
+    ...overrides,
+  }) as Workspace;
+
+test("isWorkspaceManager is true only for owner and moderator roles", () => {
+  assert.equal(isWorkspaceManager("owner"), true);
+  assert.equal(isWorkspaceManager("moderator"), true);
+  assert.equal(isWorkspaceManager("member"), false);
+  assert.equal(isWorkspaceManager("guest"), false);
+  assert.equal(isWorkspaceManager("bot"), false);
+});
+
+test("isWorkspaceManager treats missing roles as non-managers", () => {
+  assert.equal(isWorkspaceManager(undefined), false);
+  assert.equal(isWorkspaceManager(null), false);
+});
+
+test("currentRole matches a workspace by id or by route_id", () => {
+  const workspaces = [
+    workspace("W1", { role: "owner" }),
+    workspace("W2", { route_id: "acme", role: "moderator" }),
+  ];
+  assert.equal(currentRole(workspaces, "W1"), "owner");
+  assert.equal(currentRole(workspaces, "acme"), "moderator");
+});
+
+test("currentRole returns undefined when the id is blank or unmatched", () => {
+  const workspaces = [workspace("W1", { role: "owner" })];
+  assert.equal(currentRole(workspaces, undefined), undefined);
+  assert.equal(currentRole(workspaces, null), undefined);
+  assert.equal(currentRole(workspaces, ""), undefined);
+  assert.equal(currentRole(workspaces, "missing"), undefined);
+});
+
+test("currentRole surfaces an undefined role on a matched workspace", () => {
+  const workspaces = [workspace("W1", { role: undefined })];
+  assert.equal(currentRole(workspaces, "W1"), undefined);
+});


### PR DESCRIPTION
Related: N/A (proactive test coverage; no linked issue)

## What Problem This Solves

`apps/web/src/lib/permissions.ts` — the workspace-role UI gating helpers `isWorkspaceManager` and `currentRole` — had no colocated test. These helpers decide whether the web client shows manager-only UI and which role applies for the active workspace. A silent regression in them (a role dropped from the manager set, the missing-role fallthrough flipping, or the `id`/`route_id` workspace lookup breaking) would mis-gate the client UI with nothing to catch it.

## Why This Change Was Made

Adds a `node:test` suite (`permissions.test.ts`) alongside the module, matching the existing `apps/web/src/lib/*.test.ts` convention (`node --test`, `node:assert/strict`, type-only imports). It pins the current shipped behavior of both exported helpers across their branches. Non-goal: this is coverage only.

**What did NOT change (scope boundary):** no change to `permissions.ts` or any runtime module — the only file added is the test. The tests import the real helpers and assert existing behavior, so they lock it in without altering it.

## User Impact

No user-visible change. Developers gain regression protection on the role-gating helpers: the suite fails if the manager role set, the missing-role handling, or the workspace `id`/`route_id` lookup regress.

## Evidence

Ran the web lib test runner against the new file, then the whole `src/lib` suite, on fresh `main` (`601224d`):

```
$ node --test apps/web/src/lib/permissions.test.ts
1..5
# tests 5
# pass 5
# fail 0

$ node --test apps/web/src/lib/*.test.ts
# tests 30
# pass 30
# fail 0
```

Non-vacuous — each assertion pins a real branch. Verified by temporarily mutating `permissions.ts` one edit at a time (drop `moderator` from the manager set; invert the `!role` guard; force `MANAGER_ROLES.has()` → `true`; drop the `route_id` arm of the workspace lookup; return a fixed role from `currentRole`) — every mutation turned at least one test red; source restored byte-identical, suite back to 5/5. `oxfmt --check` and `oxlint` both clean on the new file (+51/−0, test-only).

<sub>Opened from an org-owned fork via the API; if GitHub's *Allow edits from maintainers* toggle isn't set on this PR, a maintainer can still push to the branch or supersede-and-land.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_019uJdRknGXxiPV3G7EfJhDz)_