### PR TITLE
fix(docs): preserve complete heading text in generated navigation

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -426,16 +426,35 @@ function tocFromHtml(html) {
   const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
   let m;
   while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
+    const text = htmlTextContent(m[3]).trim();
     items.push({ level: Number(m[1]), id: m[2], text });
   }
   if (items.length < 2) return "";
   return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
     .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.text)}</a>`)
     .join("")}</nav>`;
+}
+
+function htmlTextContent(html) {
+  let text = "";
+  let skipAnchor = false;
+  for (let index = 0; index < html.length; ) {
+    if (html[index] !== "<") {
+      if (!skipAnchor) text += html[index];
+      index += 1;
+      continue;
+    }
+    const tagEnd = html.indexOf(">", index + 1);
+    if (tagEnd < 0) break;
+    const tag = html.slice(index + 1, tagEnd).trim();
+    if (tag.startsWith('a class="anchor"')) {
+      skipAnchor = true;
+    } else if (tag === "/a" && skipAnchor) {
+      skipAnchor = false;
+    }
+    index = tagEnd + 1;
+  }
+  return text;
 }
 
 function isHomePage(page) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where generated documentation navigation derived heading text through repeated regex replacement, creating an incomplete multi-character sanitization path reported by [CodeQL alert 9](https://github.com/openclaw/clickclack/security/code-scanning/9).

## Why This Change Was Made

TOC extraction now scans rendered heading markup once, ignores generated anchor contents, and preserves text content without chained multi-character replacement. The docs builder remains dependency-free.

## User Impact

Generated documentation navigation keeps complete heading text while excluding the heading-link marker.

## Evidence

- `node --check scripts/build-docs-site.mjs`
- `node scripts/build-docs-site.mjs`
- Inspected generated TOCs in `dist/docs-site`; headings render without anchor markers.
- Production/tooling LOC: +23/-4. The positive delta establishes a deterministic parsing boundary without adding a runtime dependency.

