### PR TITLE
feat: support bot-to-bot OpenClaw canary proofs

### DIFF
--- a/apps/api/cmd/clickclack/fakeco_canary.go
+++ b/apps/api/cmd/clickclack/fakeco_canary.go
@@ -30,6 +30,8 @@ type canaryResult struct {
 	Status              string `json:"status"`
 	CorrelationID       string `json:"correlation_id"`
 	RunID               string `json:"run_id,omitempty"`
+	RequesterID         string `json:"requester_id"`
+	RequesterKind       string `json:"requester_kind"`
 	CaseID              string `json:"case_id"`
 	GatewayPreflight    bool   `json:"gateway_preflight"`
 	WorkspaceID         string `json:"workspace_id"`
@@ -102,9 +104,6 @@ func (c apiClient) runCanary(parent context.Context, options canaryOptions) (can
 	if err != nil {
 		return canaryResult{}, fmt.Errorf("resolve canary user: %w", err)
 	}
-	if user.Kind != "human" {
-		return canaryResult{}, errors.New("canary requires a human session token because OpenClaw ignores bot-authored messages")
-	}
 	channel, err := c.resolveChannelContext(ctx)
 	if err != nil {
 		return canaryResult{}, fmt.Errorf("resolve canary channel: %w", err)
@@ -141,6 +140,8 @@ func (c apiClient) runCanary(parent context.Context, options canaryOptions) (can
 				Status:              "passed",
 				CorrelationID:       correlationID,
 				RunID:               runID,
+				RequesterID:         user.ID,
+				RequesterKind:       user.Kind,
 				CaseID:              created.Message.ID,
 				GatewayPreflight:    gatewayPreflight,
 				WorkspaceID:         channel.WorkspaceID,

--- a/apps/api/cmd/clickclack/fakeco_canary_test.go
+++ b/apps/api/cmd/clickclack/fakeco_canary_test.go
@@ -30,7 +30,7 @@ func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 		case r.URL.Path == "/gateway-healthz":
 			_, _ = w.Write([]byte(`{"status":"ok"}`))
 		case r.URL.Path == "/api/me":
-			_ = json.NewEncoder(w).Encode(map[string]any{"user": store.User{ID: "usr_alice", Kind: "human", DisplayName: "Alice"}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"user": store.User{ID: "usr_openclaw_sender", Kind: "bot", DisplayName: "OpenClaw sender"}})
 		case r.URL.Path == "/api/workspaces":
 			_ = json.NewEncoder(w).Encode(map[string]any{"workspaces": []store.Workspace{{ID: "wsp_fakeco", Slug: "fakeco", Name: "FakeCo"}}})
 		case r.URL.Path == "/api/workspaces/wsp_fakeco/channels":
@@ -89,7 +89,7 @@ func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != "passed" || !result.GatewayPreflight || result.RunID != runID || result.CaseID != quoted || result.RequestMessageID != quoted || result.ResponseMessageID != "msg_reply" {
+	if result.Status != "passed" || !result.GatewayPreflight || result.RunID != runID || result.RequesterID != "usr_openclaw_sender" || result.RequesterKind != "bot" || result.CaseID != quoted || result.RequestMessageID != quoted || result.ResponseMessageID != "msg_reply" {
 		t.Fatalf("unexpected canary result: %#v", result)
 	}
 	mu.Lock()
@@ -104,7 +104,7 @@ func TestRunCanaryProvesGatewayAndQuotedBotRoundTrip(t *testing.T) {
 	}
 }
 
-func TestRunCanaryRejectsBotSessionAndUnsafeInputs(t *testing.T) {
+func TestRunCanaryRejectsUnsafeInputs(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/api/me" {
@@ -123,10 +123,6 @@ func TestRunCanaryRejectsBotSessionAndUnsafeInputs(t *testing.T) {
 	_, err = c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco-run", RunID: "unsafe run", Timeout: time.Second, PollInterval: time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "run ID") {
 		t.Fatalf("expected invalid run ID error, got %v", err)
-	}
-	_, err = c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco-bot", Timeout: time.Second, PollInterval: time.Millisecond})
-	if err == nil || !strings.Contains(err.Error(), "human session token") {
-		t.Fatalf("expected bot session rejection, got %v", err)
 	}
 	_, err = c.runCanary(context.Background(), canaryOptions{CorrelationID: "fakeco-url", GatewayHealthURL: "https://user:pass@example.test/healthz", Timeout: time.Second, PollInterval: time.Millisecond})
 	if err == nil || !strings.Contains(err.Error(), "without embedded credentials") {

--- a/docs/agent-friendly-cli.md
+++ b/docs/agent-friendly-cli.md
@@ -38,7 +38,7 @@ Implemented now:
 - `send`, `messages send`, `messages list`.
 - `threads open`, `threads reply`, and `reply`.
 - `reactions add` and `reactions remove`.
-- `canary` for a correlated human-to-OpenClaw quoted-reply check.
+- `canary` for a correlated human- or bot-to-OpenClaw quoted-reply check.
 - `--server`, `--token`, `--user` / `--user-id`, `--workspace`, `--channel`,
   `--json`, `--plain`, `--no-input`, and `--verbose`.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ Commands:
   logout     remove stored client credentials
   whoami     print the current server-side user
   status     print selected server/user/workspace/channel
-  canary     prove a human ClickClack -> OpenClaw -> quoted bot reply round trip
+  canary     prove a human- or bot-to-OpenClaw quoted bot reply round trip
   workspaces list
   channels list
   send
@@ -276,7 +276,9 @@ OPENCLAW_GATEWAY_HEALTH_URL=http://openclaw.internal:18789/healthz \
 clickclack canary --workspace fakeco --channel e2e-canary --json
 ```
 
-Requires a human session token. It optionally preflights the OpenClaw health
+Accepts either a human session token or a scoped bot token. For a bot caller,
+the receiving OpenClaw ClickClack account must enable `allowBots` and allow the
+caller in `allowFrom`. It optionally preflights the OpenClaw health
 URL, posts a unique correlated prompt, and waits for a bot reply quoting the
 request and carrying the same marker. `--timeout`, `--poll-interval`, and
 `--correlation-id` are available for controlled tests. Optional `--run-id`

--- a/docs/fakeco.md
+++ b/docs/fakeco.md
@@ -156,8 +156,10 @@ channel round trip.
 The canary accepts either a synthetic human session token or a scoped ClickClack
 bot token. A human caller proves the ordinary inbound path. A bot caller proves
 bot-to-bot delivery and requires the receiving OpenClaw account to set
-`allowBots: true` (or `allowBots: "mentions"` when the canary message mentions
-the receiver) and include the sender bot user ID in `allowFrom`.
+`allowBots: true` and include the sender bot user ID in `allowFrom`. The fixed
+canary prompt does not mention a receiver, so `allowBots: "mentions"` is not a
+supported mode for this command; exercise mention mode with a separate,
+explicitly mentioned message test.
 
 For a bot-to-bot proof, create two distinct bots in the same workspace: use one
 token as `CLICKCLACK_TOKEN` for the canary sender and configure the other bot's

--- a/docs/fakeco.md
+++ b/docs/fakeco.md
@@ -153,10 +153,16 @@ channel round trip.
 
 ## End-to-end canary
 
-The canary must authenticate as a synthetic human because OpenClaw correctly
-ignores bot-authored events. Mint and consume a magic link for one seeded human,
-then store the resulting session token in the approved secret store used by the
-canary job. Inject it only as `CLICKCLACK_TOKEN`.
+The canary accepts either a synthetic human session token or a scoped ClickClack
+bot token. A human caller proves the ordinary inbound path. A bot caller proves
+bot-to-bot delivery and requires the receiving OpenClaw account to set
+`allowBots: true` (or `allowBots: "mentions"` when the canary message mentions
+the receiver) and include the sender bot user ID in `allowFrom`.
+
+For a bot-to-bot proof, create two distinct bots in the same workspace: use one
+token as `CLICKCLACK_TOKEN` for the canary sender and configure the other bot's
+OpenClaw account as the receiver. Store the token in the approved secret store;
+never put it in the rendered config, logs, or proof artifact.
 
 ```sh
 CLICKCLACK_SERVER=https://chat.fakeco.example \
@@ -167,10 +173,11 @@ clickclack canary --run-id fakeco-smoke-20260709 --json
 ```
 
 The command first checks the configured Gateway health URL, then posts a unique
-human message and polls for an ordinary bot reply that quotes that exact
-message and equals `fakeco-canary-ok <correlation-id>`. It exits non-zero on
-gateway failure, wrong credentials, a missing workspace/channel, a bot caller,
-or timeout. The correlation ID is also sent on every HTTP request as
+human or bot message and polls for an ordinary bot reply that quotes that exact
+message and equals `fakeco-canary-ok <correlation-id>`. Its JSON result records
+`requester_id` and `requester_kind` so the proof distinguishes the bot-to-bot
+path. It exits non-zero on gateway failure, wrong credentials, a missing
+workspace/channel, or timeout. The correlation ID is also sent on every HTTP request as
 `X-Correlation-ID`, returned by ClickClack in the response header, and retained
 as optional metadata on the durable creation event. `--run-id` adds an external
 run identifier to JSON evidence only; `case_id` always equals the canary request

--- a/docs/features/bots.md
+++ b/docs/features/bots.md
@@ -416,7 +416,10 @@ Inbound:
 
 - The extension subscribes to ClickClack realtime events.
 - `message.created` events become OpenClaw inbound turns.
-- Events authored by the configured bot user are ignored.
+- Events authored by the configured bot user are ignored. Events authored by
+  other bots are admitted when the OpenClaw account sets `allowBots: true` (or
+  `allowBots: "mentions"` for mention-gated group traffic), and still pass the
+  configured `allowFrom` policy.
 - Channel messages map to OpenClaw group/channel turns.
 - DMs map to direct turns.
 - Thread replies preserve the source thread/message ID.
@@ -431,6 +434,10 @@ The live proof must configure two ClickClack accounts:
 
 - `openclaw-service`: independent service bot.
 - `peter-openclaw`: user-owned bot with Peter as owner.
+
+For bot-to-bot proof, the sender bot must be included in the receiving
+OpenClaw account's `allowFrom` list and the receiver must opt in with
+`allowBots: true` or `allowBots: "mentions"`.
 
 ## Crabbox Live Proof
 


### PR DESCRIPTION
## What Problem This Solves

ClickClack's OpenClaw canary and integration docs still required a human sender, even though ClickClack supports first-class bot identities and bot-authored message events.

## Why This Change Was Made

- Accept human session tokens or scoped bot tokens in the canary.
- Record `requester_id` and `requester_kind` in JSON evidence.
- Document the receiving OpenClaw `allowBots` and `allowFrom` requirements.
- Keep self-authored events ignored while documenting admission of other bots.
- Make the fixed canary contract explicit: it requires `allowBots: true`; mention mode is exercised by a separate explicitly-mentioned message test.

## User Impact

Operators can prove the configured bot-to-bot path with two scoped ClickClack bot identities and a receiver explicitly opted into bot traffic. The canary instructions no longer suggest a mention-gated mode that its fixed prompt cannot satisfy.

## Related PRs

- [OpenClaw bot-admission PR #119278](https://github.com/openclaw/openclaw/pull/119278) implements the receiver-side bot policy, shared loop guard, and mention-mode behavior.
- This PR supplies the ClickClack canary/docs contract that the OpenClaw integration uses.

## Evidence

- `go test ./apps/api/cmd/clickclack`
- `git diff --check`
- Live local workspace matrix passed with two scoped bot identities:
  - `allowBots: true` + sender in `allowFrom`: quoted reply and gateway preflight passed.
  - `allowBots: false`: no matching reply after 15 seconds.
  - `allowBots: true` + sender omitted from `allowFrom`: no matching reply after 15 seconds.
  - `allowBots: "mentions"` + unmentioned group message: no matching reply after 15 seconds.
  - `allowBots: "mentions"` + explicitly mentioned group message: expected reply.
  - `maxEventsPerWindow: 1`: first bot-pair event replied; second event was suppressed.
- Representative redacted canary receipt:

```json
{
  "status": "passed",
  "correlation_id": "fakeco-ff2a0fbd52575536e88478c2",
  "run_id": "clickclack-b2b-exact-allowfrom",
  "requester_id": "usr_01kz6skhwq1h58nyaams4k7s3q",
  "requester_kind": "bot",
  "request_message_id": "msg_01kz6t4c9fwkgya82q8r4ne06c",
  "response_message_id": "msg_01kz6t6e87a9g016mcknjj0n1t",
  "gateway_preflight": true
}
```

No bot tokens or other secrets are included.