### PR TITLE
refactor(realtime): drop unused Hub.PublishMany batch wrapper

### DIFF
--- a/apps/api/internal/realtime/hub.go
+++ b/apps/api/internal/realtime/hub.go
@@ -56,9 +56,3 @@ func (h *Hub) Publish(event store.Event) {
 		}
 	}
 }
-
-func (h *Hub) PublishMany(events []store.Event) {
-	for _, event := range events {
-		h.Publish(event)
-	}
-}

--- a/apps/api/internal/realtime/hub_test.go
+++ b/apps/api/internal/realtime/hub_test.go
@@ -24,7 +24,7 @@ func TestHubSubscribePublishAndUnsubscribe(t *testing.T) {
 		t.Fatal("timed out waiting for event")
 	}
 
-	hub.PublishMany([]store.Event{{ID: "evt_2", WorkspaceID: "wsp_other"}})
+	hub.Publish(store.Event{ID: "evt_2", WorkspaceID: "wsp_other"})
 	select {
 	case got := <-events:
 		t.Fatalf("unexpected event for other workspace: %#v", got)


### PR DESCRIPTION
Remove the obsolete internal `Hub.PublishMany` wrapper (six production lines) and publish the single test event directly through `Hub.Publish`. The existing workspace-isolation assertion, unsubscribe behavior, and slow-subscriber overflow coverage remain intact.

The wrapper previously had a production caller: `createThreadReply` used it until [25af1832](https://github.com/openclaw/clickclack/commit/25af1832ccca53ba59b00950bba873e6e31643e0) migrated that path to `Server.publishEvents`. The server-owned path publishes each event to the hub and delivers event subscriptions. Raw-parent diff inspection confirms this history; the wrapper became obsolete after that migration.

Thanks @KrasimirKralev for the cleanup. No runtime/API/configuration behavior changes or new dependencies. No new test was added merely to test the deletion.

### Validation

- Existing hub isolation/overflow tests and HTTP vertical slice: `go test ./apps/api/internal/realtime ./apps/api/internal/httpapi -run 'TestHub|TestChatAPIVerticalSlice' -count=1`.
- Built server on a free localhost port with fresh synthetic SQLite data and `serve --dev-bootstrap=true`.
- Created a channel root and thread reply through real HTTP while subscribed over a real WebSocket. Observed receipt:

```text
WebSocket received message.created: expected workspace and message linkage
WebSocket received thread.reply_created: expected workspace and message linkage
WebSocket received thread.state_updated: expected workspace and message linkage
HTTP root/reply creation -> 201; two reply events; persisted thread read -> one matching reply
```

The same focused tests and built-binary proof were run against the published head and a locally integrated current-main candidate. Complete published-branch Codex autoreview is scoped-clean under the configured P0 policy. Published head `12e4740f06c75558b8fb730b47ac50c82a9d4c02` already has passing Go, TypeScript, Playwright E2E, Docker and all three desktop checks in [CI](https://github.com/openclaw/clickclack/actions/runs/32948402878) and [desktop CI](https://github.com/openclaw/clickclack/actions/runs/32948402744).

The fork currently rejects maintainer pushes, so its published head is unchanged. Current main was integrated and validated locally without rewriting contributor history; no alternate publication route was used. The existing PR remains available for normal maintainer review.
