### PR TITLE
fix(auth): local sign-in works behind trusted HTTPS proxies

### DIFF
--- a/apps/api/internal/httpapi/github.go
+++ b/apps/api/internal/httpapi/github.go
@@ -545,7 +545,7 @@ func (s *Server) githubRedirectURL(r *http.Request) (string, error) {
 			return "", errors.New("github oauth requires a configured public URL")
 		}
 		scheme := "http"
-		if r.TLS != nil {
+		if requestIsHTTPS(r) {
 			scheme = "https"
 		}
 		base = scheme + "://" + r.Host
@@ -568,23 +568,25 @@ func (s *Server) cookiePath() string {
 }
 
 func (s *Server) secureCookies(r *http.Request) bool {
-	if publicURL, err := url.Parse(strings.TrimSpace(s.publicAPIURL)); err == nil && publicURL.Scheme == "https" {
-		return true
-	}
-	if publicURL, err := url.Parse(strings.TrimSpace(s.githubOAuth.PublicURL)); err == nil {
-		if publicURL.Scheme == "https" {
-			return true
-		}
-	}
-	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
-		return true
-	}
-	if publicURL, err := url.Parse(strings.TrimSpace(s.githubOAuth.PublicURL)); err == nil {
-		if !s.disableDevAuth && publicURL.Scheme == "http" && isLocalHostPort(publicURL.Host) {
-			return false
-		}
-	}
-	return !(!s.disableDevAuth && isLocalHostPort(r.RemoteAddr) && isLocalHostPort(r.Host))
+	requestHTTPS := requestIsHTTPS(r)
+	return urlIsHTTPS(s.publicAPIURL) ||
+		urlIsHTTPS(s.githubOAuth.PublicURL) ||
+		urlIsHTTPS(s.openclawID.PublicURL) ||
+		requestHTTPS ||
+		!(!s.disableDevAuth &&
+			(isLocalDevRequest(r) ||
+				urlIsLoopbackHTTP(s.githubOAuth.PublicURL) ||
+				urlIsLoopbackHTTP(s.openclawID.PublicURL)))
+}
+
+func urlIsHTTPS(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && parsed.Scheme == "https"
+}
+
+func urlIsLoopbackHTTP(raw string) bool {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	return err == nil && parsed.Scheme == "http" && isLocalHostPort(parsed.Host)
 }
 
 func (s *Server) oauthBrowserBinding(w http.ResponseWriter, r *http.Request) (string, error) {

--- a/apps/api/internal/httpapi/github_test.go
+++ b/apps/api/internal/httpapi/github_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -33,6 +34,65 @@ func TestGitHubOAuthDefaultHTTPClientTimeout(t *testing.T) {
 	cfg = GitHubOAuthConfig{HTTPClient: customClient}.withDefaults()
 	if cfg.HTTPClient != customClient {
 		t.Fatal("expected custom client to be preserved")
+	}
+}
+
+func TestAuthenticationCookiesRoundTripOnLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+	server := New(nil, nil, Options{})
+	session := store.Session{
+		Token:     "tok_loopback",
+		ExpiresAt: time.Now().Add(time.Hour).Format(time.RFC3339Nano),
+	}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/issue" {
+			if _, err := server.oauthBrowserBinding(w, r); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			server.setSessionCookie(w, r, session)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if _, bindingErr := r.Cookie(server.cookies.OAuthBinding); bindingErr != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if cookie, err := r.Cookie(server.cookies.Session); err != nil || cookie.Value != session.Token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	httpServer := httptest.NewServer(handler)
+	t.Cleanup(httpServer.Close)
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &http.Client{Jar: jar}
+
+	response, err := client.Get(httpServer.URL + "/issue")
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected cookie issue success, got %s", response.Status)
+	}
+	for _, name := range []string{server.cookies.OAuthBinding, server.cookies.Session} {
+		if cookie := findCookie(response.Cookies(), name); cookie == nil || cookie.Secure {
+			t.Fatalf("expected loopback HTTP cookie %q without Secure, got %#v", name, cookie)
+		}
+	}
+
+	response, err = client.Get(httpServer.URL + "/verify")
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected cookie jar to return both loopback cookies, got %s", response.Status)
 	}
 }
 

--- a/apps/api/internal/httpapi/openclawid.go
+++ b/apps/api/internal/httpapi/openclawid.go
@@ -257,7 +257,7 @@ func (s *Server) openclawIDRedirectURL(r *http.Request) (string, error) {
 			return "", errors.New("openclaw id sign-in requires a configured public URL")
 		}
 		scheme := "http"
-		if r.TLS != nil {
+		if requestIsHTTPS(r) {
 			scheme = "https"
 		}
 		base = scheme + "://" + r.Host

--- a/apps/api/internal/httpapi/origins.go
+++ b/apps/api/internal/httpapi/origins.go
@@ -100,6 +100,15 @@ func canonicalOriginString(origin string) (string, bool) {
 	return canonicalOrigin(parsed)
 }
 
+func requestIsHTTPS(r *http.Request) bool {
+	forwardedProto := r.Header.Values("X-Forwarded-Proto")
+	return r.TLS != nil ||
+		isLocalHostPort(r.RemoteAddr) &&
+			loopbackProxyClientIP(r) != "" &&
+			len(forwardedProto) == 1 &&
+			strings.EqualFold(strings.TrimSpace(forwardedProto[0]), "https")
+}
+
 func (s *Server) apiBaseURL(r *http.Request) string {
 	if s.publicAPIURL != "" {
 		return s.publicAPIURL
@@ -108,7 +117,7 @@ func (s *Server) apiBaseURL(r *http.Request) string {
 		return ""
 	}
 	scheme := "http"
-	if r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+	if requestIsHTTPS(r) {
 		scheme = "https"
 	}
 	base, err := authpolicy.CanonicalPublicAPIURL(scheme + "://" + r.Host)

--- a/apps/api/internal/httpapi/origins_test.go
+++ b/apps/api/internal/httpapi/origins_test.go
@@ -136,6 +136,81 @@ func TestConfiguredCookieSameSite(t *testing.T) {
 	}
 }
 
+func TestLocalRequestSchemeTrust(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		url        string
+		remoteAddr string
+		headers    http.Header
+		wantBase   string
+	}{
+		{
+			name:       "loopback_http",
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			wantBase:   "http://127.0.0.1:8080",
+		},
+		{
+			name:       "direct_https",
+			url:        "https://127.0.0.1:8443/",
+			remoteAddr: "127.0.0.1:45678",
+			wantBase:   "https://127.0.0.1:8443",
+		},
+		{
+			name:       "untrusted_forwarded_https",
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			headers:    http.Header{"X-Forwarded-Proto": []string{"https"}},
+			wantBase:   "http://127.0.0.1:8080",
+		},
+		{
+			name:       "trusted_loopback_proxy_https",
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			headers: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-For":   []string{"127.0.0.2"},
+				"X-Real-IP":         []string{"127.0.0.2"},
+			},
+			wantBase: "https://127.0.0.1:8080",
+		},
+		{
+			name:       "duplicate_forwarded_proto",
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			headers: http.Header{
+				"X-Forwarded-Proto": []string{"https", "http"},
+				"X-Forwarded-For":   []string{"127.0.0.2"},
+				"X-Real-IP":         []string{"127.0.0.2"},
+			},
+			wantBase: "http://127.0.0.1:8080",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			request := httptest.NewRequest(http.MethodGet, tc.url, nil)
+			request.RemoteAddr = tc.remoteAddr
+			for name, values := range tc.headers {
+				for _, value := range values {
+					request.Header.Add(name, value)
+				}
+			}
+			server := New(nil, nil, Options{})
+
+			if got := server.apiBaseURL(request); got != tc.wantBase {
+				t.Fatalf("API base URL = %q, want %q", got, tc.wantBase)
+			}
+			if got, err := server.githubRedirectURL(request); err != nil || got != tc.wantBase+"/api/auth/github/callback" {
+				t.Fatalf("GitHub redirect URL = %q, want %q: %v", got, tc.wantBase+"/api/auth/github/callback", err)
+			}
+			if got, err := server.openclawIDRedirectURL(request); err != nil || got != tc.wantBase+"/api/auth/openclaw/callback" {
+				t.Fatalf("OpenClaw ID redirect URL = %q, want %q: %v", got, tc.wantBase+"/api/auth/openclaw/callback", err)
+			}
+		})
+	}
+}
+
 func TestGitHubCallbackUsesCanonicalAPIBase(t *testing.T) {
 	t.Parallel()
 	server := New(nil, nil, Options{

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -2877,6 +2877,7 @@ func TestSessionCookiesDefaultSecureOutsideLocalDev(t *testing.T) {
 		options    Options
 		url        string
 		remoteAddr string
+		headers    http.Header
 		wantSecure bool
 	}{
 		{
@@ -2894,6 +2895,26 @@ func TestSessionCookiesDefaultSecureOutsideLocalDev(t *testing.T) {
 			wantSecure: false,
 		},
 		{
+			name:       "local_dev_ignores_untrusted_forwarded_https",
+			options:    Options{},
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			headers:    http.Header{"X-Forwarded-Proto": []string{"https"}},
+			wantSecure: false,
+		},
+		{
+			name:       "trusted_loopback_proxy_https",
+			options:    Options{},
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			headers: http.Header{
+				"X-Forwarded-Proto": []string{"https"},
+				"X-Forwarded-For":   []string{"127.0.0.2"},
+				"X-Real-IP":         []string{"127.0.0.2"},
+			},
+			wantSecure: true,
+		},
+		{
 			name:       "local_dev_http_public_host",
 			options:    Options{},
 			url:        "http://app.example.test/",
@@ -2907,16 +2928,38 @@ func TestSessionCookiesDefaultSecureOutsideLocalDev(t *testing.T) {
 			remoteAddr: "127.0.0.1:45678",
 			wantSecure: true,
 		},
+		{
+			name:       "openclaw_id_public_https",
+			options:    Options{OpenClawID: OpenClawIDConfig{PublicURL: "https://app.example.test"}},
+			url:        "http://127.0.0.1:8080/",
+			remoteAddr: "127.0.0.1:45678",
+			wantSecure: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			req := httptest.NewRequest(http.MethodGet, tc.url, nil)
 			req.RemoteAddr = tc.remoteAddr
-			recorder := httptest.NewRecorder()
-			New(nil, nil, tc.options).setSessionCookie(recorder, req, session)
-			cookie := findCookie(recorder.Result().Cookies(), "cc_session")
-			if cookie == nil || cookie.Secure != tc.wantSecure {
-				t.Fatalf("expected secure=%v session cookie, got %#v", tc.wantSecure, cookie)
+			for name, values := range tc.headers {
+				for _, value := range values {
+					req.Header.Add(name, value)
+				}
+			}
+			server := New(nil, nil, tc.options)
+
+			sessionResponse := httptest.NewRecorder()
+			server.setSessionCookie(sessionResponse, req, session)
+			sessionCookie := findCookie(sessionResponse.Result().Cookies(), server.cookies.Session)
+
+			bindingResponse := httptest.NewRecorder()
+			if _, err := server.oauthBrowserBinding(bindingResponse, req); err != nil {
+				t.Fatal(err)
+			}
+			bindingCookie := findCookie(bindingResponse.Result().Cookies(), server.cookies.OAuthBinding)
+
+			if sessionCookie == nil || sessionCookie.Secure != tc.wantSecure ||
+				bindingCookie == nil || bindingCookie.Secure != tc.wantSecure {
+				t.Fatalf("expected secure=%v authentication cookies, got session=%#v binding=%#v", tc.wantSecure, sessionCookie, bindingCookie)
 			}
 		})
 	}


### PR DESCRIPTION
Supersedes the cookie-policy approach in https://github.com/openclaw/clickclack/pull/171. That draft remains open and untouched pending maintainer reconciliation.

## What Problem This Solves

Fixes an issue where local sign-in could lose OAuth state when an untrusted forwarded-scheme header forced Secure cookies onto loopback HTTP. It also resolves CodeQL alerts 1 and 2 for authentication cookies that did not have a statically guaranteed Secure policy.

## Why This Change Was Made

HTTPS is now derived from direct TLS or a verified loopback proxy with one unambiguous forwarded protocol value. Both authentication cookies share that decision, all configured HTTPS public surfaces force Secure cookies, and intentional loopback HTTP development remains supported without adding configuration.

The accepted proxy contract is the repository's existing bundled Nginx example: it overwrites `Host`, `X-Forwarded-For`, `X-Real-IP`, and `X-Forwarded-Proto` before forwarding to the loopback API. Other proxy topologies must use configured public URLs or establish their own verified edge identity.

## User Impact

Local OAuth sign-in continues to work over loopback HTTP, trusted local reverse proxies produce HTTPS callback URLs and Secure cookies, and arbitrary forwarded headers can no longer influence the scheme decision.

## Evidence

- Pre-fix Crabbox proof: `TestSessionCookiesDefaultSecureOutsideLocalDev` failed for spoofed forwarding and the OpenClaw ID HTTPS sibling: https://crabbox.openclaw.ai/portal/runs/run_7dda5d05b008
- Final focused formatting and authentication-cookie/scheme tests: https://crabbox.openclaw.ai/portal/runs/run_05e222be6b78
- Full Go suite with one named pre-existing Crabbox filesystem-mode test skipped: https://crabbox.openclaw.ai/portal/runs/run_e90900b4bd85
- Untouched `main` at `5c664e0dbe32ca12694e1782baa76baa989e36e5` reproduces that unrelated `TestWriteClientConfigFilePreservesWritableMode` failure: https://crabbox.openclaw.ai/portal/runs/run_f5587c9ac47e
- Production LOC: +31/-20. Tests: +183/-5.
- Independent high-reasoning security review and test audit found no actionable P0-P2 findings after the review fixes.
- ClawSweeper exact-head review completed with no code findings, security review cleared, focused live proof passed, and both rank-up moves addressed.
- Proxy contract source: `deploy/nginx/clickclack.conf.example:67-70` and `docs/deployment.md:171-184`.
