### PR TITLE
fix(api): bound pagination integers and allocations

### DIFF
--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -127,14 +127,14 @@ func parseSearchPageRequest(r *http.Request, userID string) (store.SearchPageReq
 	values := r.URL.Query()
 	limit := 0
 	if rawLimit := strings.TrimSpace(values.Get("limit")); rawLimit != "" {
-		parsed, err := strconv.Atoi(rawLimit)
+		parsed, err := strconv.ParseInt(rawLimit, 10, 32)
 		if err != nil {
 			return store.SearchPageRequest{}, fmt.Errorf("%w: limit must be an integer", store.ErrInvalidSearch)
 		}
 		if parsed <= 0 {
 			return store.SearchPageRequest{}, fmt.Errorf("%w: limit must be positive", store.ErrInvalidSearch)
 		}
-		limit = parsed
+		limit = int(parsed)
 	}
 	return store.SearchPageRequest{
 		WorkspaceID:          values.Get("workspace_id"),

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -763,11 +763,11 @@ func parseWorkspaceMemberPageRequest(r *http.Request) (store.WorkspaceMemberPage
 		Role:   values.Get("role"),
 	}
 	if rawLimit := strings.TrimSpace(values.Get("limit")); rawLimit != "" {
-		limit, err := strconv.Atoi(rawLimit)
+		limit, err := strconv.ParseInt(rawLimit, 10, 32)
 		if err != nil || limit < 1 {
 			return page, fmt.Errorf("%w: limit must be positive", store.ErrInvalidWorkspaceMemberPage)
 		}
-		page.Limit = limit
+		page.Limit = int(limit)
 	}
 	return page, nil
 }
@@ -1845,11 +1845,11 @@ func optionalString(value string) *string {
 }
 
 func queryInt(r *http.Request, key string, fallback int) int {
-	value, err := strconv.Atoi(r.URL.Query().Get(key))
+	value, err := strconv.ParseInt(r.URL.Query().Get(key), 10, 32)
 	if err != nil {
 		return fallback
 	}
-	return value
+	return int(value)
 }
 
 func parseMessagePageRequest(r *http.Request) (store.MessagePageRequest, error) {

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -3711,9 +3711,28 @@ func TestUploadRejectsInvalidMultipartShapes(t *testing.T) {
 
 func TestQueryHelpersParseValues(t *testing.T) {
 	t.Parallel()
-	req := httptest.NewRequest(http.MethodGet, "/?limit=42", nil)
-	if got := queryInt(req, "limit", 10); got != 42 {
-		t.Fatalf("unexpected int query value %d", got)
+	for _, test := range []struct {
+		name  string
+		value string
+		want  int
+	}{
+		{name: "missing", want: 10},
+		{name: "invalid", value: "bad", want: 10},
+		{name: "minimum database integer", value: "-2147483648", want: -2147483648},
+		{name: "negative", value: "-1", want: -1},
+		{name: "zero", value: "0", want: 0},
+		{name: "positive", value: "42", want: 42},
+		{name: "maximum database integer", value: "2147483647", want: 2147483647},
+		{name: "above database integer", value: "2147483648", want: 10},
+		{name: "below database integer", value: "-2147483649", want: 10},
+		{name: "maximum 64-bit integer", value: "9223372036854775807", want: 10},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?limit="+test.value, nil)
+			if got := queryInt(req, "limit", 10); got != test.want {
+				t.Fatalf("queryInt() = %d, want %d", got, test.want)
+			}
+		})
 	}
 	server := New(nil, nil, Options{GitHubOAuth: GitHubOAuthConfig{PublicURL: "https://app.clickclack.test/path"}})
 	patterns := server.websocketOriginPatterns(httptest.NewRequest(http.MethodGet, "/", nil))
@@ -3722,6 +3741,44 @@ func TestQueryHelpersParseValues(t *testing.T) {
 	}
 	if patterns := New(nil, nil, Options{GitHubOAuth: GitHubOAuthConfig{PublicURL: "%"}}).websocketOriginPatterns(httptest.NewRequest(http.MethodGet, "/", nil)); patterns != nil {
 		t.Fatalf("unexpected invalid websocket origin patterns: %#v", patterns)
+	}
+}
+
+func TestPaginationLimitParsersUseDatabaseWidth(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		value   string
+		want    int
+		wantErr bool
+	}{
+		{name: "missing"},
+		{name: "negative", value: "-1", wantErr: true},
+		{name: "zero", value: "0", wantErr: true},
+		{name: "positive", value: "1", want: 1},
+		{name: "maximum database integer", value: "2147483647", want: 2147483647},
+		{name: "above database integer", value: "2147483648", wantErr: true},
+		{name: "maximum 64-bit integer", value: "9223372036854775807", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?limit="+test.value, nil)
+
+			search, searchErr := parseSearchPageRequest(req, "usr_test")
+			if got := searchErr != nil; got != test.wantErr {
+				t.Fatalf("parseSearchPageRequest() error = %v, want error %v", searchErr, test.wantErr)
+			}
+			if searchErr == nil && search.Limit != test.want {
+				t.Fatalf("search limit = %d, want %d", search.Limit, test.want)
+			}
+
+			members, memberErr := parseWorkspaceMemberPageRequest(req)
+			if got := memberErr != nil; got != test.wantErr {
+				t.Fatalf("parseWorkspaceMemberPageRequest() error = %v, want error %v", memberErr, test.wantErr)
+			}
+			if memberErr == nil && members.Limit != test.want {
+				t.Fatalf("member limit = %d, want %d", members.Limit, test.want)
+			}
+		})
 	}
 }
 

--- a/apps/api/internal/store/postgres/members.go
+++ b/apps/api/internal/store/postgres/members.go
@@ -211,7 +211,7 @@ func postgresWorkspaceMemberCounts(ctx context.Context, tx *sql.Tx, workspaceID 
 
 func postgresWorkspaceMemberPageFromRows(workspaceID string, req store.WorkspaceMemberPageRequest, totalCount *int, totalByRole *store.WorkspaceMemberRoleCounts, rows []storedb.ListWorkspaceMemberPageRow) (store.WorkspaceMemberPage, error) {
 	page := store.WorkspaceMemberPage{
-		Members:     make([]store.WorkspaceMember, 0, min(len(rows), req.Limit)),
+		Members:     make([]store.WorkspaceMember, 0, len(rows)),
 		TotalCount:  totalCount,
 		TotalByRole: totalByRole,
 	}

--- a/apps/api/internal/store/search_pages.go
+++ b/apps/api/internal/store/search_pages.go
@@ -155,7 +155,7 @@ func EncodeSearchCursor(req SearchPageRequest, rank float64, createdAt, messageI
 
 func BuildSearchPage(req SearchPageRequest, entries []SearchPageEntry) (SearchPage, error) {
 	page := SearchPage{
-		Results: make([]SearchHit, 0, min(len(entries), req.Limit)),
+		Results: make([]SearchHit, 0, len(entries)),
 	}
 	hasMore := len(entries) > req.Limit
 	if hasMore {

--- a/apps/api/internal/store/sqlite/members.go
+++ b/apps/api/internal/store/sqlite/members.go
@@ -212,7 +212,7 @@ func sqliteWorkspaceMemberCounts(ctx context.Context, tx *sql.Tx, workspaceID st
 
 func sqliteWorkspaceMemberPageFromRows(workspaceID string, req store.WorkspaceMemberPageRequest, totalCount *int, totalByRole *store.WorkspaceMemberRoleCounts, rows []storedb.ListWorkspaceMemberPageRow) (store.WorkspaceMemberPage, error) {
 	page := store.WorkspaceMemberPage{
-		Members:     make([]store.WorkspaceMember, 0, min(len(rows), req.Limit)),
+		Members:     make([]store.WorkspaceMember, 0, len(rows)),
 		TotalCount:  totalCount,
 		TotalByRole: totalByRole,
 	}


### PR DESCRIPTION
## Problem

CodeQL alerts 3-7 identify one pagination-boundary defect across the API and both stores:

- request limits were parsed with architecture-sized `strconv.Atoi`, then reached PostgreSQL `int32` query parameters;
- page builders expressed result capacity in terms of the request limit instead of the rows actually returned.

## Why

The HTTP boundary now parses pagination integers as signed 32-bit values before converting them to Go `int`. Existing store normalization remains the canonical behavior owner: missing and zero values retain their documented defaults, negative values retain their existing rejection/default behavior, and oversized but representable values are still clamped to each endpoint's public maximum.

PostgreSQL and SQLite member/search page builders now allocate directly from `len(rows)` or `len(entries)`. This preserves backend parity and prevents request-controlled allocation expressions without changing returned pages.

No public API, configuration, schema, SQL, generated code, or dependency surface changed.

## User impact

Out-of-range pagination integers are rejected or fall back before database-width conversions. Valid requests, endpoint defaults, clamps, cursors, and page shapes are unchanged.

## Evidence

Pre-fix regression:

```text
go test ./apps/api/internal/httpapi -run 'Test(QueryHelpersParseValues|PaginationLimitParsersUseDatabaseWidth)$' -count=1

queryInt accepted 2147483648, -2147483649, and 9223372036854775807 on 64-bit Go.
The strict search/member parsers accepted 2147483648 and 9223372036854775807.
```

Post-fix:

```text
go test ./apps/api/internal/httpapi -run 'Test(QueryHelpersParseValues|PaginationLimitParsersUseDatabaseWidth)$' -count=1
go test ./apps/api/internal/httpapi -count=1
go test ./apps/api/internal/store/... -count=1
go test ./... -count=1
CGO_ENABLED=0 GOOS=linux GOARCH=386 go test -c ./apps/api/internal/httpapi
```

All passed with Go 1.26.6. The final command produced a statically linked 32-bit Intel 80386 test binary.

Boundary coverage includes missing/default, negative, zero, positive, `MaxInt32`, `MaxInt32+1`, below `MinInt32`, and `MaxInt64`. Existing store tests cover endpoint normalization and PostgreSQL/SQLite parity. No allocation-count assertion was added: the regression is the security boundary, while exact-head CodeQL independently verifies that request-sized allocation flows are gone.

High-reasoning `gpt-5.6-sol` autoreview reported one proposed `MaxInt32-1` cap. Source tracing disproved it: search and member requests normalize to 100 and 200 before their sentinel-row `limit + 1`, while every `queryInt` consumer clamps before SQL conversion or sentinel arithmetic. `MaxInt32` is therefore safe at ingress and never reaches backend addition.

LOC split:

```text
production: +9/-9 (net 0)
tests:      +60/-3
generated:  0/0
```

Crabbox clean-machine proof passed on exact head `78931c4`:

- run: https://crabbox.openclaw.ai/portal/runs/run_753e259d347e
- focused regression, full `go test ./...`, and Linux/386 cross-compile all passed;
- disposable AWS lease `cbx_1174c9b3bcb8` stopped automatically after exit 0.

Exact-head GitHub proof on `78931c48949f8de468b7b476f1ed64fff972b6a2`:

- 12 required/applicable checks passed with zero failures or pending jobs;
- CodeQL Go analysis `1679826001` on `refs/pull/173/head` reported zero results;
- ClawSweeper revision 8 rated the patch A/A/A, marked it correct and security-cleared, reported no findings, and listed no rank-up moves: https://github.com/openclaw/clawsweeper/actions/runs/33048031433

ClawSweeper requested explicit owner acceptance for changing strict search/member overflow from downstream clamping to an ingress error. @vincentkoc is an active `openclaw-secops` maintainer and explicitly accepted the signed-32-bit ingress boundary for this campaign.

## Scope and credit

This updates the existing campaign-owned PR and branch created by @vincentkoc. No external contributor commit was copied. https://github.com/openclaw/clickclack/pull/169 is unrelated web cursor work and remains untouched.
