### PR TITLE
fix: enforce current message access for nonce recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed message recovery by nonce returning hidden channel and direct messages after the sender loses access.
+
 - Fixed delayed thread loads reopening closed panes or replacing newer selections, and preserved failed reply drafts and quotes with duplicate-safe retries.
 
 - Added configurable workspace home destinations and labels, preserving desktop home navigation and keeping long labels within the badge. Thanks @sercada.

--- a/apps/api/internal/store/postgres/moderation_test.go
+++ b/apps/api/internal/store/postgres/moderation_test.go
@@ -1,0 +1,114 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestMessageNonceRecoveryFollowsCurrentAccess(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	moderator, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Moderator", Email: "nonce-mod@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultGuestWorkspaceMember(ctx, moderator.ID, store.WorkspaceRoleModerator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "nonce-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspace.ID, moderator.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generalChannelID, guestChannelID string
+	for _, channel := range channels {
+		switch channel.Name {
+		case "general":
+			generalChannelID = channel.ID
+		case "guest":
+			guestChannelID = channel.ID
+		}
+	}
+	if generalChannelID == "" || guestChannelID == "" {
+		t.Fatalf("expected general and guest channels, got %#v", channels)
+	}
+	general, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: generalChannelID, AuthorID: member.ID, Body: "before demotion", Nonce: "nonce-replay"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	guest, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: guestChannelID, AuthorID: member.ID, Body: "waiting room", Nonce: "guest-nonce"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := st.CreateDirectConversation(ctx, store.CreateDirectConversationInput{WorkspaceID: workspace.ID, UserID: member.ID, MemberIDs: []string{moderator.ID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	direct, _, err := st.CreateDirectMessage(ctx, store.CreateDirectMessageInput{ConversationID: dm.ID, AuthorID: member.ID, Body: "direct before demotion", Nonce: "direct-nonce"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name    string
+		message store.Message
+		denied  bool
+	}{
+		{"channel", general, true},
+		{"direct", direct, true},
+		{"guest channel", guest, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" before demotion", func(t *testing.T) {
+			if got, err := st.GetMessageByNonce(ctx, member.ID, " "+tc.message.Nonce+" "); err != nil || got.ID != tc.message.ID {
+				t.Fatalf("expected sender to recover message %s, got %s: %v", tc.message.ID, got.ID, err)
+			}
+			if _, err := st.GetMessageByNonce(ctx, moderator.ID, tc.message.Nonce); !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("expected other author's nonce to be hidden, got %v", err)
+			}
+		})
+	}
+	for _, nonce := range []string{"", "missing"} {
+		if _, err := st.GetMessageByNonce(ctx, member.ID, nonce); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected absent nonce %q to return no rows, got %v", nonce, err)
+		}
+	}
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: member.ID, Role: store.WorkspaceRoleGuest}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" after demotion", func(t *testing.T) {
+			var wantErr error
+			if tc.denied {
+				wantErr = store.ErrModerationRestricted
+			}
+			if _, err := st.GetMessage(ctx, tc.message.ID, member.ID); !errors.Is(err, wantErr) {
+				t.Fatalf("unexpected message access after demotion: %v", err)
+			}
+			got, err := st.GetMessageByNonce(ctx, member.ID, tc.message.Nonce)
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("expected nonce recovery error %v, got %v", wantErr, err)
+			}
+			if !tc.denied && got.ID != tc.message.ID {
+				t.Fatalf("expected permitted message %s, got %s", tc.message.ID, got.ID)
+			}
+		})
+	}
+	if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: generalChannelID, AuthorID: member.ID, Body: "before demotion", Nonce: "nonce-replay"}); !errors.Is(err, store.ErrModerationRestricted) {
+		t.Fatalf("expected replayed hidden channel nonce to be blocked, got %v", err)
+	}
+}

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -671,19 +671,14 @@ func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (
 	if normalized == "" {
 		return store.Message{}, sql.ErrNoRows
 	}
-	message, err := scanMessage(s.db.QueryRowContext(ctx, messageSelect()+` WHERE m.author_id = $1 AND m.client_nonce = $2`, authorID, normalized))
+	messageID, err := storedb.New(s.db).GetMessageIDByAuthorNonce(ctx, storedb.GetMessageIDByAuthorNonceParams{
+		AuthorID:    authorID,
+		ClientNonce: normalized,
+	})
 	if err != nil {
 		return store.Message{}, err
 	}
-	messages, err := s.hydrateAttachments(ctx, []store.Message{message})
-	if err != nil {
-		return store.Message{}, err
-	}
-	messages, err = s.hydrateReactions(ctx, authorID, messages)
-	if err != nil {
-		return store.Message{}, err
-	}
-	return messages[0], nil
+	return s.GetMessage(ctx, messageID, authorID)
 }
 
 func (s *Store) requireMessageAccess(ctx context.Context, message store.Message, userID string) error {

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -997,6 +997,11 @@ SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_si
 FROM uploads
 WHERE id = sqlc.arg(id);
 
+-- name: GetMessageIDByAuthorNonce :one
+SELECT id
+FROM messages
+WHERE author_id = sqlc.arg(author_id) AND client_nonce = sqlc.arg(client_nonce);
+
 -- name: GetUploadByOwnerNonce :one
 SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -1589,6 +1589,24 @@ func (q *Queries) GetMemberModerationState(ctx context.Context, arg GetMemberMod
 	return i, err
 }
 
+const getMessageIDByAuthorNonce = `-- name: GetMessageIDByAuthorNonce :one
+SELECT id
+FROM messages
+WHERE author_id = $1 AND client_nonce = $2
+`
+
+type GetMessageIDByAuthorNonceParams struct {
+	AuthorID    string `json:"author_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+func (q *Queries) GetMessageIDByAuthorNonce(ctx context.Context, arg GetMessageIDByAuthorNonceParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, getMessageIDByAuthorNonce, arg.AuthorID, arg.ClientNonce)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getNotificationSettings = `-- name: GetNotificationSettings :one
 SELECT pushover_enabled, pushover_user_key
 FROM user_notification_settings

--- a/apps/api/internal/store/sqlite/moderation_test.go
+++ b/apps/api/internal/store/sqlite/moderation_test.go
@@ -411,7 +411,7 @@ func TestGuestPostBudgetIgnoresPreDemotionMemberPosts(t *testing.T) {
 	}
 }
 
-func TestDemotedGuestCannotReplayHiddenChannelNonce(t *testing.T) {
+func TestMessageNonceRecoveryFollowsCurrentAccess(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	st := newTestStore(t)
@@ -435,20 +435,78 @@ func TestDemotedGuestCannotReplayHiddenChannelNonce(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var generalChannelID string
+	var generalChannelID, guestChannelID string
 	for _, channel := range channels {
-		if channel.Name == "general" {
+		switch channel.Name {
+		case "general":
 			generalChannelID = channel.ID
+		case "guest":
+			guestChannelID = channel.ID
 		}
 	}
-	if generalChannelID == "" {
-		t.Fatalf("expected general channel, got %#v", channels)
+	if generalChannelID == "" || guestChannelID == "" {
+		t.Fatalf("expected general and guest channels, got %#v", channels)
 	}
-	if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: generalChannelID, AuthorID: member.ID, Body: "before demotion", Nonce: "nonce-replay"}); err != nil {
+	general, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: generalChannelID, AuthorID: member.ID, Body: "before demotion", Nonce: "nonce-replay"})
+	if err != nil {
 		t.Fatal(err)
+	}
+	guest, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: guestChannelID, AuthorID: member.ID, Body: "waiting room", Nonce: "guest-nonce"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm, err := st.CreateDirectConversation(ctx, store.CreateDirectConversationInput{WorkspaceID: workspace.ID, UserID: member.ID, MemberIDs: []string{moderator.ID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	direct, _, err := st.CreateDirectMessage(ctx, store.CreateDirectMessageInput{ConversationID: dm.ID, AuthorID: member.ID, Body: "direct before demotion", Nonce: "direct-nonce"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		name    string
+		message store.Message
+		denied  bool
+	}{
+		{"channel", general, true},
+		{"direct", direct, true},
+		{"guest channel", guest, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" before demotion", func(t *testing.T) {
+			if got, err := st.GetMessageByNonce(ctx, member.ID, " "+tc.message.Nonce+" "); err != nil || got.ID != tc.message.ID {
+				t.Fatalf("expected sender to recover message %s, got %s: %v", tc.message.ID, got.ID, err)
+			}
+			if _, err := st.GetMessageByNonce(ctx, moderator.ID, tc.message.Nonce); !errors.Is(err, sql.ErrNoRows) {
+				t.Fatalf("expected other author's nonce to be hidden, got %v", err)
+			}
+		})
+	}
+	for _, nonce := range []string{"", "missing"} {
+		if _, err := st.GetMessageByNonce(ctx, member.ID, nonce); !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("expected absent nonce %q to return no rows, got %v", nonce, err)
+		}
 	}
 	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: moderator.ID, TargetUserID: member.ID, Role: store.WorkspaceRoleGuest}); err != nil {
 		t.Fatal(err)
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+" after demotion", func(t *testing.T) {
+			var wantErr error
+			if tc.denied {
+				wantErr = store.ErrModerationRestricted
+			}
+			if _, err := st.GetMessage(ctx, tc.message.ID, member.ID); !errors.Is(err, wantErr) {
+				t.Fatalf("unexpected message access after demotion: %v", err)
+			}
+			got, err := st.GetMessageByNonce(ctx, member.ID, tc.message.Nonce)
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("expected nonce recovery error %v, got %v", wantErr, err)
+			}
+			if !tc.denied && got.ID != tc.message.ID {
+				t.Fatalf("expected permitted message %s, got %s", tc.message.ID, got.ID)
+			}
+		})
 	}
 	if _, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: generalChannelID, AuthorID: member.ID, Body: "before demotion", Nonce: "nonce-replay"}); !errors.Is(err, store.ErrModerationRestricted) {
 		t.Fatalf("expected replayed hidden channel nonce to be blocked, got %v", err)

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -974,6 +974,11 @@ SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_si
 FROM uploads
 WHERE id = sqlc.arg(id);
 
+-- name: GetMessageIDByAuthorNonce :one
+SELECT id
+FROM messages
+WHERE author_id = sqlc.arg(author_id) AND client_nonce = sqlc.arg(client_nonce);
+
 -- name: GetUploadByOwnerNonce :one
 SELECT id, workspace_id, owner_id, client_nonce, filename, content_type, byte_size, width, height, duration_ms, storage_path, created_at
 FROM uploads

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -685,19 +685,14 @@ func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (
 	if normalized == "" {
 		return store.Message{}, sql.ErrNoRows
 	}
-	message, err := scanMessage(s.db.QueryRowContext(ctx, messageSelect()+` WHERE m.author_id = ? AND m.client_nonce = ?`, authorID, normalized))
+	messageID, err := storedb.New(s.db).GetMessageIDByAuthorNonce(ctx, storedb.GetMessageIDByAuthorNonceParams{
+		AuthorID:    authorID,
+		ClientNonce: normalized,
+	})
 	if err != nil {
 		return store.Message{}, err
 	}
-	messages, err := s.hydrateAttachments(ctx, []store.Message{message})
-	if err != nil {
-		return store.Message{}, err
-	}
-	messages, err = s.hydrateReactions(ctx, authorID, messages)
-	if err != nil {
-		return store.Message{}, err
-	}
-	return messages[0], nil
+	return s.GetMessage(ctx, messageID, authorID)
 }
 
 func (s *Store) requireMessageAccess(ctx context.Context, message store.Message, userID string) error {

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -1581,6 +1581,24 @@ func (q *Queries) GetMemberModerationState(ctx context.Context, arg GetMemberMod
 	return i, err
 }
 
+const getMessageIDByAuthorNonce = `-- name: GetMessageIDByAuthorNonce :one
+SELECT id
+FROM messages
+WHERE author_id = ?1 AND client_nonce = ?2
+`
+
+type GetMessageIDByAuthorNonceParams struct {
+	AuthorID    string `json:"author_id"`
+	ClientNonce string `json:"client_nonce"`
+}
+
+func (q *Queries) GetMessageIDByAuthorNonce(ctx context.Context, arg GetMessageIDByAuthorNonceParams) (string, error) {
+	row := q.db.QueryRowContext(ctx, getMessageIDByAuthorNonce, arg.AuthorID, arg.ClientNonce)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const getNotificationSettings = `-- name: GetNotificationSettings :one
 SELECT pushover_enabled, pushover_user_key
 FROM user_notification_settings

--- a/docs/features/messages.md
+++ b/docs/features/messages.md
@@ -44,6 +44,8 @@ DELETE /api/messages/{message_id}
 - `GET /api/messages/by-nonce` lets the authenticated author reconcile a
   durable create after an interrupted request. It returns the matching message,
   including attachments, or a capability-marked 404 when no message exists.
+  Recovery requires current access to the message's channel or direct
+  conversation, just like reading by message ID.
   The `X-ClickClack-Message-Nonce: supported` response header distinguishes
   that result from an older server that does not implement the endpoint.
 - `POST /read` accepts `{seq}` and updates the caller's monotonic read pointer


### PR DESCRIPTION
After a member is demoted to guest, reading their earlier channel or direct message by ID correctly returns 403, but recovering the same message by nonce returned 200 with current message data. Nonce recovery now enforces the same current conversation permissions in SQLite and PostgreSQL.

Both stores resolve the author-scoped nonce to a message ID through sqlc, then call `GetMessage`. This removes duplicate message projection and attachment/reaction hydration, leaving one owner for message access and enrichment. Existing HTTP workspace and bot scope checks, missing-nonce responses, and nonce normalization remain in place.

Validation:

- The regression matrix fails on the baseline in both SQLite and PostgreSQL 17 for hidden channel and DM recovery after demotion, and passes with the fix. It also covers permitted recovery before demotion, continued guest-room access, missing nonces, and other-author isolation.
- Existing reaction hydration, HTTP attachment recovery, capability-marked 404, and bot DM-scope tests pass.
- Independent real HTTP proof against an immutable candidate and synthetic data: channel and DM reads by ID/by nonce both return 200 before demotion and 403 afterward. The baseline returned 200 by nonce after demotion.
- Isolated Codex autoreview: no accepted/actionable findings at the required P0 threshold. `pnpm check` passed with PostgreSQL enabled, and `pnpm coverage` passed at 86.1%. All checks are green on this exact head: [CI](https://github.com/openclaw/clickclack/actions/runs/33349999663) and [desktop builds](https://github.com/openclaw/clickclack/actions/runs/33349999690). The initial browser run passed192 tests and failed one unrelated spreadsheet-preview check; the unchanged failed-job rerun passed, with no test or timeout changes.

No schema, configuration, dependency, or API-shape changes.

<details>
<summary>Independent real HTTP proof receipt</summary>

Executed with synthetic users against the same SQLite database before and after the fix. The candidate contains the production source committed at `b5e359e538b852c7e17eaa799e1d997204ed0463`; its SHA-256 is `e6dca94d2d731f50039e91bc89a6357bb286951913c0dd2b8973b798819a5697`. The driver creates a member-authored channel message and DM, reads each through `/api/messages/{id}` and `/api/messages/by-nonce`, demotes the member through the moderation API, then repeats both reads. HTTP statuses below are captured responses, not expectations.

HTTP baseline binary: `72e471b7b20c38cafa31f2a3c080ebcaed3ee514`, SHA-256 `f3092d1892f544cde019817f4ae315c00a12cd9a19f27a6429092b0079c66834`. Its HTTP/store source is identical to the immediate parent `8457c35f`; the committed store regressions were separately demonstrated failing on that immediate parent.

Baseline responses:

```json
{
  "proof": "real HTTP, synthetic users, member-to-guest transition",
  "results": [
    {
      "kind": "channel",
      "before_id": 200,
      "before_nonce": 200,
      "after_id": 403,
      "after_nonce": 200
    },
    {
      "kind": "direct",
      "before_id": 200,
      "before_nonce": 200,
      "after_id": 403,
      "after_nonce": 200
    }
  ]
}
```

Candidate:

```json
{
  "proof": "real HTTP, synthetic users, member-to-guest transition",
  "results": [
    {
      "kind": "channel",
      "before_id": 200,
      "before_nonce": 200,
      "after_id": 403,
      "after_nonce": 403
    },
    {
      "kind": "direct",
      "before_id": 200,
      "before_nonce": 200,
      "after_id": 403,
      "after_nonce": 403
    }
  ]
}
```

The committed PostgreSQL regression runs the same permission transition on a real PostgreSQL 17 database and fails before/passes after the fix. HTTP runtime proof above uses SQLite.

</details>
