### PR TITLE
test(artifacts): cover classify/language/extension/label/limit branches

### DIFF
--- a/apps/web/src/lib/artifacts.test.ts
+++ b/apps/web/src/lib/artifacts.test.ts
@@ -54,10 +54,7 @@ test("classifyArtifact detects docx by extension and by content type", () => {
   assert.equal(classifyArtifact(upload("resume.docx")), "docx");
   assert.equal(
     classifyArtifact(
-      upload(
-        "resume",
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      ),
+      upload("resume", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
     ),
     "docx",
   );

--- a/apps/web/src/lib/artifacts.test.ts
+++ b/apps/web/src/lib/artifacts.test.ts
@@ -1,0 +1,166 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  artifactContentType,
+  artifactExtension,
+  artifactKindLabel,
+  artifactLanguage,
+  artifactPreviewLimit,
+  classifyArtifact,
+  OFFICE_ARTIFACT_LIMIT,
+  PDF_ARTIFACT_LIMIT,
+  TEXT_ARTIFACT_LIMIT,
+  type ArtifactKind,
+} from "./artifacts.ts";
+import type { Upload } from "./types";
+
+const upload = (filename: string, content_type = ""): Upload =>
+  ({
+    id: "u1",
+    workspace_id: "w1",
+    owner_id: "o1",
+    filename,
+    content_type,
+    byte_size: 1,
+    created_at: "2026-01-01T00:00:00Z",
+  }) as Upload;
+
+test("artifactExtension lowercases and takes the segment after the last dot", () => {
+  assert.equal(artifactExtension("Report.TS"), "ts");
+  assert.equal(artifactExtension("archive.tar.gz"), "gz");
+});
+
+test("artifactExtension strips directory prefixes for both slash styles", () => {
+  assert.equal(artifactExtension("a/b/notes.MD"), "md");
+  assert.equal(artifactExtension("a\\b\\slides.PPTX"), "pptx");
+});
+
+test("artifactExtension returns empty for no extension, dotfiles, and trailing separators", () => {
+  assert.equal(artifactExtension("README"), "");
+  assert.equal(artifactExtension(".gitignore"), "");
+  assert.equal(artifactExtension("nested/dir/"), "");
+});
+
+test("artifactContentType strips parameters, trims, and lowercases", () => {
+  assert.equal(artifactContentType(upload("f", "text/HTML; charset=utf-8")), "text/html");
+  assert.equal(artifactContentType(upload("f", "  Application/PDF  ")), "application/pdf");
+});
+
+test("artifactContentType falls back to empty when the header is blank", () => {
+  assert.equal(artifactContentType(upload("f", "")), "");
+});
+
+test("classifyArtifact detects docx by extension and by content type", () => {
+  assert.equal(classifyArtifact(upload("resume.docx")), "docx");
+  assert.equal(
+    classifyArtifact(
+      upload(
+        "resume",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      ),
+    ),
+    "docx",
+  );
+});
+
+test("classifyArtifact detects spreadsheets by extension and by content type", () => {
+  assert.equal(classifyArtifact(upload("data.xlsm")), "spreadsheet");
+  assert.equal(
+    classifyArtifact(
+      upload("data", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    ),
+    "spreadsheet",
+  );
+});
+
+test("classifyArtifact detects presentations by extension and by content type", () => {
+  assert.equal(classifyArtifact(upload("deck.ppsx")), "presentation");
+  assert.equal(
+    classifyArtifact(
+      upload("deck", "application/vnd.openxmlformats-officedocument.presentationml.slideshow"),
+    ),
+    "presentation",
+  );
+});
+
+test("classifyArtifact detects markdown, html, and pdf by extension and by content type", () => {
+  assert.equal(classifyArtifact(upload("notes.markdown")), "markdown");
+  assert.equal(classifyArtifact(upload("notes", "text/markdown")), "markdown");
+  assert.equal(classifyArtifact(upload("page.htm")), "html");
+  assert.equal(classifyArtifact(upload("page", "text/html")), "html");
+  assert.equal(classifyArtifact(upload("paper.pdf")), "pdf");
+  assert.equal(classifyArtifact(upload("paper", "application/pdf")), "pdf");
+});
+
+test("classifyArtifact detects code by known extension and by known content type", () => {
+  assert.equal(classifyArtifact(upload("main.rs")), "code");
+  assert.equal(classifyArtifact(upload("blob", "application/json")), "code");
+});
+
+test("classifyArtifact detects text by extension, plain type, and the text/* fallback", () => {
+  assert.equal(classifyArtifact(upload("server.log")), "text");
+  assert.equal(classifyArtifact(upload("note", "text/plain")), "text");
+  assert.equal(classifyArtifact(upload("note", "text/rtf")), "text");
+});
+
+test("classifyArtifact returns unsupported for unknown extension and content type", () => {
+  assert.equal(classifyArtifact(upload("photo.png", "image/png")), "unsupported");
+  assert.equal(classifyArtifact(upload("blob")), "unsupported");
+});
+
+test("classifyArtifact lets the extension win over the content type in the cascade", () => {
+  assert.equal(classifyArtifact(upload("notes.md", "application/pdf")), "markdown");
+});
+
+test("artifactLanguage maps known code extensions", () => {
+  assert.equal(artifactLanguage(upload("app.tsx")), "typescript");
+  assert.equal(artifactLanguage(upload("run.py")), "python");
+});
+
+test("artifactLanguage falls back to content-type substrings when the extension is unknown", () => {
+  assert.equal(artifactLanguage(upload("blob", "application/ld+json")), "json");
+  assert.equal(artifactLanguage(upload("blob", "text/javascript")), "javascript");
+  assert.equal(artifactLanguage(upload("blob", "application/typescript")), "typescript");
+  assert.equal(artifactLanguage(upload("blob", "application/x-yaml")), "yaml");
+  assert.equal(artifactLanguage(upload("blob", "text/xml")), "xml");
+  assert.equal(artifactLanguage(upload("blob", "application/sql")), "sql");
+});
+
+test("artifactLanguage prefers the code extension over the content type", () => {
+  assert.equal(artifactLanguage(upload("run.py", "application/json")), "python");
+});
+
+test("artifactLanguage returns undefined when nothing matches", () => {
+  assert.equal(artifactLanguage(upload("photo.png", "image/png")), undefined);
+});
+
+test("artifactKindLabel returns a label for every kind and a default", () => {
+  const labels: Record<ArtifactKind, string> = {
+    code: "Code",
+    text: "Text",
+    markdown: "Markdown",
+    pdf: "PDF",
+    docx: "Word document",
+    spreadsheet: "Spreadsheet",
+    presentation: "Slide text outline",
+    html: "Web page",
+    unsupported: "File",
+  };
+  for (const [kind, label] of Object.entries(labels)) {
+    assert.equal(artifactKindLabel(kind as ArtifactKind), label);
+  }
+});
+
+test("artifactPreviewLimit returns the per-family cap", () => {
+  assert.equal(artifactPreviewLimit("pdf"), PDF_ARTIFACT_LIMIT);
+  assert.equal(artifactPreviewLimit("spreadsheet"), OFFICE_ARTIFACT_LIMIT);
+  assert.equal(artifactPreviewLimit("presentation"), OFFICE_ARTIFACT_LIMIT);
+  for (const kind of ["code", "text", "markdown", "html"] as ArtifactKind[]) {
+    assert.equal(artifactPreviewLimit(kind), TEXT_ARTIFACT_LIMIT);
+  }
+});
+
+test("artifactPreviewLimit returns undefined for kinds without an inline preview", () => {
+  assert.equal(artifactPreviewLimit("docx"), undefined);
+  assert.equal(artifactPreviewLimit("unsupported"), undefined);
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled on this PR so a maintainer can refresh the branch or land it in place.

</details>

## What Problem This Solves

`apps/web/src/lib/artifacts.ts` exports the six pure helpers that decide how an uploaded file is classified and previewed in the web app — `artifactExtension`, `artifactContentType`, `classifyArtifact`, `artifactLanguage`, `artifactKindLabel`, and `artifactPreviewLimit` — and the module shipped with **no direct test coverage** (no `apps/web/src/lib/artifacts.test.ts` on `main`). Several of these carry subtle contracts a plausible refactor could silently break:

- **`artifactExtension`** takes the segment after the *last* dot of the basename, lowercased, but the `dot > 0` guard means a dotfile (`.gitignore`) and an extension-less name both return `""` — a `> 0` → `>= 0` slip would start reporting `gitignore` as the extension.
- **`classifyArtifact`** is an ordered cascade: extension beats content-type (`notes.md` + `application/pdf` → `markdown`), and a final `contentType.startsWith("text/")` fallback catches unknown text subtypes (`text/rtf` → `text`).
- **`artifactLanguage`** prefers a known code extension, then falls back to content-type substring matches (`json`/`javascript`/`typescript`/`yaml`/`xml`/`sql`).
- **`artifactKindLabel`** and **`artifactPreviewLimit`** map every `ArtifactKind` (plus the default / no-preview cases) to a fixed label and byte cap.

A regression in any of these ships green today, because nothing executes the module.

## Why This Change Was Made

Coverage-only. This adds one new file, `apps/web/src/lib/artifacts.test.ts` (**+166, no production code touched**), pinning the module's current `main` behavior. The tests import the **real** exported functions and drive them directly — no stubs — so they exercise the production path callers actually hit. Each helper is covered on both its positive and its negative/omit path: `artifactExtension`'s empty cases (no-ext, dotfile, trailing separator) alongside the both-slash-style directory strip; `classifyArtifact`'s docx/spreadsheet/presentation/markdown/html/pdf/code/text detections by *both* extension and content type, the `text/*` fallback, the `unsupported` end, and the extension-wins cascade; `artifactLanguage`'s extension map, all six content-type substrings, the extension-over-content precedence, and the `undefined` miss; and the full `ArtifactKind` → label / preview-limit maps including the default and no-preview kinds. No new config, defaults, or dependencies.

## User Impact

No user-visible or runtime change. For maintainers, the artifact-classification contract now regresses loudly instead of silently: a future edit that breaks the dotfile extension guard, the classify cascade precedence, the `text/*` fallback, a language substring, or a kind label/limit will fail this suite.

## Evidence

Linux, Node **v22.22.2** (native TypeScript type-stripping — the same `node --test src/lib/*.test.ts` the `apps/web` package's `test` script runs). Branched off and **rebased onto current `main`** (`c41adb3`, `chore(deps): refresh runtime dependencies (#155)`).

**20/20 pass on the new file:**

```console
$ node --test src/lib/artifacts.test.ts
# tests 20
# pass 20
# fail 0
```

**Full `apps/web` lib suite green with the new file — no regression** (baseline 30 + these 20 = 50):

```console
$ node --test src/lib/*.test.ts
# tests 50
# pass 50
# fail 0
```

**Non-vacuous — the suite bites when the target is mutated** (each mutation applied to `src/lib/artifacts.ts`, `node --test src/lib/artifacts.test.ts` re-run, then reverted byte-identical):

| Mutation to `artifacts.ts` | Result |
| --- | --- |
| `artifactExtension` `dot > 0` → `dot >= 0` (dotfile) | 1 fail |
| `classifyArtifact` drop the `text/*` fallback | 1 fail |
| *(reverted — control)* | **20 pass** |

**Scope note:** one new `*.test.ts` file under `apps/web/src/lib/`, `+166 / -0`, no production code touched. Same family as the just-landed `permissions.ts` coverage (#149).

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQH3gp99ibF8chMdMHyS7G)_