### PR TITLE
fix: serialize PostgreSQL channel partial updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed concurrent PostgreSQL channel settings updates overwriting changes to omitted fields.
+
 - Fixed message recovery by nonce returning hidden channel and direct messages after the sender loses access.
 
 - Fixed delayed thread loads reopening closed panes or replacing newer selections, and preserved failed reply drafts and quotes with duplicate-safe retries.

--- a/apps/api/internal/store/postgres/bot_deletion_test.go
+++ b/apps/api/internal/store/postgres/bot_deletion_test.go
@@ -688,6 +688,7 @@ func waitForBlockedBotLifecycleOperations(t *testing.T, ctx context.Context, db 
 			SELECT COUNT(*)
 			FROM pg_stat_activity
 			WHERE datname = current_database()
+			  AND application_name = current_schema()
 			  AND pid <> pg_backend_pid()
 			  AND wait_event_type = 'Lock'
 			  AND cardinality(pg_blocking_pids(pid)) > 0

--- a/apps/api/internal/store/postgres/bot_deletion_test.go
+++ b/apps/api/internal/store/postgres/bot_deletion_test.go
@@ -714,6 +714,7 @@ func waitForBlockedPostgresQuery(t *testing.T, ctx context.Context, db *sql.DB, 
 			SELECT COUNT(*)
 			FROM pg_stat_activity
 			WHERE datname = current_database()
+			  AND application_name = current_schema()
 			  AND pid <> pg_backend_pid()
 			  AND wait_event_type = 'Lock'
 			  AND cardinality(pg_blocking_pids(pid)) > 0

--- a/apps/api/internal/store/postgres/mutations.go
+++ b/apps/api/internal/store/postgres/mutations.go
@@ -244,6 +244,10 @@ func (s *Store) UpdateChannel(ctx context.Context, input store.UpdateChannelInpu
 	}
 	defer tx.Rollback()
 	qtx := s.q.WithTx(tx)
+	// Merge omitted fields only after earlier channel writers have committed.
+	if _, err := qtx.LockChannelForUpdate(ctx, input.ChannelID); err != nil {
+		return store.Channel{}, store.Event{}, err
+	}
 	chRow, err := qtx.GetChannel(ctx, input.ChannelID)
 	if err != nil {
 		return store.Channel{}, store.Event{}, err

--- a/apps/api/internal/store/postgres/mutations_test.go
+++ b/apps/api/internal/store/postgres/mutations_test.go
@@ -131,6 +131,65 @@ func TestChannelDisplayTitleRoundTripPostgres(t *testing.T) {
 	}
 }
 
+func TestChannelUpdateSerializesPartialWrites(t *testing.T) {
+	ctx := context.Background()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Channel Owner", "channel-lock@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := st.EnsureDefaultWorkspaceMember(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel, _, err := st.CreateChannel(ctx, store.CreateChannelInput{WorkspaceID: workspace.ID, UserID: owner.ID, Name: "before-lock"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	tx := mustBeginPostgresTx(t, ctx, st.db)
+	if _, err := tx.ExecContext(ctx, `UPDATE channels SET name = 'concurrent-name', archived_at = '2026-08-30T00:00:00Z', external_managed = 1, external_ref = 'concurrent-ref' WHERE id = $1`, channel.ID); err != nil {
+		t.Fatal(err)
+	}
+	nextTitle := "New display title"
+	type updateResult struct {
+		channel store.Channel
+		event   store.Event
+		err     error
+	}
+	result := make(chan updateResult, 1)
+	go func() {
+		updated, event, err := st.UpdateChannel(ctx, store.UpdateChannelInput{ChannelID: channel.ID, UserID: owner.ID, DisplayTitle: &nextTitle})
+		result <- updateResult{updated, event, err}
+	}()
+	waitForBlockedPostgresQuery(t, ctx, st.db, "channels")
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	updated := <-result
+	if updated.err != nil {
+		t.Fatal(updated.err)
+	}
+	persisted, err := st.GetChannel(ctx, channel.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, got := range []store.Channel{updated.channel, persisted} {
+		if got.Name != "concurrent-name" || got.DisplayTitle == nil || *got.DisplayTitle != nextTitle || got.ArchivedAt == nil || !got.ExternalManaged || got.ExternalRef == nil || *got.ExternalRef != "concurrent-ref" {
+			t.Fatalf("partial channel update lost a concurrent field: %#v", got)
+		}
+	}
+	payload, ok := updated.event.Payload.(map[string]any)
+	if !ok || payload["archived"] != true {
+		t.Fatalf("channel.updated lost concurrent archive state: %#v", updated.event.Payload)
+	}
+}
+
 func TestWorkspaceUpdateSerializesPartialWrites(t *testing.T) {
 	ctx := context.Background()
 	st := newIsolatedPostgresTestStore(t)

--- a/apps/api/internal/store/postgres/pins.go
+++ b/apps/api/internal/store/postgres/pins.go
@@ -38,7 +38,7 @@ func (s *Store) PinMessage(ctx context.Context, channelID, messageID, userID str
 		return store.PinnedMessage{}, store.Event{}, errors.New("deleted messages cannot be pinned")
 	}
 
-	if _, err := qtx.LockChannelForPinning(ctx, channelID); err != nil {
+	if _, err := qtx.LockChannelForUpdate(ctx, channelID); err != nil {
 		return store.PinnedMessage{}, store.Event{}, err
 	}
 	existingPinCount, err := qtx.CountPinnedMessage(ctx, storedb.CountPinnedMessageParams{

--- a/apps/api/internal/store/postgres/postgres_test.go
+++ b/apps/api/internal/store/postgres/postgres_test.go
@@ -307,6 +307,7 @@ func newIsolatedPostgresTestStore(t *testing.T) *Store {
 	}
 	query := parsed.Query()
 	query.Set("search_path", schema)
+	query.Set("application_name", schema)
 	parsed.RawQuery = query.Encode()
 	st, err := Open(parsed.String())
 	if err != nil {

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -1435,7 +1435,7 @@ INSERT INTO pinned_messages (id, workspace_id, channel_id, message_id, pinned_by
 VALUES (sqlc.arg(id), sqlc.arg(workspace_id), sqlc.arg(channel_id), sqlc.arg(message_id), sqlc.arg(pinned_by), sqlc.arg(created_at))
 ON CONFLICT(channel_id, message_id) DO NOTHING;
 
--- name: LockChannelForPinning :one
+-- name: LockChannelForUpdate :one
 SELECT id FROM channels WHERE id = sqlc.arg(channel_id) FOR UPDATE;
 
 -- name: LockMessageForPinning :one

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -4851,12 +4851,12 @@ func (q *Queries) LockBotWorkspaceMembership(ctx context.Context, arg LockBotWor
 	return user_id, err
 }
 
-const lockChannelForPinning = `-- name: LockChannelForPinning :one
+const lockChannelForUpdate = `-- name: LockChannelForUpdate :one
 SELECT id FROM channels WHERE id = $1 FOR UPDATE
 `
 
-func (q *Queries) LockChannelForPinning(ctx context.Context, channelID string) (string, error) {
-	row := q.db.QueryRowContext(ctx, lockChannelForPinning, channelID)
+func (q *Queries) LockChannelForUpdate(ctx context.Context, channelID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, lockChannelForUpdate, channelID)
 	var id string
 	err := row.Scan(&id)
 	return id, err

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -83,6 +83,8 @@ external_managed, external_ref, external_url, sidebar_section}`. Setting
 `archived=true` fills
 `archived_at`; `archived=false` clears it. Sending an empty string for any of
 the nullable display, external, or sidebar fields clears that field.
+Omitted fields retain their current values, including changes committed by
+concurrent updates.
 
 Channel responses include `display_title` when set. Human-facing web labels use
 it and fall back to `name`; API selectors, links, and routing continue to use


### PR DESCRIPTION
A title-only channel PATCH could overwrite a concurrent rename, archive change, or managed metadata on PostgreSQL. `UpdateChannel` read the old row before waiting for its write lock, then copied stale values into fields omitted from the request.

Acquire the channel row lock before reading and merging the patch, matching the existing workspace-update transaction. Rename and reuse the existing pinning lock query as `LockChannelForUpdate`; pinning keeps the same SQL and lock behavior. Read-only channel retrieval, validation, permissions, and error handling retain their existing paths.

Validation:

- A deterministic PostgreSQL 17 regression holds the first writer open, observes the second writer actually blocked in PostgreSQL using the isolated test's session identity, then releases the first writer. It fails on the parent commit and passes with this fix, checking the response, persisted row, and archive event.
- Existing channel display-title and managed-field roundtrips, workspace serialization, and pinning regressions pass.
- Full Go tests and the coverage gate pass with PostgreSQL enabled (86.1%). `pnpm check` also passed. Exact-head CI is green: Go, TypeScript, Docker, full Playwright, CodeQL, and desktop checks on Linux, Windows, and macOS.
- Required isolated Codex autoreviews found no actionable findings at the P0 threshold. Final-head ClawSweeper review found no correctness/security issues and accepted the real PostgreSQL/HTTP proof; parent independent source review is also clear.

No schema, configuration, dependency, or API-shape changes.

<details>
<summary>Independent real PostgreSQL 17 + HTTP proof</summary>

Using synthetic data, transaction A renames a channel and holds its row lock. A concurrent HTTP PATCH changes only `display_title`. The driver observes the blocked query in PostgreSQL, commits A, and records the PATCH response.

Baseline binary: `72e471b7b20c38cafa31f2a3c080ebcaed3ee514` (SHA-256 `f3092d1892f544cde019817f4ae315c00a12cd9a19f27a6429092b0079c66834`). Its `UpdateChannel` owner is identical to the immediate parent `9efb6299`, on which the regression test separately failed.

```json
{
  "proof": "real PostgreSQL17 transaction and HTTP channel PATCH",
  "blocked_at": "update",
  "concurrent_name": "renamed-concurrently",
  "returned_name": "concurrent-324588cf",
  "returned_display_title": "New display title",
  "both_changes_preserved": false
}
```

Candidate production source matches final head `c608d73bc3d62ca10d52d0cd7b33d36a9666539f`; the follow-up commits only scope test lock observations to their own database sessions. Immutable candidate SHA-256: `a9a25dfe7e034c9acf3651ff8866477ae77ebadb9edf66d4803d1e3e83c0d8b2`. Same database and driver; the wait now occurs at the lock/read, and both changes survive:

```json
{
  "proof": "real PostgreSQL17 transaction and HTTP channel PATCH",
  "blocked_at": "read",
  "concurrent_name": "renamed-concurrently",
  "returned_name": "renamed-concurrently",
  "returned_display_title": "New display title",
  "both_changes_preserved": true
}
```

</details>
