### PR TITLE
refactor(httpapi): drop two unreachable request-helper functions

### DIFF
--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1437,10 +1437,6 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func websocketBearerToken(r *http.Request) string {
-	return strings.TrimPrefix(websocketBearerProtocol(r), websocketBearerProtocolPrefix)
-}
-
 func websocketBearerProtocol(r *http.Request) string {
 	for _, protocol := range strings.Split(r.Header.Get("Sec-WebSocket-Protocol"), ",") {
 		protocol = strings.TrimSpace(protocol)
@@ -1845,14 +1841,6 @@ func optionalString(value string) *string {
 
 func queryInt(r *http.Request, key string, fallback int) int {
 	value, err := strconv.Atoi(r.URL.Query().Get(key))
-	if err != nil {
-		return fallback
-	}
-	return value
-}
-
-func queryInt64(r *http.Request, key string, fallback int64) int64 {
-	value, err := strconv.ParseInt(r.URL.Query().Get(key), 10, 64)
 	if err != nil {
 		return fallback
 	}

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -3711,19 +3711,9 @@ func TestUploadRejectsInvalidMultipartShapes(t *testing.T) {
 
 func TestQueryHelpersParseValues(t *testing.T) {
 	t.Parallel()
-	req := httptest.NewRequest(http.MethodGet, "/?limit=42&after_seq=123", nil)
+	req := httptest.NewRequest(http.MethodGet, "/?limit=42", nil)
 	if got := queryInt(req, "limit", 10); got != 42 {
 		t.Fatalf("unexpected int query value %d", got)
-	}
-	if got := queryInt64(req, "after_seq", 10); got != 123 {
-		t.Fatalf("unexpected int64 query value %d", got)
-	}
-	req = httptest.NewRequest(http.MethodGet, "/?after_seq=bad", nil)
-	if got := queryInt64(req, "after_seq", 10); got != 10 {
-		t.Fatalf("unexpected fallback int64 query value %d", got)
-	}
-	if got := websocketBearerToken(httptest.NewRequest(http.MethodGet, "/", nil)); got != "" {
-		t.Fatalf("unexpected bearer token %q", got)
 	}
 	server := New(nil, nil, Options{GitHubOAuth: GitHubOAuthConfig{PublicURL: "https://app.clickclack.test/path"}})
 	patterns := server.websocketOriginPatterns(httptest.NewRequest(http.MethodGet, "/", nil))


### PR DESCRIPTION
## What Problem This Solves

Two unexported helper functions in `apps/api/internal/httpapi/server.go` are unreachable from any production code path and exist only to be exercised by their own unit tests. This is dead code that carries a false sense of coverage: the tests pass, but they protect no behavior a running server ever reaches.

- `websocketBearerToken` duplicates logic the `websocket()` handler already performs **inline** (`server.go:1296-1300`): it calls the live `websocketBearerProtocol(r)` and trims `websocketBearerProtocolPrefix`. The handler never calls the wrapper — it needs the raw protocol string first for a presence check, so it inlines the trim. The wrapper's only caller is `TestQueryHelpersParseValues`.
- `queryInt64` is a dead `int64` sibling of the live `queryInt`. The only `int64` query values in the server are the message-page cursors (`before_seq` / `after_seq` / `around_seq`), and `parseMessagePageRequest` parses those **inline** with `strconv.ParseInt` plus required / non-negative / mutual-exclusion validation. `queryInt64`'s silent fallback-on-error semantics would be wrong for those cursors, so nothing uses it; its only callers are two assertions in `TestQueryHelpersParseValues`.

## Why This Change Was Made

Debt cleanup (family: dead-code removal). Delete both unreachable helpers and the three test-only assertions that kept them alive, leaving the live helpers `queryInt` and `websocketOriginPatterns` (and their assertions in the same test) untouched. Behavior-preserving, single production file, net **−22** lines (−12 production, −10 test). No new symbols, config, or dependencies.

## User Impact

None. No runtime, HTTP, CLI, config, or public-API behavior changes — the removed functions were reachable from nothing at runtime (they are unexported and live in an `internal/` package, so they are not importable from outside the module either).

## Evidence

Branched off current `main` (`93ff8e2`), Linux, Go 1.26.5.

**Dead-code proof** — the official reachability analyzer (`golang.org/x/tools/cmd/deadcode`) flagged both functions as unreachable from the `clickclack` binary on clean `main`:

```text
$ deadcode ./apps/api/cmd/clickclack/
apps/api/internal/httpapi/server.go:1440:6: unreachable func: websocketBearerToken
apps/api/internal/httpapi/server.go:1854:6: unreachable func: queryInt64
...
```

A whole-module `grep` confirms the only non-definition references to each are in `server_test.go` (no production caller).

**After the change** — `deadcode` no longer reports either function, and no new unreachable functions were introduced.

**Build + tests green** on this branch:

```text
$ go build ./...                                   # exit 0
$ go vet ./apps/api/internal/httpapi/              # exit 0
$ go test ./apps/api/internal/httpapi/
ok  	github.com/openclaw/clickclack/apps/api/internal/httpapi	11.432s
$ gofmt -l apps/api/internal/httpapi/server.go apps/api/internal/httpapi/server_test.go   # empty
```

The live helpers this touches near — `queryInt` and `websocketOriginPatterns` — retain their coverage in `TestQueryHelpersParseValues`; only the two dead helpers' assertions were removed.

_AI-assisted contribution._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoUkshodx8mLu6x94QDFKD)_