### PR TITLE
build: move Go floor to 1.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Updated the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
+
 ## v0.3.0 - 2026-08-13
 
 **Highlight:** conversations get real organization — topics with filtered

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY packages packages
 COPY scripts scripts
 RUN pnpm build
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS api
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS api
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.cloudflare
+++ b/Dockerfile.cloudflare
@@ -13,7 +13,7 @@ COPY packages packages
 COPY scripts scripts
 RUN pnpm build
 
-FROM golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS api
+FROM golang:1.26.6-alpine@sha256:af8d6740070b8906d12eae1c3e3ea0957fb63f492051ea05e354c38ef9fe88df AS api
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The complete documentation is at **[docs.clickclack.chat](https://docs.clickclac
 
 ## Development
 
-Source builds require Go 1.26.5, Node.js 24 or newer, and pnpm 11.20.0.
+Source builds require Go 1.26.6, Node.js 24 or newer, and pnpm 11.20.0.
 
 ```sh
 pnpm install --frozen-lockfile

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -80,7 +80,7 @@ docker run --rm -p 8080:8080 -v clickclack-data:/app/data clickclack
 Stages:
 
 1. `node:24-alpine` — installs pnpm dependencies and runs `pnpm build`.
-2. `golang:1.26.5-alpine` — builds the Go binary, importing the SPA dist.
+2. `golang:1.26.6-alpine` — builds the Go binary, importing the SPA dist.
 3. `alpine:3.23` — runtime image, runs as the `clickclack` user, exposes
    `8080`, mounts `/app/data` as a volume.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openclaw/clickclack
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/coder/websocket v1.8.15


### PR DESCRIPTION
Raises the minimum Go toolchain and active build documentation to 1.26.6, and pins both production Docker build paths to the fresh 1.26.6-alpine manifest digest. This clears GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218. Verified with the exact Go 1.26.6 build and test suite, a live local server health/readiness/app smoke, and both Docker API build stages.