### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.3.1 - 2026-08-14
 
 - Updated the minimum Go toolchain to 1.26.6 to resolve GO-2026-5026, GO-2026-5972, GO-2026-6090, and GO-2026-6218.
 


### PR DESCRIPTION
Stamps the changelog for v0.3.1 (Go 1.26.6 toolchain floor — ships the patched stdlib in released binaries).