### PR TITLE
feat: add existing users to a workspace from the CLI

### DIFF
--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -279,6 +280,79 @@ func admin(args []string) error {
 			}
 		}
 		fmt.Printf("%s\n", user.ID)
+		return nil
+	case "member":
+		if len(args) < 2 || args[1] != "add" {
+			return fmt.Errorf("usage: clickclack admin member add --workspace WORKSPACE_ID --email EMAIL [--role member]")
+		}
+		flags := flag.NewFlagSet("admin member add", flag.ExitOnError)
+		data := flags.String("data", defaultData(), "data directory")
+		dbURL := flags.String("db", defaultDB(), "database URL")
+		workspaceID := flags.String("workspace", "", "workspace id")
+		email := flags.String("email", "", "existing user email")
+		role := flags.String("role", store.WorkspaceRoleMember, "workspace role")
+		if err := flags.Parse(args[2:]); err != nil {
+			return err
+		}
+		*workspaceID = strings.TrimSpace(*workspaceID)
+		*email = strings.ToLower(strings.TrimSpace(*email))
+		*role = strings.TrimSpace(*role)
+		if *workspaceID == "" {
+			return fmt.Errorf("--workspace is required")
+		}
+		if *email == "" {
+			return fmt.Errorf("--email is required")
+		}
+		switch *role {
+		case store.WorkspaceRoleMember, store.WorkspaceRoleModerator, store.WorkspaceRoleOwner:
+		default:
+			return fmt.Errorf("--role must be one of member, moderator, owner; guest and bot are managed by other flows")
+		}
+		st, err := openStore(resolveDB(*data, *dbURL))
+		if err != nil {
+			return err
+		}
+		defer st.Close()
+		ctx := context.Background()
+		if err := st.Migrate(ctx); err != nil {
+			return err
+		}
+		user, err := st.GetUserByEmail(ctx, *email)
+		if errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("no user found for email %q; use clickclack admin user create --workspace %s --email %s", *email, *workspaceID, *email)
+		}
+		if err != nil {
+			return err
+		}
+		workspaces, err := st.ListWorkspaces(ctx, user.ID)
+		if err != nil {
+			return err
+		}
+		status := "added"
+		for _, workspace := range workspaces {
+			if workspace.ID == *workspaceID {
+				status = "already_member"
+				break
+			}
+		}
+		if err := st.AddWorkspaceMember(ctx, *workspaceID, user.ID, *role); err != nil {
+			return err
+		}
+		workspaces, err = st.ListWorkspaces(ctx, user.ID)
+		if err != nil {
+			return err
+		}
+		resultRole := ""
+		for _, workspace := range workspaces {
+			if workspace.ID == *workspaceID {
+				resultRole = workspace.Role
+				break
+			}
+		}
+		if resultRole == "" {
+			return fmt.Errorf("workspace membership was not created")
+		}
+		fmt.Printf("workspace=%s user=%s role=%s status=%s\n", *workspaceID, user.ID, resultRole, status)
 		return nil
 	case "invite":
 		if len(args) < 2 || args[1] != "create" {

--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -295,7 +295,9 @@ func admin(args []string) error {
 			return err
 		}
 		*workspaceID = strings.TrimSpace(*workspaceID)
-		*email = strings.ToLower(strings.TrimSpace(*email))
+		// Left as typed: the store folds case on both sides, and errors should
+		// echo the address the operator actually passed.
+		*email = strings.TrimSpace(*email)
 		*role = strings.TrimSpace(*role)
 		if *workspaceID == "" {
 			return fmt.Errorf("--workspace is required")

--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -283,32 +283,37 @@ func admin(args []string) error {
 		return nil
 	case "member":
 		if len(args) < 2 || args[1] != "add" {
-			return fmt.Errorf("usage: clickclack admin member add --workspace WORKSPACE_ID --email EMAIL [--role member]")
+			return fmt.Errorf("usage: clickclack admin member add --workspace WORKSPACE_ID --created-by USER_ID (--email EMAIL | --user USER_ID) [--role member]")
 		}
 		flags := flag.NewFlagSet("admin member add", flag.ExitOnError)
 		data := flags.String("data", defaultData(), "data directory")
 		dbURL := flags.String("db", defaultDB(), "database URL")
 		workspaceID := flags.String("workspace", "", "workspace id")
+		createdBy := flags.String("created-by", "", "owner or moderator user id")
 		email := flags.String("email", "", "existing user email")
+		userID := flags.String("user", "", "existing user id")
 		role := flags.String("role", store.WorkspaceRoleMember, "workspace role")
 		if err := flags.Parse(args[2:]); err != nil {
 			return err
 		}
 		*workspaceID = strings.TrimSpace(*workspaceID)
-		// Left as typed: the store folds case on both sides, and errors should
-		// echo the address the operator actually passed.
+		*createdBy = strings.TrimSpace(*createdBy)
 		*email = strings.TrimSpace(*email)
+		*userID = strings.TrimSpace(*userID)
 		*role = strings.TrimSpace(*role)
 		if *workspaceID == "" {
 			return fmt.Errorf("--workspace is required")
 		}
-		if *email == "" {
-			return fmt.Errorf("--email is required")
+		if *createdBy == "" {
+			return fmt.Errorf("--created-by is required")
+		}
+		if (*email == "") == (*userID == "") {
+			return fmt.Errorf("exactly one of --email or --user is required")
 		}
 		switch *role {
-		case store.WorkspaceRoleMember, store.WorkspaceRoleModerator, store.WorkspaceRoleOwner:
+		case store.WorkspaceRoleMember, store.WorkspaceRoleModerator:
 		default:
-			return fmt.Errorf("--role must be one of member, moderator, owner; guest and bot are managed by other flows")
+			return fmt.Errorf("--role must be one of member or moderator; owner, guest, and bot are managed by other flows")
 		}
 		st, err := openStore(resolveDB(*data, *dbURL))
 		if err != nil {
@@ -319,42 +324,38 @@ func admin(args []string) error {
 		if err := st.Migrate(ctx); err != nil {
 			return err
 		}
-		user, err := st.GetUserByEmail(ctx, *email)
+		var user store.User
+		if *userID != "" {
+			user, err = st.GetUser(ctx, *userID)
+		} else {
+			user, err = st.GetUserByEmail(ctx, *email)
+		}
 		if errors.Is(err, sql.ErrNoRows) {
+			if *userID != "" {
+				return fmt.Errorf("no user found for id %q", *userID)
+			}
 			return fmt.Errorf("no user found for email %q; use clickclack admin user create --workspace %s --email %s", *email, *workspaceID, *email)
 		}
+		if errors.Is(err, store.ErrAmbiguousUserEmail) {
+			return fmt.Errorf("multiple users found for email %q; retry with --user USER_ID", *email)
+		}
 		if err != nil {
 			return err
 		}
-		workspaces, err := st.ListWorkspaces(ctx, user.ID)
+		result, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+			WorkspaceID: *workspaceID,
+			UserID:      user.ID,
+			ActorUserID: *createdBy,
+			Role:        *role,
+		})
 		if err != nil {
 			return err
 		}
-		status := "added"
-		for _, workspace := range workspaces {
-			if workspace.ID == *workspaceID {
-				status = "already_member"
-				break
-			}
+		status := "already_member"
+		if result.Added {
+			status = "added"
 		}
-		if err := st.AddWorkspaceMember(ctx, *workspaceID, user.ID, *role); err != nil {
-			return err
-		}
-		workspaces, err = st.ListWorkspaces(ctx, user.ID)
-		if err != nil {
-			return err
-		}
-		resultRole := ""
-		for _, workspace := range workspaces {
-			if workspace.ID == *workspaceID {
-				resultRole = workspace.Role
-				break
-			}
-		}
-		if resultRole == "" {
-			return fmt.Errorf("workspace membership was not created")
-		}
-		fmt.Printf("workspace=%s user=%s role=%s status=%s\n", *workspaceID, user.ID, resultRole, status)
+		fmt.Printf("workspace=%s user=%s role=%s status=%s\n", *workspaceID, user.ID, result.Role, status)
 		return nil
 	case "invite":
 		if len(args) < 2 || args[1] != "create" {

--- a/apps/api/cmd/clickclack/main_test.go
+++ b/apps/api/cmd/clickclack/main_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -191,6 +192,168 @@ func TestAdminBotCreateUsesExplicitAuthorizedActor(t *testing.T) {
 	if ownersByHandle["cli-service"] != "" || ownersByHandle["cli-personal"] != member.ID {
 		t.Fatalf("unexpected bot ownership: %#v", ownersByHandle)
 	}
+}
+
+func TestAdminMemberAddAddsExistingUserToSecondWorkspace(t *testing.T) {
+	dbURL, user, _, second := setupAdminMemberTest(t)
+
+	output := captureStdout(t, func() error {
+		return admin([]string{
+			"member", "add",
+			"--db", dbURL,
+			"--workspace", second.ID,
+			"--email", " Existing@Example.COM ",
+		})
+	})
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=added\n", second.ID, user.ID)
+	if output != wantOutput {
+		t.Fatalf("unexpected output: got %q want %q", output, wantOutput)
+	}
+
+	ctx := context.Background()
+	st, err := sqlitestore.Open(dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	workspaces, err := st.ListWorkspaces(ctx, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workspaces) != 2 {
+		t.Fatalf("expected two workspace memberships, got %#v", workspaces)
+	}
+	for _, workspace := range workspaces {
+		if workspace.ID == second.ID && workspace.Role == store.WorkspaceRoleMember {
+			return
+		}
+	}
+	t.Fatalf("second workspace membership not found: %#v", workspaces)
+}
+
+func TestAdminMemberAddRejectsUnknownEmail(t *testing.T) {
+	dbURL, _, _, second := setupAdminMemberTest(t)
+	err := admin([]string{
+		"member", "add",
+		"--db", dbURL,
+		"--workspace", second.ID,
+		"--email", " Missing@Example.COM ",
+	})
+	if err == nil || !strings.Contains(err.Error(), `no user found for email "missing@example.com"`) {
+		t.Fatalf("expected unknown email error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "clickclack admin user create --workspace "+second.ID) {
+		t.Fatalf("expected actionable user create guidance, got %v", err)
+	}
+}
+
+func TestAdminMemberAddValidatesRequiredFlagsBeforeOpeningDatabase(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{name: "workspace", args: []string{"--email", "existing@example.com"}, wantErr: "--workspace is required"},
+		{name: "email", args: []string{"--workspace", "wsp_missing"}, wantErr: "--email is required"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "missing.db")
+			args := append([]string{"member", "add", "--db", "sqlite://" + dbPath}, test.args...)
+			err := admin(args)
+			if err == nil || err.Error() != test.wantErr {
+				t.Fatalf("expected %q, got %v", test.wantErr, err)
+			}
+			if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("validation opened the database before rejecting the command: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestAdminMemberAddRejectsInvalidRole(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "missing.db")
+	err := admin([]string{
+		"member", "add",
+		"--db", "sqlite://" + dbPath,
+		"--workspace", "wsp_missing",
+		"--email", "existing@example.com",
+		"--role", store.WorkspaceRoleGuest,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--role must be one of member, moderator, owner") {
+		t.Fatalf("expected invalid role error, got %v", err)
+	}
+	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("validation opened the database before rejecting the command: %v", statErr)
+	}
+}
+
+func TestAdminMemberAddIsIdempotentForExistingMember(t *testing.T) {
+	dbURL, user, first, _ := setupAdminMemberTest(t)
+
+	output := captureStdout(t, func() error {
+		return admin([]string{
+			"member", "add",
+			"--db", dbURL,
+			"--workspace", first.ID,
+			"--email", "existing@example.com",
+			"--role", store.WorkspaceRoleOwner,
+		})
+	})
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=already_member\n", first.ID, user.ID)
+	if output != wantOutput {
+		t.Fatalf("unexpected output: got %q want %q", output, wantOutput)
+	}
+
+	ctx := context.Background()
+	st, err := sqlitestore.Open(dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	workspaces, err := st.ListWorkspaces(ctx, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(workspaces) != 1 || workspaces[0].ID != first.ID || workspaces[0].Role != store.WorkspaceRoleMember {
+		t.Fatalf("existing membership changed: %#v", workspaces)
+	}
+}
+
+func setupAdminMemberTest(t *testing.T) (string, store.User, store.Workspace, store.Workspace) {
+	t.Helper()
+	ctx := context.Background()
+	dbURL := "sqlite://" + filepath.Join(t.TempDir(), "clickclack.db")
+	st, err := sqlitestore.Open(dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Owner", Email: "owner@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "First", Slug: "first"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Second", Slug: "second"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	user, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Existing", Email: "existing@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, first.ID, user.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return dbURL, user, first, second
 }
 
 func TestOpenUploadStorageValidation(t *testing.T) {

--- a/apps/api/cmd/clickclack/main_test.go
+++ b/apps/api/cmd/clickclack/main_test.go
@@ -195,28 +195,29 @@ func TestAdminBotCreateUsesExplicitAuthorizedActor(t *testing.T) {
 }
 
 func TestAdminMemberAddAddsExistingUserToSecondWorkspace(t *testing.T) {
-	dbURL, user, _, second := setupAdminMemberTest(t)
+	fixture := setupAdminMemberTest(t)
 
 	output := captureStdout(t, func() error {
 		return admin([]string{
 			"member", "add",
-			"--db", dbURL,
-			"--workspace", second.ID,
+			"--db", fixture.dbURL,
+			"--workspace", fixture.second.ID,
+			"--created-by", fixture.owner.ID,
 			"--email", " Existing@Example.COM ",
 		})
 	})
-	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=added\n", second.ID, user.ID)
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=added\n", fixture.second.ID, fixture.user.ID)
 	if output != wantOutput {
 		t.Fatalf("unexpected output: got %q want %q", output, wantOutput)
 	}
 
 	ctx := context.Background()
-	st, err := sqlitestore.Open(dbURL)
+	st, err := sqlitestore.Open(fixture.dbURL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	workspaces, err := st.ListWorkspaces(ctx, user.ID)
+	workspaces, err := st.ListWorkspaces(ctx, fixture.user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +225,7 @@ func TestAdminMemberAddAddsExistingUserToSecondWorkspace(t *testing.T) {
 		t.Fatalf("expected two workspace memberships, got %#v", workspaces)
 	}
 	for _, workspace := range workspaces {
-		if workspace.ID == second.ID && workspace.Role == store.WorkspaceRoleMember {
+		if workspace.ID == fixture.second.ID && workspace.Role == store.WorkspaceRoleMember {
 			return
 		}
 	}
@@ -232,17 +233,18 @@ func TestAdminMemberAddAddsExistingUserToSecondWorkspace(t *testing.T) {
 }
 
 func TestAdminMemberAddRejectsUnknownEmail(t *testing.T) {
-	dbURL, _, _, second := setupAdminMemberTest(t)
+	fixture := setupAdminMemberTest(t)
 	err := admin([]string{
 		"member", "add",
-		"--db", dbURL,
-		"--workspace", second.ID,
+		"--db", fixture.dbURL,
+		"--workspace", fixture.second.ID,
+		"--created-by", fixture.owner.ID,
 		"--email", " Missing@Example.COM ",
 	})
 	if err == nil || !strings.Contains(err.Error(), `no user found for email "Missing@Example.COM"`) {
 		t.Fatalf("expected unknown email error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "clickclack admin user create --workspace "+second.ID) {
+	if !strings.Contains(err.Error(), "clickclack admin user create --workspace "+fixture.second.ID) {
 		t.Fatalf("expected actionable user create guidance, got %v", err)
 	}
 }
@@ -253,8 +255,10 @@ func TestAdminMemberAddValidatesRequiredFlagsBeforeOpeningDatabase(t *testing.T)
 		args    []string
 		wantErr string
 	}{
-		{name: "workspace", args: []string{"--email", "existing@example.com"}, wantErr: "--workspace is required"},
-		{name: "email", args: []string{"--workspace", "wsp_missing"}, wantErr: "--email is required"},
+		{name: "workspace", args: []string{"--created-by", "usr_owner", "--email", "existing@example.com"}, wantErr: "--workspace is required"},
+		{name: "actor", args: []string{"--workspace", "wsp_missing", "--email", "existing@example.com"}, wantErr: "--created-by is required"},
+		{name: "selector", args: []string{"--workspace", "wsp_missing", "--created-by", "usr_owner"}, wantErr: "exactly one of --email or --user is required"},
+		{name: "selectors", args: []string{"--workspace", "wsp_missing", "--created-by", "usr_owner", "--email", "existing@example.com", "--user", "usr_existing"}, wantErr: "exactly one of --email or --user is required"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -277,10 +281,11 @@ func TestAdminMemberAddRejectsInvalidRole(t *testing.T) {
 		"member", "add",
 		"--db", "sqlite://" + dbPath,
 		"--workspace", "wsp_missing",
+		"--created-by", "usr_owner",
 		"--email", "existing@example.com",
 		"--role", store.WorkspaceRoleGuest,
 	})
-	if err == nil || !strings.Contains(err.Error(), "--role must be one of member, moderator, owner") {
+	if err == nil || !strings.Contains(err.Error(), "--role must be one of member or moderator") {
 		t.Fatalf("expected invalid role error, got %v", err)
 	}
 	if _, statErr := os.Stat(dbPath); !errors.Is(statErr, os.ErrNotExist) {
@@ -289,33 +294,34 @@ func TestAdminMemberAddRejectsInvalidRole(t *testing.T) {
 }
 
 func TestAdminMemberAddIsIdempotentForExistingMember(t *testing.T) {
-	dbURL, user, first, _ := setupAdminMemberTest(t)
+	fixture := setupAdminMemberTest(t)
 
 	output := captureStdout(t, func() error {
 		return admin([]string{
 			"member", "add",
-			"--db", dbURL,
-			"--workspace", first.ID,
+			"--db", fixture.dbURL,
+			"--workspace", fixture.first.ID,
+			"--created-by", fixture.owner.ID,
 			"--email", "existing@example.com",
-			"--role", store.WorkspaceRoleOwner,
+			"--role", store.WorkspaceRoleModerator,
 		})
 	})
-	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=already_member\n", first.ID, user.ID)
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=already_member\n", fixture.first.ID, fixture.user.ID)
 	if output != wantOutput {
 		t.Fatalf("unexpected output: got %q want %q", output, wantOutput)
 	}
 
 	ctx := context.Background()
-	st, err := sqlitestore.Open(dbURL)
+	st, err := sqlitestore.Open(fixture.dbURL)
 	if err != nil {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = st.Close() })
-	workspaces, err := st.ListWorkspaces(ctx, user.ID)
+	workspaces, err := st.ListWorkspaces(ctx, fixture.user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(workspaces) != 1 || workspaces[0].ID != first.ID || workspaces[0].Role != store.WorkspaceRoleMember {
+	if len(workspaces) != 1 || workspaces[0].ID != fixture.first.ID || workspaces[0].Role != store.WorkspaceRoleMember {
 		t.Fatalf("existing membership changed: %#v", workspaces)
 	}
 }
@@ -353,6 +359,7 @@ func TestAdminMemberAddResolvesMixedCaseIdentityEmail(t *testing.T) {
 			"member", "add",
 			"--db", dbURL,
 			"--workspace", workspace.ID,
+			"--created-by", owner.ID,
 			"--email", "existing@example.com",
 		})
 	})
@@ -362,7 +369,81 @@ func TestAdminMemberAddResolvesMixedCaseIdentityEmail(t *testing.T) {
 	}
 }
 
-func setupAdminMemberTest(t *testing.T) (string, store.User, store.Workspace, store.Workspace) {
+func TestAdminMemberAddRejectsAmbiguousEmailAndAcceptsUserID(t *testing.T) {
+	fixture := setupAdminMemberTest(t)
+	ctx := context.Background()
+	st, err := sqlitestore.Open(fixture.dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Duplicate", Email: "EXISTING@example.com"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	err = admin([]string{
+		"member", "add",
+		"--db", fixture.dbURL,
+		"--workspace", fixture.second.ID,
+		"--created-by", fixture.owner.ID,
+		"--email", "existing@example.com",
+	})
+	if err == nil || !strings.Contains(err.Error(), "multiple users found") || !strings.Contains(err.Error(), "--user USER_ID") {
+		t.Fatalf("expected actionable ambiguous-email error, got %v", err)
+	}
+
+	output := captureStdout(t, func() error {
+		return admin([]string{
+			"member", "add",
+			"--db", fixture.dbURL,
+			"--workspace", fixture.second.ID,
+			"--created-by", fixture.owner.ID,
+			"--user", fixture.user.ID,
+		})
+	})
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=added\n", fixture.second.ID, fixture.user.ID)
+	if output != wantOutput {
+		t.Fatalf("unexpected ID-selected output: got %q want %q", output, wantOutput)
+	}
+}
+
+func TestAdminMemberAddEnforcesManagerRoleInStore(t *testing.T) {
+	fixture := setupAdminMemberTest(t)
+	err := admin([]string{
+		"member", "add",
+		"--db", fixture.dbURL,
+		"--workspace", fixture.second.ID,
+		"--created-by", fixture.user.ID,
+		"--user", fixture.user.ID,
+	})
+	if !errors.Is(err, store.ErrNotWorkspaceManager) {
+		t.Fatalf("expected non-manager rejection, got %v", err)
+	}
+}
+
+func TestAdminMemberAddRejectsUnknownUserID(t *testing.T) {
+	fixture := setupAdminMemberTest(t)
+	err := admin([]string{
+		"member", "add",
+		"--db", fixture.dbURL,
+		"--workspace", fixture.second.ID,
+		"--created-by", fixture.owner.ID,
+		"--user", "usr_missing",
+	})
+	if err == nil || err.Error() != `no user found for id "usr_missing"` {
+		t.Fatalf("expected unknown user ID error, got %v", err)
+	}
+}
+
+type adminMemberFixture struct {
+	dbURL         string
+	owner, user   store.User
+	first, second store.Workspace
+}
+
+func setupAdminMemberTest(t *testing.T) adminMemberFixture {
 	t.Helper()
 	ctx := context.Background()
 	dbURL := "sqlite://" + filepath.Join(t.TempDir(), "clickclack.db")
@@ -395,7 +476,7 @@ func setupAdminMemberTest(t *testing.T) (string, store.User, store.Workspace, st
 	if err := st.Close(); err != nil {
 		t.Fatal(err)
 	}
-	return dbURL, user, first, second
+	return adminMemberFixture{dbURL: dbURL, owner: owner, user: user, first: first, second: second}
 }
 
 func TestOpenUploadStorageValidation(t *testing.T) {

--- a/apps/api/cmd/clickclack/main_test.go
+++ b/apps/api/cmd/clickclack/main_test.go
@@ -239,7 +239,7 @@ func TestAdminMemberAddRejectsUnknownEmail(t *testing.T) {
 		"--workspace", second.ID,
 		"--email", " Missing@Example.COM ",
 	})
-	if err == nil || !strings.Contains(err.Error(), `no user found for email "missing@example.com"`) {
+	if err == nil || !strings.Contains(err.Error(), `no user found for email "Missing@Example.COM"`) {
 		t.Fatalf("expected unknown email error, got %v", err)
 	}
 	if !strings.Contains(err.Error(), "clickclack admin user create --workspace "+second.ID) {
@@ -317,6 +317,48 @@ func TestAdminMemberAddIsIdempotentForExistingMember(t *testing.T) {
 	}
 	if len(workspaces) != 1 || workspaces[0].ID != first.ID || workspaces[0].Role != store.WorkspaceRoleMember {
 		t.Fatalf("existing membership changed: %#v", workspaces)
+	}
+}
+
+// Regression: admin user create stores the address exactly as typed, so a
+// mixed-case identity must still resolve from a differently-cased lookup.
+func TestAdminMemberAddResolvesMixedCaseIdentityEmail(t *testing.T) {
+	ctx := context.Background()
+	dbURL := "sqlite://" + filepath.Join(t.TempDir(), "clickclack.db")
+	st, err := sqlitestore.Open(dbURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Owner", Email: "owner@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Mixed", Slug: "mixed"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mixed, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Mixed", Email: "Existing@Example.COM"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() error {
+		return admin([]string{
+			"member", "add",
+			"--db", dbURL,
+			"--workspace", workspace.ID,
+			"--email", "existing@example.com",
+		})
+	})
+	wantOutput := fmt.Sprintf("workspace=%s user=%s role=member status=added\n", workspace.ID, mixed.ID)
+	if output != wantOutput {
+		t.Fatalf("unexpected output: got %q want %q", output, wantOutput)
 	}
 }
 

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -267,7 +267,7 @@ func (s *Store) CreateBot(ctx context.Context, input store.CreateBotInput) (stor
 		}
 		return store.User{}, store.BotToken{}, err
 	}
-	if err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: workspaceID,
 		UserID:      bot.ID,
 		Role:        "bot",

--- a/apps/api/internal/store/postgres/member_add_test.go
+++ b/apps/api/internal/store/postgres/member_add_test.go
@@ -1,0 +1,83 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestAddWorkspaceMemberByActorPostgres(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Owner", Email: "pg-member-add-owner@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Postgres Member Add"}, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "pg-member-add-actor@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	target, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Target", Email: "pg-member-add-target@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      target.ID,
+		ActorUserID: member.ID,
+		Role:        store.WorkspaceRoleMember,
+	}); !errors.Is(err, store.ErrNotWorkspaceManager) {
+		t.Fatalf("expected member actor rejection, got %v", err)
+	}
+	first, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      target.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleModerator,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Added || first.Role != store.WorkspaceRoleModerator {
+		t.Fatalf("unexpected insert result: %#v", first)
+	}
+	replay, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      target.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleMember,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replay.Added || replay.Role != store.WorkspaceRoleModerator {
+		t.Fatalf("idempotent add changed or misreported the role: %#v", replay)
+	}
+	if _, err := st.db.ExecContext(ctx, `DELETE FROM workspace_members WHERE workspace_id = $1 AND user_id = $2`, workspace.ID, target.ID); err != nil {
+		t.Fatal(err)
+	}
+	readded, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      target.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleMember,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !readded.Added || readded.Role != store.WorkspaceRoleMember {
+		t.Fatalf("re-add restored a stale privileged role: %#v", readded)
+	}
+}

--- a/apps/api/internal/store/postgres/members.go
+++ b/apps/api/internal/store/postgres/members.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/postgres/storedb"
@@ -27,7 +29,7 @@ func (s *Store) AddWorkspaceMember(ctx context.Context, workspaceID, userID, rol
 			return err
 		}
 	}
-	if err := storedb.New(tx).InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := storedb.New(tx).InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: workspaceID,
 		UserID:      userID,
 		Role:        normalizeWorkspaceRole(role),
@@ -36,6 +38,83 @@ func (s *Store) AddWorkspaceMember(ctx context.Context, workspaceID, userID, rol
 		return err
 	}
 	return tx.Commit()
+}
+
+func (s *Store) AddWorkspaceMemberByActor(ctx context.Context, input store.AddWorkspaceMemberInput) (store.AddWorkspaceMemberResult, error) {
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	userID := strings.TrimSpace(input.UserID)
+	actorUserID := strings.TrimSpace(input.ActorUserID)
+	role := strings.TrimSpace(input.Role)
+	if workspaceID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("workspace is required")
+	}
+	if userID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("user is required")
+	}
+	if actorUserID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("actor user is required")
+	}
+	if role == "" {
+		role = store.WorkspaceRoleMember
+	}
+	if role != store.WorkspaceRoleMember && role != store.WorkspaceRoleModerator {
+		return store.AddWorkspaceMemberResult{}, fmt.Errorf("role %q cannot be assigned when adding a workspace member", role)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	defer tx.Rollback()
+	qtx := storedb.New(tx)
+	roleRows, err := qtx.MembershipRolesForUpdate(ctx, storedb.MembershipRolesForUpdateParams{
+		WorkspaceID:  workspaceID,
+		ActorUserID:  actorUserID,
+		TargetUserID: userID,
+	})
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	actorRole := ""
+	for _, row := range roleRows {
+		if row.UserID == actorUserID {
+			actorRole = row.Role
+			break
+		}
+	}
+	if actorRole != store.WorkspaceRoleOwner && actorRole != store.WorkspaceRoleModerator {
+		return store.AddWorkspaceMemberResult{}, store.ErrNotWorkspaceManager
+	}
+	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, actorUserID); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if role == store.WorkspaceRoleModerator && actorRole != store.WorkspaceRoleOwner {
+		return store.AddWorkspaceMemberResult{}, store.ErrWorkspaceOwnerRequired
+	}
+	var userKind string
+	if err := tx.QueryRowContext(ctx, `SELECT kind FROM users WHERE id = $1 FOR KEY SHARE`, userID).Scan(&userKind); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if userKind != "human" {
+		return store.AddWorkspaceMemberResult{}, errors.New("only human users can be added with this operation")
+	}
+	rows, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Role:        role,
+		CreatedAt:   now(),
+	})
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	resultRole, err := memberRoleTx(ctx, tx, workspaceID, userID)
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	return store.AddWorkspaceMemberResult{Role: resultRole, Added: rows == 1}, nil
 }
 
 func (s *Store) ListWorkspaceMemberPage(ctx context.Context, workspaceID, actorUserID string, page store.WorkspaceMemberPageRequest) (store.WorkspaceMemberPage, error) {

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -200,6 +200,14 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 	return s.hydrateUserNotificationSettings(ctx, storeUserFromGetUser(row))
 }
 
+func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
+	row, err := s.q.GetUserByIdentityEmail(ctx, strings.ToLower(strings.TrimSpace(email)))
+	if err != nil {
+		return store.User{}, err
+	}
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmail(row))
+}
+
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
 	displayName, handle, avatarURL, err := normalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -203,11 +203,17 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 // Identity rows keep the casing they were created with, so this folds both
 // sides rather than assuming stored addresses are already normalized.
 func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
-	row, err := s.q.GetUserByIdentityEmailFold(ctx, strings.TrimSpace(email))
+	rows, err := s.q.ListUsersByIdentityEmailFold(ctx, strings.TrimSpace(email))
 	if err != nil {
 		return store.User{}, err
 	}
-	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(row))
+	if len(rows) == 0 {
+		return store.User{}, sql.ErrNoRows
+	}
+	if len(rows) > 1 {
+		return store.User{}, store.ErrAmbiguousUserEmail
+	}
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(rows[0]))
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
@@ -487,7 +493,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	if !inserted {
 		return store.Workspace{}, errors.New("could not create workspace route_id after collision retries")
 	}
-	if err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: w.ID,
 		UserID:      ownerID,
 		Role:        "owner",

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -200,12 +200,14 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 	return s.hydrateUserNotificationSettings(ctx, storeUserFromGetUser(row))
 }
 
+// Identity rows keep the casing they were created with, so this folds both
+// sides rather than assuming stored addresses are already normalized.
 func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
-	row, err := s.q.GetUserByIdentityEmail(ctx, strings.ToLower(strings.TrimSpace(email)))
+	row, err := s.q.GetUserByIdentityEmailFold(ctx, strings.TrimSpace(email))
 	if err != nil {
 		return store.User{}, err
 	}
-	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmail(row))
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(row))
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -113,13 +113,13 @@ LIMIT 1;
 -- Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
 -- casing they were created with (admin user create stores the address as
 -- given), so an exact match cannot find them from a normalized lookup.
--- name: GetUserByIdentityEmailFold :one
-SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+-- name: ListUsersByIdentityEmailFold :many
+SELECT DISTINCT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i
 JOIN users u ON u.id = i.user_id
 WHERE lower(i.email) = lower(sqlc.arg(email))
-ORDER BY u.created_at
-LIMIT 1;
+ORDER BY u.created_at, u.id
+LIMIT 2;
 
 -- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
@@ -316,7 +316,7 @@ ORDER BY u.id;
 INSERT INTO invites (id, workspace_id, token, created_by, created_at)
 VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(token), sqlc.arg(created_by), sqlc.arg(created_at));
 
--- name: InsertWorkspaceMember :exec
+-- name: InsertWorkspaceMember :execrows
 INSERT INTO workspace_members (
   workspace_id, user_id, role, created_at, role_sort, sort_name, sort_handle
 )

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -110,6 +110,17 @@ WHERE i.email = sqlc.arg(email)
 ORDER BY u.created_at
 LIMIT 1;
 
+-- Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+-- casing they were created with (admin user create stores the address as
+-- given), so an exact match cannot find them from a normalized lookup.
+-- name: GetUserByIdentityEmailFold :one
+SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower(sqlc.arg(email))
+ORDER BY u.created_at
+LIMIT 1;
+
 -- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/postgres/sqlc_adapters.go
+++ b/apps/api/internal/store/postgres/sqlc_adapters.go
@@ -115,7 +115,7 @@ func storeUserFromIdentityEmail(row storedb.GetUserByIdentityEmailRow) store.Use
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 
-func storeUserFromIdentityEmailFold(row storedb.GetUserByIdentityEmailFoldRow) store.User {
+func storeUserFromIdentityEmailFold(row storedb.ListUsersByIdentityEmailFoldRow) store.User {
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 

--- a/apps/api/internal/store/postgres/sqlc_adapters.go
+++ b/apps/api/internal/store/postgres/sqlc_adapters.go
@@ -115,6 +115,10 @@ func storeUserFromIdentityEmail(row storedb.GetUserByIdentityEmailRow) store.Use
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 
+func storeUserFromIdentityEmailFold(row storedb.GetUserByIdentityEmailFoldRow) store.User {
+	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
+}
+
 func storeUserFromIdentityProviderSubject(row storedb.GetUserByIdentityProviderSubjectRow) store.User {
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1910,43 +1910,6 @@ func (q *Queries) GetUserByIdentityEmail(ctx context.Context, email string) (Get
 	return i, err
 }
 
-const getUserByIdentityEmailFold = `-- name: GetUserByIdentityEmailFold :one
-SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
-FROM identities i
-JOIN users u ON u.id = i.user_id
-WHERE lower(i.email) = lower($1)
-ORDER BY u.created_at
-LIMIT 1
-`
-
-type GetUserByIdentityEmailFoldRow struct {
-	ID          string         `json:"id"`
-	Kind        string         `json:"kind"`
-	OwnerUserID sql.NullString `json:"owner_user_id"`
-	DisplayName string         `json:"display_name"`
-	Handle      string         `json:"handle"`
-	AvatarUrl   string         `json:"avatar_url"`
-	CreatedAt   string         `json:"created_at"`
-}
-
-// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
-// casing they were created with (admin user create stores the address as
-// given), so an exact match cannot find them from a normalized lookup.
-func (q *Queries) GetUserByIdentityEmailFold(ctx context.Context, email string) (GetUserByIdentityEmailFoldRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByIdentityEmailFold, email)
-	var i GetUserByIdentityEmailFoldRow
-	err := row.Scan(
-		&i.ID,
-		&i.Kind,
-		&i.OwnerUserID,
-		&i.DisplayName,
-		&i.Handle,
-		&i.AvatarUrl,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const getUserByIdentityProviderSubject = `-- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i
@@ -2937,7 +2900,7 @@ func (q *Queries) InsertWorkspace(ctx context.Context, arg InsertWorkspaceParams
 	return err
 }
 
-const insertWorkspaceMember = `-- name: InsertWorkspaceMember :exec
+const insertWorkspaceMember = `-- name: InsertWorkspaceMember :execrows
 INSERT INTO workspace_members (
   workspace_id, user_id, role, created_at, role_sort, sort_name, sort_handle
 )
@@ -2966,14 +2929,17 @@ type InsertWorkspaceMemberParams struct {
 	CreatedAt   string `json:"created_at"`
 }
 
-func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspaceMemberParams) error {
-	_, err := q.db.ExecContext(ctx, insertWorkspaceMember,
+func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspaceMemberParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertWorkspaceMember,
 		arg.WorkspaceID,
 		arg.UserID,
 		arg.Role,
 		arg.CreatedAt,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const latestEventCursor = `-- name: LatestEventCursor :one
@@ -4048,6 +4014,59 @@ func (q *Queries) ListThreadStates(ctx context.Context, rootMessageIds []string)
 			&i.ReplyCount,
 			&i.LastReplyAt,
 			&i.LastReplyAuthorIdsJson,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUsersByIdentityEmailFold = `-- name: ListUsersByIdentityEmailFold :many
+SELECT DISTINCT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower($1)
+ORDER BY u.created_at, u.id
+LIMIT 2
+`
+
+type ListUsersByIdentityEmailFoldRow struct {
+	ID          string         `json:"id"`
+	Kind        string         `json:"kind"`
+	OwnerUserID sql.NullString `json:"owner_user_id"`
+	DisplayName string         `json:"display_name"`
+	Handle      string         `json:"handle"`
+	AvatarUrl   string         `json:"avatar_url"`
+	CreatedAt   string         `json:"created_at"`
+}
+
+// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+// casing they were created with (admin user create stores the address as
+// given), so an exact match cannot find them from a normalized lookup.
+func (q *Queries) ListUsersByIdentityEmailFold(ctx context.Context, email string) ([]ListUsersByIdentityEmailFoldRow, error) {
+	rows, err := q.db.QueryContext(ctx, listUsersByIdentityEmailFold, email)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUsersByIdentityEmailFoldRow
+	for rows.Next() {
+		var i ListUsersByIdentityEmailFoldRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kind,
+			&i.OwnerUserID,
+			&i.DisplayName,
+			&i.Handle,
+			&i.AvatarUrl,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1910,6 +1910,43 @@ func (q *Queries) GetUserByIdentityEmail(ctx context.Context, email string) (Get
 	return i, err
 }
 
+const getUserByIdentityEmailFold = `-- name: GetUserByIdentityEmailFold :one
+SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower($1)
+ORDER BY u.created_at
+LIMIT 1
+`
+
+type GetUserByIdentityEmailFoldRow struct {
+	ID          string         `json:"id"`
+	Kind        string         `json:"kind"`
+	OwnerUserID sql.NullString `json:"owner_user_id"`
+	DisplayName string         `json:"display_name"`
+	Handle      string         `json:"handle"`
+	AvatarUrl   string         `json:"avatar_url"`
+	CreatedAt   string         `json:"created_at"`
+}
+
+// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+// casing they were created with (admin user create stores the address as
+// given), so an exact match cannot find them from a normalized lookup.
+func (q *Queries) GetUserByIdentityEmailFold(ctx context.Context, email string) (GetUserByIdentityEmailFoldRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByIdentityEmailFold, email)
+	var i GetUserByIdentityEmailFoldRow
+	err := row.Scan(
+		&i.ID,
+		&i.Kind,
+		&i.OwnerUserID,
+		&i.DisplayName,
+		&i.Handle,
+		&i.AvatarUrl,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getUserByIdentityProviderSubject = `-- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/sqlite/bots.go
+++ b/apps/api/internal/store/sqlite/bots.go
@@ -221,7 +221,7 @@ func (s *Store) CreateBot(ctx context.Context, input store.CreateBotInput) (stor
 		}
 		return store.User{}, store.BotToken{}, err
 	}
-	if err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: workspaceID,
 		UserID:      bot.ID,
 		Role:        "bot",

--- a/apps/api/internal/store/sqlite/members.go
+++ b/apps/api/internal/store/sqlite/members.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
@@ -28,7 +30,7 @@ func (s *Store) AddWorkspaceMember(ctx context.Context, workspaceID, userID, rol
 		  )`, userID).Scan(&one); err != nil {
 		return err
 	}
-	if err := storedb.New(tx).InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := storedb.New(tx).InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: workspaceID,
 		UserID:      userID,
 		Role:        normalizeWorkspaceRole(role),
@@ -37,6 +39,83 @@ func (s *Store) AddWorkspaceMember(ctx context.Context, workspaceID, userID, rol
 		return err
 	}
 	return tx.Commit()
+}
+
+func (s *Store) AddWorkspaceMemberByActor(ctx context.Context, input store.AddWorkspaceMemberInput) (store.AddWorkspaceMemberResult, error) {
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	userID := strings.TrimSpace(input.UserID)
+	actorUserID := strings.TrimSpace(input.ActorUserID)
+	role := strings.TrimSpace(input.Role)
+	if workspaceID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("workspace is required")
+	}
+	if userID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("user is required")
+	}
+	if actorUserID == "" {
+		return store.AddWorkspaceMemberResult{}, errors.New("actor user is required")
+	}
+	if role == "" {
+		role = store.WorkspaceRoleMember
+	}
+	if role != store.WorkspaceRoleMember && role != store.WorkspaceRoleModerator {
+		return store.AddWorkspaceMemberResult{}, fmt.Errorf("role %q cannot be assigned when adding a workspace member", role)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	defer tx.Rollback()
+	qtx := storedb.New(tx)
+	roleRows, err := qtx.MembershipRolesForUpdate(ctx, storedb.MembershipRolesForUpdateParams{
+		WorkspaceID:  workspaceID,
+		ActorUserID:  actorUserID,
+		TargetUserID: userID,
+	})
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	actorRole := ""
+	for _, row := range roleRows {
+		if row.UserID == actorUserID {
+			actorRole = row.Role
+			break
+		}
+	}
+	if actorRole != store.WorkspaceRoleOwner && actorRole != store.WorkspaceRoleModerator {
+		return store.AddWorkspaceMemberResult{}, store.ErrNotWorkspaceManager
+	}
+	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, actorUserID); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if role == store.WorkspaceRoleModerator && actorRole != store.WorkspaceRoleOwner {
+		return store.AddWorkspaceMemberResult{}, store.ErrWorkspaceOwnerRequired
+	}
+	var userKind string
+	if err := tx.QueryRowContext(ctx, `SELECT kind FROM users WHERE id = ?`, userID).Scan(&userKind); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if userKind != "human" {
+		return store.AddWorkspaceMemberResult{}, errors.New("only human users can be added with this operation")
+	}
+	rows, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		Role:        role,
+		CreatedAt:   now(),
+	})
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	resultRole, err := memberRoleTx(ctx, tx, workspaceID, userID)
+	if err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return store.AddWorkspaceMemberResult{}, err
+	}
+	return store.AddWorkspaceMemberResult{Role: resultRole, Added: rows == 1}, nil
 }
 
 func (s *Store) ListWorkspaceMemberPage(ctx context.Context, workspaceID, actorUserID string, page store.WorkspaceMemberPageRequest) (store.WorkspaceMemberPage, error) {

--- a/apps/api/internal/store/sqlite/members_test.go
+++ b/apps/api/internal/store/sqlite/members_test.go
@@ -331,6 +331,130 @@ func TestWorkspaceMemberPageMigrationsUpgradeExistingData(t *testing.T) {
 	}
 }
 
+func TestAddWorkspaceMemberByActorEnforcesRolesAndInsertOutcome(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	st := newTestStore(t)
+
+	owner, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Owner", Email: "member-add-owner@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultWorkspaceMember(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	moderator, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Moderator", Email: "member-add-moderator@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, moderator.ID, store.WorkspaceRoleModerator); err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "member-add-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	guest, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Guest", Email: "member-add-guest@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, guest.ID, store.WorkspaceRoleGuest); err != nil {
+		t.Fatal(err)
+	}
+	firstTarget, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "First Target", Email: "member-add-first@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTarget, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Second Target", Email: "member-add-second@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, actor := range []store.User{member, guest} {
+		_, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+			WorkspaceID: workspace.ID,
+			UserID:      firstTarget.ID,
+			ActorUserID: actor.ID,
+			Role:        store.WorkspaceRoleMember,
+		})
+		if !errors.Is(err, store.ErrNotWorkspaceManager) {
+			t.Fatalf("expected %s to be denied, got %v", actor.DisplayName, err)
+		}
+	}
+	if _, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      firstTarget.ID,
+		ActorUserID: moderator.ID,
+		Role:        store.WorkspaceRoleModerator,
+	}); !errors.Is(err, store.ErrWorkspaceOwnerRequired) {
+		t.Fatalf("expected moderator assignment to require owner, got %v", err)
+	}
+	first, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      firstTarget.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleModerator,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Added || first.Role != store.WorkspaceRoleModerator {
+		t.Fatalf("unexpected first insert result: %#v", first)
+	}
+	replay, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      firstTarget.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleMember,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replay.Added || replay.Role != store.WorkspaceRoleModerator {
+		t.Fatalf("idempotent add changed or misreported the role: %#v", replay)
+	}
+	second, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      secondTarget.ID,
+		ActorUserID: moderator.ID,
+		Role:        store.WorkspaceRoleMember,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.Added || second.Role != store.WorkspaceRoleMember {
+		t.Fatalf("moderator could not add a member: %#v", second)
+	}
+	if _, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      secondTarget.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleOwner,
+	}); err == nil {
+		t.Fatal("owner role was accepted outside the ownership-transfer flow")
+	}
+
+	if _, err := st.db.ExecContext(ctx, `DELETE FROM workspace_members WHERE workspace_id = ? AND user_id = ?`, workspace.ID, firstTarget.ID); err != nil {
+		t.Fatal(err)
+	}
+	readded, err := st.AddWorkspaceMemberByActor(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: workspace.ID,
+		UserID:      firstTarget.ID,
+		ActorUserID: owner.ID,
+		Role:        store.WorkspaceRoleMember,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !readded.Added || readded.Role != store.WorkspaceRoleMember {
+		t.Fatalf("re-add restored a stale privileged role: %#v", readded)
+	}
+}
+
 func memberNames(members []store.WorkspaceMember) []string {
 	names := make([]string, 0, len(members))
 	for _, member := range members {

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -111,13 +111,13 @@ LIMIT 1;
 -- Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
 -- casing they were created with (admin user create stores the address as
 -- given), so an exact match cannot find them from a normalized lookup.
--- name: GetUserByIdentityEmailFold :one
-SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+-- name: ListUsersByIdentityEmailFold :many
+SELECT DISTINCT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i
 JOIN users u ON u.id = i.user_id
 WHERE lower(i.email) = lower(sqlc.arg(email))
-ORDER BY u.created_at
-LIMIT 1;
+ORDER BY u.created_at, u.id
+LIMIT 2;
 
 -- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
@@ -317,7 +317,7 @@ ORDER BY u.id;
 INSERT INTO invites (id, workspace_id, token, created_by, created_at)
 VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(token), sqlc.arg(created_by), sqlc.arg(created_at));
 
--- name: InsertWorkspaceMember :exec
+-- name: InsertWorkspaceMember :execrows
 INSERT OR IGNORE INTO workspace_members (
   workspace_id, user_id, role, created_at, role_sort, sort_name, sort_handle
 )

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -108,6 +108,17 @@ WHERE i.email = sqlc.arg(email)
 ORDER BY u.created_at
 LIMIT 1;
 
+-- Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+-- casing they were created with (admin user create stores the address as
+-- given), so an exact match cannot find them from a normalized lookup.
+-- name: GetUserByIdentityEmailFold :one
+SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower(sqlc.arg(email))
+ORDER BY u.created_at
+LIMIT 1;
+
 -- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/sqlite/sqlc_adapters.go
+++ b/apps/api/internal/store/sqlite/sqlc_adapters.go
@@ -115,7 +115,7 @@ func storeUserFromIdentityEmail(row storedb.GetUserByIdentityEmailRow) store.Use
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 
-func storeUserFromIdentityEmailFold(row storedb.GetUserByIdentityEmailFoldRow) store.User {
+func storeUserFromIdentityEmailFold(row storedb.ListUsersByIdentityEmailFoldRow) store.User {
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 

--- a/apps/api/internal/store/sqlite/sqlc_adapters.go
+++ b/apps/api/internal/store/sqlite/sqlc_adapters.go
@@ -115,6 +115,10 @@ func storeUserFromIdentityEmail(row storedb.GetUserByIdentityEmailRow) store.Use
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }
 
+func storeUserFromIdentityEmailFold(row storedb.GetUserByIdentityEmailFoldRow) store.User {
+	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
+}
+
 func storeUserFromIdentityProviderSubject(row storedb.GetUserByIdentityProviderSubjectRow) store.User {
 	return storeUserFromDB(row.ID, row.Kind, row.OwnerUserID, row.DisplayName, row.Handle, row.AvatarUrl, row.CreatedAt)
 }

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -217,11 +217,17 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 // Identity rows keep the casing they were created with, so this folds both
 // sides rather than assuming stored addresses are already normalized.
 func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
-	row, err := s.q.GetUserByIdentityEmailFold(ctx, strings.TrimSpace(email))
+	rows, err := s.q.ListUsersByIdentityEmailFold(ctx, strings.TrimSpace(email))
 	if err != nil {
 		return store.User{}, err
 	}
-	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(row))
+	if len(rows) == 0 {
+		return store.User{}, sql.ErrNoRows
+	}
+	if len(rows) > 1 {
+		return store.User{}, store.ErrAmbiguousUserEmail
+	}
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(rows[0]))
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
@@ -501,7 +507,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	if !inserted {
 		return store.Workspace{}, errors.New("could not create workspace route_id after collision retries")
 	}
-	if err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
+	if _, err := qtx.InsertWorkspaceMember(ctx, storedb.InsertWorkspaceMemberParams{
 		WorkspaceID: w.ID,
 		UserID:      ownerID,
 		Role:        "owner",

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -214,6 +214,14 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 	return s.hydrateUserNotificationSettings(ctx, storeUserFromGetUser(row))
 }
 
+func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
+	row, err := s.q.GetUserByIdentityEmail(ctx, strings.ToLower(strings.TrimSpace(email)))
+	if err != nil {
+		return store.User{}, err
+	}
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmail(row))
+}
+
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
 	displayName, handle, avatarURL, err := normalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -214,12 +214,14 @@ func (s *Store) GetUser(ctx context.Context, id string) (store.User, error) {
 	return s.hydrateUserNotificationSettings(ctx, storeUserFromGetUser(row))
 }
 
+// Identity rows keep the casing they were created with, so this folds both
+// sides rather than assuming stored addresses are already normalized.
 func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, error) {
-	row, err := s.q.GetUserByIdentityEmail(ctx, strings.ToLower(strings.TrimSpace(email)))
+	row, err := s.q.GetUserByIdentityEmailFold(ctx, strings.TrimSpace(email))
 	if err != nil {
 		return store.User{}, err
 	}
-	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmail(row))
+	return s.hydrateUserNotificationSettings(ctx, storeUserFromIdentityEmailFold(row))
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1902,43 +1902,6 @@ func (q *Queries) GetUserByIdentityEmail(ctx context.Context, email string) (Get
 	return i, err
 }
 
-const getUserByIdentityEmailFold = `-- name: GetUserByIdentityEmailFold :one
-SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
-FROM identities i
-JOIN users u ON u.id = i.user_id
-WHERE lower(i.email) = lower(?1)
-ORDER BY u.created_at
-LIMIT 1
-`
-
-type GetUserByIdentityEmailFoldRow struct {
-	ID          string         `json:"id"`
-	Kind        string         `json:"kind"`
-	OwnerUserID sql.NullString `json:"owner_user_id"`
-	DisplayName string         `json:"display_name"`
-	Handle      string         `json:"handle"`
-	AvatarUrl   string         `json:"avatar_url"`
-	CreatedAt   string         `json:"created_at"`
-}
-
-// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
-// casing they were created with (admin user create stores the address as
-// given), so an exact match cannot find them from a normalized lookup.
-func (q *Queries) GetUserByIdentityEmailFold(ctx context.Context, email string) (GetUserByIdentityEmailFoldRow, error) {
-	row := q.db.QueryRowContext(ctx, getUserByIdentityEmailFold, email)
-	var i GetUserByIdentityEmailFoldRow
-	err := row.Scan(
-		&i.ID,
-		&i.Kind,
-		&i.OwnerUserID,
-		&i.DisplayName,
-		&i.Handle,
-		&i.AvatarUrl,
-		&i.CreatedAt,
-	)
-	return i, err
-}
-
 const getUserByIdentityProviderSubject = `-- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i
@@ -2928,7 +2891,7 @@ func (q *Queries) InsertWorkspace(ctx context.Context, arg InsertWorkspaceParams
 	return err
 }
 
-const insertWorkspaceMember = `-- name: InsertWorkspaceMember :exec
+const insertWorkspaceMember = `-- name: InsertWorkspaceMember :execrows
 INSERT OR IGNORE INTO workspace_members (
   workspace_id, user_id, role, created_at, role_sort, sort_name, sort_handle
 )
@@ -2956,14 +2919,17 @@ type InsertWorkspaceMemberParams struct {
 	CreatedAt   string `json:"created_at"`
 }
 
-func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspaceMemberParams) error {
-	_, err := q.db.ExecContext(ctx, insertWorkspaceMember,
+func (q *Queries) InsertWorkspaceMember(ctx context.Context, arg InsertWorkspaceMemberParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, insertWorkspaceMember,
 		arg.WorkspaceID,
 		arg.UserID,
 		arg.Role,
 		arg.CreatedAt,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const latestEventCursor = `-- name: LatestEventCursor :one
@@ -3964,6 +3930,59 @@ func (q *Queries) ListThreadStates(ctx context.Context, rootMessageIds []string)
 			&i.ReplyCount,
 			&i.LastReplyAt,
 			&i.LastReplyAuthorIdsJson,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUsersByIdentityEmailFold = `-- name: ListUsersByIdentityEmailFold :many
+SELECT DISTINCT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower(?1)
+ORDER BY u.created_at, u.id
+LIMIT 2
+`
+
+type ListUsersByIdentityEmailFoldRow struct {
+	ID          string         `json:"id"`
+	Kind        string         `json:"kind"`
+	OwnerUserID sql.NullString `json:"owner_user_id"`
+	DisplayName string         `json:"display_name"`
+	Handle      string         `json:"handle"`
+	AvatarUrl   string         `json:"avatar_url"`
+	CreatedAt   string         `json:"created_at"`
+}
+
+// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+// casing they were created with (admin user create stores the address as
+// given), so an exact match cannot find them from a normalized lookup.
+func (q *Queries) ListUsersByIdentityEmailFold(ctx context.Context, email string) ([]ListUsersByIdentityEmailFoldRow, error) {
+	rows, err := q.db.QueryContext(ctx, listUsersByIdentityEmailFold, email)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListUsersByIdentityEmailFoldRow
+	for rows.Next() {
+		var i ListUsersByIdentityEmailFoldRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kind,
+			&i.OwnerUserID,
+			&i.DisplayName,
+			&i.Handle,
+			&i.AvatarUrl,
+			&i.CreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1902,6 +1902,43 @@ func (q *Queries) GetUserByIdentityEmail(ctx context.Context, email string) (Get
 	return i, err
 }
 
+const getUserByIdentityEmailFold = `-- name: GetUserByIdentityEmailFold :one
+SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
+FROM identities i
+JOIN users u ON u.id = i.user_id
+WHERE lower(i.email) = lower(?1)
+ORDER BY u.created_at
+LIMIT 1
+`
+
+type GetUserByIdentityEmailFoldRow struct {
+	ID          string         `json:"id"`
+	Kind        string         `json:"kind"`
+	OwnerUserID sql.NullString `json:"owner_user_id"`
+	DisplayName string         `json:"display_name"`
+	Handle      string         `json:"handle"`
+	AvatarUrl   string         `json:"avatar_url"`
+	CreatedAt   string         `json:"created_at"`
+}
+
+// Case-insensitive twin of GetUserByIdentityEmail. Identity rows keep the
+// casing they were created with (admin user create stores the address as
+// given), so an exact match cannot find them from a normalized lookup.
+func (q *Queries) GetUserByIdentityEmailFold(ctx context.Context, email string) (GetUserByIdentityEmailFoldRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByIdentityEmailFold, email)
+	var i GetUserByIdentityEmailFoldRow
+	err := row.Scan(
+		&i.ID,
+		&i.Kind,
+		&i.OwnerUserID,
+		&i.DisplayName,
+		&i.Handle,
+		&i.AvatarUrl,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getUserByIdentityProviderSubject = `-- name: GetUserByIdentityProviderSubject :one
 SELECT u.id, u.kind, u.owner_user_id, u.display_name, u.handle, u.avatar_url, u.created_at
 FROM identities i

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -146,6 +146,11 @@ var ErrNotWorkspaceManager = errors.New("workspace manager permission required")
 // current owner, not just a moderator.
 var ErrWorkspaceOwnerRequired = errors.New("workspace owner permission required")
 
+// ErrAmbiguousUserEmail is returned when a case-insensitive identity email
+// lookup resolves to more than one user. Callers must use an unambiguous user
+// ID rather than guessing which account should receive access.
+var ErrAmbiguousUserEmail = errors.New("multiple users have this identity email")
+
 // ErrBotOwnerRequired is returned when a user-owned bot operation is attempted
 // by someone other than the bot owner.
 var ErrBotOwnerRequired = errors.New("only the bot owner can manage this bot")
@@ -351,6 +356,18 @@ type Event struct {
 type CreateUserInput struct {
 	DisplayName string
 	Email       string
+}
+
+type AddWorkspaceMemberInput struct {
+	WorkspaceID string
+	UserID      string
+	ActorUserID string
+	Role        string
+}
+
+type AddWorkspaceMemberResult struct {
+	Role  string
+	Added bool
 }
 
 type CreateBotInput struct {
@@ -1190,6 +1207,7 @@ type Store interface {
 	UpsertChannelNotificationSettings(ctx context.Context, input ChannelNotificationInput) error
 	GetChannelNotificationPreference(ctx context.Context, channelID, userID string) (string, error)
 	AddWorkspaceMember(ctx context.Context, workspaceID, userID, role string) error
+	AddWorkspaceMemberByActor(ctx context.Context, input AddWorkspaceMemberInput) (AddWorkspaceMemberResult, error)
 	EnsureDefaultWorkspaceMember(ctx context.Context, userID string) (Workspace, error)
 	EnsureDefaultGuestWorkspaceMember(ctx context.Context, userID, role string) (Workspace, error)
 	ListWorkspaceMemberPage(ctx context.Context, workspaceID, actorUserID string, page WorkspaceMemberPageRequest) (WorkspaceMemberPage, error)

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -1203,6 +1203,7 @@ type Store interface {
 	ReleaseUploadQuotaReservation(ctx context.Context, reservationID, userID string) error
 	FirstUser(ctx context.Context) (User, error)
 	GetUser(ctx context.Context, id string) (User, error)
+	GetUserByEmail(ctx context.Context, email string) (User, error)
 	ListWorkspaces(ctx context.Context, userID string) ([]Workspace, error)
 	CreateWorkspace(ctx context.Context, input CreateWorkspaceInput, ownerID string) (Workspace, error)
 	GetWorkspace(ctx context.Context, workspaceID, userID string) (Workspace, error)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ clickclack <command> [flags]
 Commands:
   serve      run the HTTP/WebSocket server (default if no command given)
   migrate    apply embedded SQL migrations
-  admin      bootstrap, FakeCo seed, user create, invite create, bot create, events prune, magic-link create
+  admin      bootstrap, FakeCo seed, user create, member add, invite create, bot create, events prune, magic-link create
   backup     write a SQLite backup file
   export     write a JSON dump to a file or stdout
   login      consume a magic-link token and store/print a session token
@@ -115,6 +115,17 @@ clickclack admin user create --name "Ari" --email ari@example.com [--workspace w
 
 Creates a user. With `--workspace`, also adds them to that workspace as a
 `member`. Prints the new user ID.
+
+### `admin member add`
+
+```sh
+clickclack admin member add --workspace wsp_... --email ari@example.com [--role member]
+```
+
+Adds an existing user to a workspace as a `member`, `moderator`, or `owner`.
+Existing memberships succeed without changing their role. Prints the workspace
+ID, user ID, resulting role, and whether the membership was added or already
+present.
 
 ### `admin fakeco seed`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,13 +119,21 @@ Creates a user. With `--workspace`, also adds them to that workspace as a
 ### `admin member add`
 
 ```sh
-clickclack admin member add --workspace wsp_... --email ari@example.com [--role member]
+clickclack admin member add \
+  --workspace wsp_... \
+  --created-by usr_manager \
+  --email ari@example.com \
+  [--role member]
 ```
 
-Adds an existing user to a workspace as a `member`, `moderator`, or `owner`.
-Existing memberships succeed without changing their role. Prints the workspace
-ID, user ID, resulting role, and whether the membership was added or already
-present.
+Adds an existing human user to a workspace as a `member`, or as a `moderator`
+when `--created-by` identifies the workspace owner. Workspace moderators may
+add members; ordinary members and guests may not add anyone. Existing
+memberships succeed without changing their role. Use `--user usr_...` instead
+of `--email` when multiple identities share an email address. Prints the
+workspace ID, user ID, resulting role, and whether the membership was added or
+already present. Ownership changes continue to use the dedicated transfer
+operation.
 
 ### `admin fakeco seed`
 

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -26,8 +26,11 @@ GET  /api/workspaces/{workspace_id}/members   # paginated public member director
 form of `name` and must be unique.
 
 The owner who creates the workspace is auto-added with role `owner`. Adding
-other members today goes through auth/bootstrap flows or admin commands; the
-HTTP API exposes moderation for existing members, not arbitrary invites.
+other members today goes through auth/bootstrap flows or the admin CLI. The
+admin CLI requires an existing owner or moderator actor, enforces that role in
+the store transaction, and reserves ownership changes for the dedicated
+transfer flow. The HTTP API exposes moderation for existing members, not
+arbitrary invites.
 
 Owners and moderators can update the workspace name, slug, and icon. An icon
 must reference an upload from the same workspace. Owners can transfer ownership


### PR DESCRIPTION
## What Problem This Solves

An operator running a self-hosted deployment cannot add an existing person to a second workspace. Membership can only be created three ways today: bootstrap, SSO auto-provisioning (which always joins the default workspace), and `admin user create --workspace`, which only works for users who do not exist yet. Anyone who has already signed in — which, with trusted-proxy SSO, is everyone — can never be added to another workspace.

The practical effect is that a second workspace works with exactly one human in it and cannot grow. In our deployment we wanted one workspace per OpenClaw agent so that different operators are isolated from each other, and hit this wall immediately.

## Why This Change Was Made

`admin member add` resolves an existing user by normalized identity email and adds them to a workspace as `member`, `moderator`, or `owner`. It is the symmetric counterpart to `admin user create --workspace`, which already calls `AddWorkspaceMember` for brand-new users.

Two deliberate boundaries:

- **CLI only.** `docs/features/workspaces.md` lists "arbitrary HTTP member invites/additions" under *What is intentionally missing*, so this adds no HTTP route or handler and leaves that position untouched.
- **Never mutates an existing membership.** Both backends already insert with `INSERT OR IGNORE` / `ON CONFLICT DO NOTHING`, so re-running the command reports `already_member` and preserves the current role. Running it with `--role owner` against someone who is already a `member` cannot promote them, and the reverse cannot demote an owner. `guest` and `bot` are rejected because those shapes are managed by the moderation and bot-install flows.

The only store addition is `GetUserByEmail`, a thin wrapper over the existing generated `GetUserByIdentityEmail` query, implemented for both sqlite and postgres. No sqlc regeneration was needed and no generated code was edited.

## User Impact

Operators can grow a workspace beyond its first member:

```sh
clickclack admin member add --workspace wsp_... --email ari@example.com
clickclack admin member add --workspace wsp_... --email ari@example.com --role moderator
```

The command prints the workspace id, user id, resulting role, and whether the membership was `added` or `already_member`. An unknown email returns an actionable error pointing at `admin user create --workspace`. Documented in `docs/cli.md`.

## Evidence

Five tests in `apps/api/cmd/clickclack/main_test.go`, following the existing `TestAdminBotCreate*` patterns against a real sqlite store:

- `TestAdminMemberAddAddsExistingUserToSecondWorkspace` — the happy path, asserting both memberships afterwards
- `TestAdminMemberAddRejectsUnknownEmail` — asserts the guidance toward `admin user create`
- `TestAdminMemberAddValidatesRequiredFlagsBeforeOpeningDatabase` — asserts no database file is created when a required flag is missing, matching the convention `TestAdminBotCreateValidatesActorBeforeOpeningDatabase` establishes
- `TestAdminMemberAddRejectsInvalidRole`
- `TestAdminMemberAddIsIdempotentForExistingMember` — adds an existing `member` with `--role owner` and asserts the role is unchanged and the status is `already_member`

```
$ gofmt -l apps/api
(no output)

$ go test ./apps/api/cmd/...
ok  	github.com/openclaw/clickclack/apps/api/cmd/clickclack	0.741s

$ go test ./apps/api/internal/store/...
ok  	github.com/openclaw/clickclack/apps/api/internal/store	0.003s
ok  	github.com/openclaw/clickclack/apps/api/internal/store/postgres	0.007s
ok  	github.com/openclaw/clickclack/apps/api/internal/store/sqlite	12.220s
```

The postgres implementation compiles and its package tests pass, but the new lookup was not exercised against a live postgres instance. Happy to adjust the shape if you would rather this land as invite-token consumption instead.
