### PR TITLE
fix(desktop): match signing identities with literal text

### DIFF
--- a/apps/desktop/scripts/macos-signing.test.mjs
+++ b/apps/desktop/scripts/macos-signing.test.mjs
@@ -75,8 +75,8 @@ test("macOS release policy is fail-closed and Foundation-scoped", async () => {
   assert.match(config, /hardenedRuntime: true/);
   assert.match(config, /strictVerify: true/);
   assert.match(config, /notarize: false/);
-  assert.match(verifier, new RegExp(EXPECTED_IDENTITY.replace(/[()]/g, "\\$&")));
-  assert.match(packageScript, new RegExp(EXPECTED_IDENTITY_QUALIFIER.replace(/[()]/g, "\\$&")));
+  assert.match(verifier, new RegExp(RegExp.escape(EXPECTED_IDENTITY)));
+  assert.match(packageScript, new RegExp(RegExp.escape(EXPECTED_IDENTITY_QUALIFIER)));
   assert.match(packageScript, /NOTARYTOOL_KEYCHAIN_PROFILE/);
   assert.match(packageScript, /tag -v/);
   assert.match(verifier, /codesign --verify --strict --deep/);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where the macOS signing-policy tests escaped only parentheses in an identity string before constructing regular expressions, reported by [CodeQL alerts 10 and 11](https://github.com/openclaw/clickclack/actions/runs/32474269674).

## Why This Change Was Made

The test now uses the runtime's native `RegExp.escape` contract, so every regular-expression metacharacter in a signing identity is treated literally.

## User Impact

No production behavior changes. Release-policy tests now remain correct for signing identities containing any regex metacharacter.

## Evidence

- `node apps/desktop/scripts/macos-signing.test.mjs` (4 passing tests)
- `oxfmt --check apps/desktop/scripts/macos-signing.test.mjs`
- Production LOC: +0/-0. Test LOC: +2/-2.

