### PR TITLE
fix: preserve durable realtime order through commit and delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed durable realtime events being skipped after delayed publication or concurrent PostgreSQL commits, restored idle WebSocket ping/disconnect handling, and kept attachment callbacks and moderation responses consistent with committed events.
+
 - Fixed person actions opening group DMs, preserved exact one-to-one reopening, and made failed workspace, channel, and DM creation visible and retryable without late responses taking over navigation.
 
 - Fixed concurrent PostgreSQL channel settings updates overwriting changes to omitted fields.

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -426,7 +426,8 @@ func TestHTTPBotDeletionReleasesHandle(t *testing.T) {
 	}
 
 	hub := realtime.NewHub()
-	events, unsubscribe := hub.Subscribe(workspace.ID)
+	subscription, unsubscribe := hub.Subscribe(workspace.ID)
+	events := subscription.Events
 	t.Cleanup(unsubscribe)
 	server := httptest.NewServer(New(st, hub, Options{UploadDir: filepath.Join(t.TempDir(), "uploads")}).Handler())
 	t.Cleanup(server.Close)

--- a/apps/api/internal/httpapi/bot_commands_test.go
+++ b/apps/api/internal/httpapi/bot_commands_test.go
@@ -76,7 +76,8 @@ func TestHTTPBotCommandAuthorizationAndRealtime(t *testing.T) {
 	}
 
 	hub := realtime.NewHub()
-	events, unsubscribe := hub.Subscribe(workspace.ID)
+	subscription, unsubscribe := hub.Subscribe(workspace.ID)
+	events := subscription.Events
 	t.Cleanup(unsubscribe)
 	server := httptest.NewServer(New(st, hub, Options{}).Handler())
 	t.Cleanup(server.Close)

--- a/apps/api/internal/httpapi/features.go
+++ b/apps/api/internal/httpapi/features.go
@@ -599,7 +599,7 @@ func (s *Server) attachUpload(w http.ResponseWriter, r *http.Request) {
 	}
 	event, err := s.store.AttachUpload(r.Context(), store.AttachUploadInput{MessageID: chi.URLParam(r, "message_id"), UploadID: body.UploadID, UserID: act.user.ID})
 	if err == nil && event.ID != "" {
-		s.hub.Publish(event)
+		s.publishEvent(r.Context(), event)
 	}
 	writeResult(w, map[string]any{"ok": true}, err)
 }

--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -322,8 +322,15 @@ func TestDeletePinnedMessagePublishesPinRemovalBeforeDeletion(t *testing.T) {
 		Event         store.Event         `json:"event"`
 	}](t, server.URL+"/api/channels/"+channels[0].ID+"/pins", map[string]string{"message_id": message.ID})
 
-	events, unsubscribe := hub.Subscribe(workspaces[0].ID)
-	t.Cleanup(unsubscribe)
+	cursor, err := st.LatestEventCursor(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, _, err := websocket.Dial(ctx, strings.Replace(server.URL, "http://", "ws://", 1)+"/api/realtime/ws?workspace_id="+workspaces[0].ID+"&after_cursor="+cursor, &websocket.DialOptions{HTTPHeader: http.Header{"X-ClickClack-User": []string{owner.ID}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.CloseNow()
 	deleted := deleteJSONBody[struct {
 		Message store.Message `json:"message"`
 		Event   store.Event   `json:"event"`
@@ -331,16 +338,22 @@ func TestDeletePinnedMessagePublishesPinRemovalBeforeDeletion(t *testing.T) {
 	if deleted.Message.DeletedAt == nil || deleted.Event.Type != "message.deleted" {
 		t.Fatalf("unexpected delete response: %#v", deleted)
 	}
+	readCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	for index, want := range []string{"pin.removed", "message.deleted"} {
-		select {
-		case event := <-events:
-			if event.Type != want || event.Payload == nil {
-				t.Fatalf("event %d: expected %s with payload, got %#v", index, want, event)
-			}
-		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for event %d (%s)", index, want)
+		_, body, err := conn.Read(readCtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var event store.Event
+		if err := json.Unmarshal(body, &event); err != nil {
+			t.Fatal(err)
+		}
+		if event.Type != want || event.Payload == nil {
+			t.Fatalf("event %d: expected %s with payload, got %#v", index, want, event)
 		}
 	}
+
 	pinned := getJSON[struct {
 		Messages []store.Message `json:"messages"`
 	}](t, server.URL+"/api/channels/"+channels[0].ID+"/pins")

--- a/apps/api/internal/httpapi/realtime_control_test.go
+++ b/apps/api/internal/httpapi/realtime_control_test.go
@@ -1,0 +1,46 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+)
+
+func TestRealtimeIdleConnectionControlFrames(t *testing.T) {
+	for _, scenario := range []string{"ping", "disconnect"} {
+		t.Run(scenario, func(t *testing.T) {
+			fixture := newRealtimeWorkspaceFixture(t, "control-"+scenario+"@example.com")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			done := make(chan struct{})
+			handler := New(fixture.store, realtime.NewHub(), Options{}).Handler()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer close(done)
+				handler.ServeHTTP(w, r.WithContext(ctx))
+			}))
+			defer server.Close()
+			conn := dialRealtimeAsUser(t, server.URL, fixture.workspace.ID, fixture.owner.ID)
+			defer conn.CloseNow()
+			if scenario == "ping" {
+				conn.CloseRead(ctx)
+				pingCtx, pingCancel := context.WithTimeout(ctx, time.Second)
+				defer pingCancel()
+				if err := conn.Ping(pingCtx); err != nil {
+					t.Fatalf("idle realtime socket did not answer ping: %v", err)
+				}
+			}
+			if err := conn.CloseNow(); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+				t.Fatal("idle realtime handler remained subscribed after peer disconnected")
+			}
+		})
+	}
+}

--- a/apps/api/internal/httpapi/realtime_order_test.go
+++ b/apps/api/internal/httpapi/realtime_order_test.go
@@ -1,0 +1,271 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+type latePublicationCreateResult struct {
+	Message store.Message `json:"message"`
+	Event   store.Event   `json:"event"`
+}
+
+type latePublicationHTTPResult struct {
+	result latePublicationCreateResult
+	err    error
+}
+
+type latePublicationStore struct {
+	store.Store
+	heldNonce string
+	committed chan latePublicationCreateResult
+	release   <-chan struct{}
+	tails     chan string
+}
+
+func (s *latePublicationStore) CreateMessage(ctx context.Context, input store.CreateMessageInput) (store.Message, store.Event, error) {
+	message, event, err := s.Store.CreateMessage(ctx, input)
+	if err != nil || input.Nonce != s.heldNonce {
+		return message, event, err
+	}
+	// The real SQLite transaction has committed. Hold only this request's
+	// return to the HTTP handler, where the durable event is published.
+	s.committed <- latePublicationCreateResult{Message: message, Event: event}
+	select {
+	case <-s.release:
+		return message, event, nil
+	case <-ctx.Done():
+		return store.Message{}, store.Event{}, ctx.Err()
+	}
+}
+
+func (s *latePublicationStore) LatestEventCursor(ctx context.Context, workspaceID, userID string) (string, error) {
+	cursor, err := s.Store.LatestEventCursor(ctx, workspaceID, userID)
+	if err == nil {
+		select {
+		case s.tails <- cursor:
+		default:
+		}
+	}
+	return cursor, err
+}
+
+func TestRealtimeReconnectDoesNotLoseLatePublication(t *testing.T) {
+	fixture := newRealtimeWorkspaceFixture(t, "late-publication-owner@example.com")
+	ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+	defer cancel()
+
+	_, baseline, err := fixture.store.CreateMessage(ctx, store.CreateMessageInput{
+		ChannelID: fixture.channel.ID,
+		AuthorID:  fixture.owner.ID,
+		Body:      "baseline before either request",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release := make(chan struct{})
+	releaseHeld := sync.OnceFunc(func() { close(release) })
+	defer releaseHeld()
+	wrapped := &latePublicationStore{
+		Store:     fixture.store,
+		heldNonce: "late-publication-a",
+		committed: make(chan latePublicationCreateResult, 1),
+		release:   release,
+		tails:     make(chan string, 2),
+	}
+	server := httptest.NewServer(New(wrapped, realtime.NewHub(), Options{}).Handler())
+	t.Cleanup(server.Close)
+
+	post := func(body, nonce string) (latePublicationCreateResult, error) {
+		var result latePublicationCreateResult
+		payload, err := json.Marshal(map[string]string{"body": body, "nonce": nonce})
+		if err != nil {
+			return result, err
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			server.URL+"/api/channels/"+fixture.channel.ID+"/messages", bytes.NewReader(payload))
+		if err != nil {
+			return result, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-ClickClack-User", fixture.owner.ID)
+		resp, err := server.Client().Do(req)
+		if err != nil {
+			return result, err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			return result, fmt.Errorf("create message returned %s", resp.Status)
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			return result, err
+		}
+		return result, nil
+	}
+	mustPost := func(body, nonce string) latePublicationCreateResult {
+		t.Helper()
+		result, err := post(body, nonce)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	dial := func(cursor string) *websocket.Conn {
+		t.Helper()
+		endpoint := strings.Replace(server.URL, "http://", "ws://", 1) +
+			"/api/realtime/ws?workspace_id=" + url.QueryEscape(fixture.workspace.ID) +
+			"&after_cursor=" + url.QueryEscape(cursor)
+		conn, _, err := websocket.Dial(ctx, endpoint, &websocket.DialOptions{
+			HTTPHeader: http.Header{"X-ClickClack-User": []string{fixture.owner.ID}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = conn.CloseNow() })
+		select {
+		case captured := <-wrapped.tails:
+			if captured != cursor {
+				t.Fatalf("captured tail = %q, want starting checkpoint %q", captured, cursor)
+			}
+		case <-ctx.Done():
+			t.Fatalf("websocket did not capture its tail: %v", ctx.Err())
+		}
+		return conn
+	}
+	read := func(conn *websocket.Conn) store.Event {
+		t.Helper()
+		_, payload, err := conn.Read(ctx)
+		if err != nil {
+			t.Fatalf("read real event: %v", err)
+		}
+		var event store.Event
+		if err := json.Unmarshal(payload, &event); err != nil {
+			t.Fatal(err)
+		}
+		return event
+	}
+
+	first := dial(baseline.Cursor)
+	aResponse := make(chan latePublicationHTTPResult, 1)
+	go func() {
+		result, err := post("A commits before B but its handler is held", wrapped.heldNonce)
+		aResponse <- latePublicationHTTPResult{result: result, err: err}
+	}()
+	var a latePublicationCreateResult
+	select {
+	case a = <-wrapped.committed:
+	case response := <-aResponse:
+		t.Fatalf("A returned before reaching the commit barrier: %v", response.err)
+	case <-ctx.Done():
+		t.Fatalf("A did not reach the commit barrier: %v", ctx.Err())
+	}
+	persisted, err := fixture.store.GetMessage(ctx, a.Message.ID, fixture.owner.ID)
+	if err != nil || persisted.Body != a.Message.Body {
+		t.Fatalf("A is not durably readable while its handler is held: message=%#v error=%v", persisted, err)
+	}
+
+	b := mustPost("B publishes while A's handler is held", "late-publication-b")
+	if a.Event.Cursor == "" || a.Event.Cursor >= b.Event.Cursor {
+		t.Fatalf("fixture cursors do not establish A before B: A=%q B=%q", a.Event.Cursor, b.Event.Cursor)
+	}
+	seenA := 0
+	var checkpoint string
+	for {
+		event := read(first)
+		if event.ID == a.Event.ID {
+			seenA++
+		}
+		if event.ID == b.Event.ID {
+			checkpoint = event.Cursor
+			break
+		}
+	}
+	if err := first.CloseNow(); err != nil {
+		t.Fatal(err)
+	}
+
+	reconnected := dial(checkpoint)
+	releaseHeld()
+	select {
+	case response := <-aResponse:
+		if response.err != nil || response.result.Event.ID != a.Event.ID {
+			t.Fatalf("held A request failed: result=%#v error=%v", response.result, response.err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("A did not finish after release: %v", ctx.Err())
+	}
+
+	// A's completed HTTP response establishes that its publication finished.
+	// A later real message is the delivery barrier; no timeout proves absence.
+	sentinel := mustPost("sentinel after A's response completed", "late-publication-sentinel")
+	for {
+		event := read(reconnected)
+		if event.ID == a.Event.ID {
+			seenA++
+		}
+		if event.ID == sentinel.Event.ID {
+			break
+		}
+	}
+	if seenA != 1 {
+		t.Fatalf("committed event A was delivered %d times across checkpoint and reconnect; want once: A=%s checkpoint=%s sentinel=%s", seenA, a.Event.Cursor, checkpoint, sentinel.Event.Cursor)
+	}
+}
+
+func TestPrivatePublicationWakesEarlierPublicEvent(t *testing.T) {
+	f := newRealtimeWorkspaceFixture(t, "private-wake@example.com")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	viewer, err := f.store.CreateUser(ctx, store.CreateUserInput{DisplayName: "Viewer", Email: "private-viewer@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.store.AddWorkspaceMember(ctx, f.workspace.ID, viewer.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	defer releaseOnce()
+	observed := &capturedTailStore{Store: f.store, captured: make(chan string, 1), release: release}
+	server := httptest.NewServer(New(observed, realtime.NewHub(), Options{}).Handler())
+	defer server.Close()
+	conn := dialRealtimeAsUser(t, server.URL, f.workspace.ID, viewer.ID)
+	defer conn.CloseNow()
+	select {
+	case <-observed.captured:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	// Commit A without publishing its receipt; the later private read is its sole wakeup.
+	message, a, err := f.store.CreateMessage(ctx, store.CreateMessageInput{ChannelID: f.channel.ID, AuthorID: f.owner.ID, Body: "earlier public event"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postJSONAsUser[map[string]any](t, f.owner.ID, server.URL+"/api/channels/"+f.channel.ID+"/read", map[string]int64{"seq": *message.ChannelSeq})
+	releaseOnce()
+	_, body, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("private publication did not wake public event: %v", err)
+	}
+	var got store.Event
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != a.ID {
+		t.Fatalf("got %#v, want only earlier public event %s", got, a.ID)
+	}
+}

--- a/apps/api/internal/httpapi/realtime_tail_test.go
+++ b/apps/api/internal/httpapi/realtime_tail_test.go
@@ -462,120 +462,135 @@ func TestRealtimeCursorAheadOfTailRequestsAuthoritativeResync(t *testing.T) {
 	}
 }
 
-func TestRealtimeOverflowClosesAndReconnectReplays(t *testing.T) {
-	t.Parallel()
-	fixture := newRealtimeWorkspaceFixture(t, "realtime-overflow-owner@example.com")
-	ctx, st, owner, workspace, channel := fixture.ctx, fixture.store, fixture.owner, fixture.workspace, fixture.channel
+func TestRealtimeLiveDrainAndOverflowRecovery(t *testing.T) {
+	for _, overflow := range []bool{false, true} {
+		t.Run(fmt.Sprintf("ephemeral_overflow=%t", overflow), func(t *testing.T) {
+			t.Parallel()
+			fixture := newRealtimeWorkspaceFixture(t, "realtime-overflow-owner@example.com")
+			ctx, st, owner, workspace, channel := fixture.ctx, fixture.store, fixture.owner, fixture.workspace, fixture.channel
 
-	hub := realtime.NewHub()
-	tailCaptured := make(chan struct{})
-	entered := make(chan struct{})
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
-	blockingStore := &blockingChannelStore{
-		Store:        st,
-		tailCaptured: tailCaptured,
-		entered:      entered,
-		release:      release,
-	}
-	server := httptest.NewServer(New(blockingStore, hub, Options{}).Handler())
-	t.Cleanup(server.Close)
+			hub := realtime.NewHub()
+			tailCaptured := make(chan struct{})
+			entered := make(chan struct{})
+			release := make(chan struct{})
+			var releaseOnce sync.Once
+			t.Cleanup(func() { releaseOnce.Do(func() { close(release) }) })
+			blockingStore := &blockingChannelStore{
+				Store:        st,
+				tailCaptured: tailCaptured,
+				entered:      entered,
+				release:      release,
+			}
+			server := httptest.NewServer(New(blockingStore, hub, Options{}).Handler())
+			t.Cleanup(server.Close)
 
-	dial := func(afterCursor string) *websocket.Conn {
-		t.Helper()
-		dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		wsURL := strings.Replace(server.URL, "http://", "ws://", 1) +
-			"/api/realtime/ws?workspace_id=" + url.QueryEscape(workspace.ID) +
-			"&after_cursor=" + url.QueryEscape(afterCursor)
-		conn, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
-			HTTPHeader: http.Header{"X-ClickClack-User": []string{owner.ID}},
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		return conn
-	}
+			dial := func(afterCursor string) *websocket.Conn {
+				t.Helper()
+				dialCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				wsURL := strings.Replace(server.URL, "http://", "ws://", 1) +
+					"/api/realtime/ws?workspace_id=" + url.QueryEscape(workspace.ID) +
+					"&after_cursor=" + url.QueryEscape(afterCursor)
+				conn, _, err := websocket.Dial(dialCtx, wsURL, &websocket.DialOptions{
+					HTTPHeader: http.Header{"X-ClickClack-User": []string{owner.ID}},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return conn
+			}
 
-	conn := dial("")
-	t.Cleanup(func() { conn.CloseNow() })
-	select {
-	case <-tailCaptured:
-	case <-time.After(5 * time.Second):
-		t.Fatal("websocket did not capture the replay tail")
-	}
-
-	published := make([]store.Event, 0, 34)
-	for i := 0; i < 34; i++ {
-		_, event, err := st.CreateMessage(ctx, store.CreateMessageInput{
-			ChannelID: channel.ID,
-			AuthorID:  owner.ID,
-			Body:      fmt.Sprintf("overflow message %d", i),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		published = append(published, event)
-		hub.Publish(event)
-		if i == 0 {
+			conn := dial("")
+			t.Cleanup(func() { conn.CloseNow() })
 			select {
-			case <-entered:
+			case <-tailCaptured:
 			case <-time.After(5 * time.Second):
-				t.Fatal("websocket did not begin delivering the first live event")
+				t.Fatal("websocket did not capture the replay tail")
 			}
-		}
-	}
-	releaseOnce.Do(func() { close(release) })
 
-	readCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	received := make([]store.Event, 0, 33)
-	for {
-		_, body, err := conn.Read(readCtx)
-		if err != nil {
-			if got := websocket.CloseStatus(err); got != websocket.StatusTryAgainLater {
-				t.Fatalf("close status = %v, want %v: %v", got, websocket.StatusTryAgainLater, err)
+			published := make([]store.Event, 0, 34)
+			for i := 0; i < 34; i++ {
+				_, event, err := st.CreateMessage(ctx, store.CreateMessageInput{
+					ChannelID: channel.ID,
+					AuthorID:  owner.ID,
+					Body:      fmt.Sprintf("overflow message %d", i),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				published = append(published, event)
+				hub.Publish(event)
+				if i == 0 {
+					select {
+					case <-entered:
+					case <-time.After(5 * time.Second):
+						t.Fatal("websocket did not begin delivering the first live event")
+					}
+				}
 			}
-			var closeErr websocket.CloseError
-			if !errors.As(err, &closeErr) {
-				t.Fatalf("expected websocket close error, got %T: %v", err, err)
+			if overflow {
+				for i := 0; i < 34; i++ {
+					hub.Publish(store.Event{WorkspaceID: workspace.ID, Type: "presence.changed"})
+				}
 			}
-			if closeErr.Reason != realtimeOverflowCloseReason {
-				t.Fatalf("close reason = %q, want %q", closeErr.Reason, realtimeOverflowCloseReason)
-			}
-			break
-		}
-		var event store.Event
-		if err := json.Unmarshal(body, &event); err != nil {
-			t.Fatal(err)
-		}
-		received = append(received, event)
-	}
-	if len(received) == 0 || len(received) >= len(published) {
-		t.Fatalf("received %d of %d events before overflow close", len(received), len(published))
-	}
-	for i, event := range received {
-		if event.ID != published[i].ID {
-			t.Fatalf("live event %d = %q, want %q", i, event.ID, published[i].ID)
-		}
-	}
+			releaseOnce.Do(func() { close(release) })
 
-	reconnected := dial(received[len(received)-1].Cursor)
-	defer reconnected.CloseNow()
-	replayCtx, replayCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer replayCancel()
-	for i := len(received); i < len(published); i++ {
-		_, body, err := reconnected.Read(replayCtx)
-		if err != nil {
-			t.Fatal(err)
-		}
-		var replayed store.Event
-		if err := json.Unmarshal(body, &replayed); err != nil {
-			t.Fatal(err)
-		}
-		if replayed.ID != published[i].ID {
-			t.Fatalf("replayed event %d = %q, want %q", i, replayed.ID, published[i].ID)
-		}
+			readCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			received := make([]store.Event, 0, 33)
+			for overflow || len(received) < len(published) {
+				_, body, err := conn.Read(readCtx)
+				if err != nil {
+					if !overflow {
+						t.Fatalf("durable burst closed after %d of %d events: %v", len(received), len(published), err)
+					}
+					if got := websocket.CloseStatus(err); got != websocket.StatusTryAgainLater {
+						t.Fatalf("close status = %v, want %v: %v", got, websocket.StatusTryAgainLater, err)
+					}
+					var closeErr websocket.CloseError
+					if !errors.As(err, &closeErr) {
+						t.Fatalf("expected websocket close error, got %T: %v", err, err)
+					}
+					if closeErr.Reason != realtimeOverflowCloseReason {
+						t.Fatalf("close reason = %q, want %q", closeErr.Reason, realtimeOverflowCloseReason)
+					}
+					break
+				}
+				var event store.Event
+				if err := json.Unmarshal(body, &event); err != nil {
+					t.Fatal(err)
+				}
+				received = append(received, event)
+			}
+			if overflow && (len(received) == 0 || len(received) >= len(published)) {
+				t.Fatalf("received %d of %d events before overflow close", len(received), len(published))
+			}
+			for i, event := range received {
+				if event.ID != published[i].ID {
+					t.Fatalf("live event %d = %q, want %q", i, event.ID, published[i].ID)
+				}
+			}
+
+			if !overflow {
+				return
+			}
+			reconnected := dial(received[len(received)-1].Cursor)
+			defer reconnected.CloseNow()
+			replayCtx, replayCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer replayCancel()
+			for i := len(received); i < len(published); i++ {
+				_, body, err := reconnected.Read(replayCtx)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var replayed store.Event
+				if err := json.Unmarshal(body, &replayed); err != nil {
+					t.Fatal(err)
+				}
+				if replayed.ID != published[i].ID {
+					t.Fatalf("replayed event %d = %q, want %q", i, replayed.ID, published[i].ID)
+				}
+			}
+		})
 	}
 }

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1331,7 +1331,7 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
-	events, unsubscribe := s.hub.Subscribe(workspaceID)
+	subscription, unsubscribe := s.hub.Subscribe(workspaceID)
 	defer unsubscribe()
 	acceptOptions := &websocket.AcceptOptions{OriginPatterns: s.websocketOriginPatterns(r)}
 	if bearerProtocol != "" {
@@ -1342,96 +1342,116 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer conn.CloseNow()
-	ctx := r.Context()
-	replayTail, err := s.store.LatestEventCursor(ctx, workspaceID, act.user.ID)
-	if err != nil {
-		_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-		return
-	}
+	ctx := conn.CloseRead(r.Context())
 	replayCursor := r.URL.Query().Get("after_cursor")
-	if replayCursor != "" {
-		exists, err := s.store.EventCursorExists(ctx, workspaceID, act.user.ID, replayCursor)
+	// Startup and live delivery share one ordered, authorized durable-log drain.
+	// Capture a finite tail each time; a wake received during this drain stays queued.
+	drain := func() bool {
+		replayTail, err := s.store.LatestEventCursor(ctx, workspaceID, act.user.ID)
 		if err != nil {
 			_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-			return
+			return false
 		}
-		if !exists {
-			_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
-			return
-		}
-	}
-	if replayCursor != "" && (replayTail == "" || replayCursor > replayTail) {
-		_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
-		return
-	}
-	replayedEvents := 0
-	for replayTail != "" && replayCursor < replayTail {
-		pageCursor := replayCursor
-		backlog, err := s.store.ListEventsAfter(ctx, workspaceID, act.user.ID, pageCursor, realtimeReplayPageSize)
-		if err != nil {
-			_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-			return
-		}
-		if len(backlog) == 0 {
-			_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
-			return
-		}
-		if pageCursor != "" {
-			exists, err := s.store.EventCursorExists(ctx, workspaceID, act.user.ID, pageCursor)
+		if replayCursor != "" {
+			exists, err := s.store.EventCursorExists(ctx, workspaceID, act.user.ID, replayCursor)
 			if err != nil {
 				_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-				return
+				return false
 			}
 			if !exists {
 				_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
-				return
+				return false
 			}
 		}
-		previousCursor := pageCursor
-		for _, event := range backlog {
-			if event.Cursor > replayTail {
-				break
-			}
-			if replayedEvents >= s.realtimeReplayLimit {
-				_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
-				return
-			}
-			replayedEvents++
-			// ListEventsAfter prefilters visibility, while this live lookup closes
-			// the revocation window between fetching a page and writing its events.
-			deliver, err := s.shouldDeliverEventToActorResult(ctx, event, act.user.ID)
+		if replayCursor != "" && (replayTail == "" || replayCursor > replayTail) {
+			_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
+			return false
+		}
+		replayedEvents := 0
+		for replayTail != "" && replayCursor < replayTail {
+			pageCursor := replayCursor
+			backlog, err := s.store.ListEventsAfter(ctx, workspaceID, act.user.ID, pageCursor, realtimeReplayPageSize)
 			if err != nil {
 				_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-				return
+				return false
 			}
-			if !deliver {
+			if len(backlog) == 0 {
+				_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
+				return false
+			}
+			if pageCursor != "" {
+				exists, err := s.store.EventCursorExists(ctx, workspaceID, act.user.ID, pageCursor)
+				if err != nil {
+					_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
+					return false
+				}
+				if !exists {
+					_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
+					return false
+				}
+			}
+			previousCursor := pageCursor
+			for _, event := range backlog {
+				if event.Cursor > replayTail {
+					break
+				}
+				if replayedEvents >= s.realtimeReplayLimit {
+					_ = conn.Close(realtimeResyncRequiredStatus, realtimeResyncRequiredCloseReason)
+					return false
+				}
+				replayedEvents++
+				// ListEventsAfter prefilters visibility, while this live lookup closes
+				// the revocation window between fetching a page and writing its events.
+				deliver, err := s.shouldDeliverEventToActorResult(ctx, event, act.user.ID)
+				if err != nil {
+					_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
+					return false
+				}
+				if !deliver {
+					replayCursor = event.Cursor
+					continue
+				}
+				if err := writeWS(ctx, conn, event); err != nil {
+					return false
+				}
 				replayCursor = event.Cursor
-				continue
 			}
-			if err := writeWS(ctx, conn, event); err != nil {
-				return
+			if replayCursor == previousCursor {
+				_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
+				return false
 			}
-			replayCursor = event.Cursor
 		}
-		if replayCursor == previousCursor {
-			_ = conn.Close(websocket.StatusTryAgainLater, realtimeReplayCloseReason)
-			return
-		}
+		return true
+	}
+	if !drain() {
+		return
 	}
 	for {
+		// Prefer overflow termination to starting another durable drain.
+		select {
+		case <-subscription.Done:
+			_ = conn.Close(websocket.StatusTryAgainLater, realtimeOverflowCloseReason)
+			return
+		default:
+		}
 		select {
 		case <-ctx.Done():
 			return
-		case event, ok := <-events:
+		case <-subscription.Done:
+			_ = conn.Close(websocket.StatusTryAgainLater, realtimeOverflowCloseReason)
+			return
+		case _, ok := <-subscription.Wake:
 			if !ok {
-				_ = conn.Close(websocket.StatusTryAgainLater, realtimeOverflowCloseReason)
-				return
-			}
-			if event.Cursor != "" && event.Cursor <= replayCursor {
 				continue
 			}
-			// Bot deletion and membership-removal revocations are intentionally
-			// ephemeral, so they only arrive on the live hub path, never replay.
+			if !drain() {
+				return
+			}
+		case event, ok := <-subscription.Events:
+			if !ok {
+				continue
+			}
+			// Revocations and other cursorless events are intentionally ephemeral.
 			if eventRevokesWorkspaceAccess(event, act.user.ID) {
 				_ = conn.Close(websocket.StatusPolicyViolation, "workspace access revoked")
 				return

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -1630,7 +1630,7 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 		EventSubscription store.EventSubscription `json:"event_subscription"`
 	}](t, owner.ID, server.URL+"/api/workspaces/"+workspace.ID+"/event-subscriptions", map[string]any{
 		"app_installation_id": createdInstall.AppInstallation.ID,
-		"event_types":         []string{"message.created"},
+		"event_types":         []string{"message.created", "message.updated"},
 		"callback_url":        eventCallbackServer.URL,
 	})
 	eventSigningSecret = eventSubscription.EventSubscription.SigningSecret
@@ -1703,6 +1703,32 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 		nil,
 		http.StatusBadRequest,
 	)
+	// Attachments use the same signed callback owner as other message updates.
+	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "callback.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: filepath.Join(dataDir, "callback.txt")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postJSONAsUser[map[string]any](t, owner.ID, server.URL+"/api/messages/"+topicMessage.Message.ID+"/attachments", map[string]string{"upload_id": upload.ID})
+	if eventPayload["event"].(map[string]any)["type"] != "message.updated" {
+		t.Fatalf("missing attachment callback: %#v", eventPayload)
+	}
+	// An idempotent attachment retry and a private DM attachment must not send callbacks.
+	postJSONAsUser[map[string]any](t, owner.ID, server.URL+"/api/messages/"+topicMessage.Message.ID+"/attachments", map[string]string{"upload_id": upload.ID})
+	privateDM, err := st.CreateDirectConversation(ctx, store.CreateDirectConversationInput{WorkspaceID: workspace.ID, UserID: owner.ID, MemberIDs: []string{createdBot.Bot.ID}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateMessage, _, err := st.CreateDirectMessage(ctx, store.CreateDirectMessageInput{ConversationID: privateDM.ID, AuthorID: owner.ID, Body: "private attachment"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	postJSONAsUser[map[string]any](t, owner.ID, server.URL+"/api/messages/"+privateMessage.ID+"/attachments", map[string]string{"upload_id": upload.ID})
+	attachmentDeliveries := getJSONAsUser[struct {
+		Deliveries []store.EventDeliveryAttempt `json:"deliveries"`
+	}](t, owner.ID, server.URL+"/api/event-subscriptions/"+eventSubscription.EventSubscription.ID+"/deliveries")
+	if len(attachmentDeliveries.Deliveries) != 4 || attachmentDeliveries.Deliveries[0].EventType != "message.updated" {
+		t.Fatalf("attachment callback count/privacy changed: %#v", attachmentDeliveries)
+	}
 	revokedSubscription := postJSONAsUser[struct {
 		EventSubscription store.EventSubscription `json:"event_subscription"`
 	}](t, owner.ID, server.URL+"/api/event-subscriptions/"+eventSubscription.EventSubscription.ID+"/revoke", map[string]any{})

--- a/apps/api/internal/realtime/hub.go
+++ b/apps/api/internal/realtime/hub.go
@@ -8,37 +8,51 @@ import (
 
 const subscriberBufferSize = 32
 
+type Subscription struct {
+	Events <-chan store.Event
+	Wake   <-chan struct{}
+	Done   <-chan struct{}
+}
+
+type subscriber struct {
+	events chan store.Event
+	wake   chan struct{}
+	done   chan struct{}
+}
+
 type Hub struct {
 	mu   sync.Mutex
-	subs map[string]map[chan store.Event]struct{}
+	subs map[string]map[*subscriber]struct{}
 }
 
 func NewHub() *Hub {
-	return &Hub{subs: map[string]map[chan store.Event]struct{}{}}
+	return &Hub{subs: map[string]map[*subscriber]struct{}{}}
 }
 
-func (h *Hub) Subscribe(workspaceID string) (<-chan store.Event, func()) {
-	ch := make(chan store.Event, subscriberBufferSize)
+func (h *Hub) Subscribe(workspaceID string) (Subscription, func()) {
+	sub := &subscriber{make(chan store.Event, subscriberBufferSize), make(chan struct{}, 1), make(chan struct{})}
 	h.mu.Lock()
 	if h.subs[workspaceID] == nil {
-		h.subs[workspaceID] = map[chan store.Event]struct{}{}
+		h.subs[workspaceID] = map[*subscriber]struct{}{}
 	}
-	h.subs[workspaceID][ch] = struct{}{}
+	h.subs[workspaceID][sub] = struct{}{}
 	h.mu.Unlock()
-	return ch, func() {
+	return Subscription{sub.events, sub.wake, sub.done}, func() {
 		h.mu.Lock()
 		defer h.mu.Unlock()
-		h.removeSubscriberLocked(workspaceID, ch)
+		h.removeSubscriberLocked(workspaceID, sub)
 	}
 }
 
-func (h *Hub) removeSubscriberLocked(workspaceID string, ch chan store.Event) {
+func (h *Hub) removeSubscriberLocked(workspaceID string, sub *subscriber) {
 	subs := h.subs[workspaceID]
-	if _, ok := subs[ch]; !ok {
+	if _, ok := subs[sub]; !ok {
 		return
 	}
-	delete(subs, ch)
-	close(ch)
+	delete(subs, sub)
+	close(sub.done)
+	close(sub.events)
+	close(sub.wake)
 	if len(subs) == 0 {
 		delete(h.subs, workspaceID)
 	}
@@ -47,12 +61,20 @@ func (h *Hub) removeSubscriberLocked(workspaceID string, ch chan store.Event) {
 func (h *Hub) Publish(event store.Event) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	subs := h.subs[event.WorkspaceID]
-	for ch := range subs {
+	for sub := range h.subs[event.WorkspaceID] {
+		if event.Cursor != "" {
+			// Durable receipts only wake the authorized log reader. Even a private
+			// receipt can unblock delivery of earlier public events in this workspace.
+			select {
+			case sub.wake <- struct{}{}:
+			default:
+			}
+			continue
+		}
 		select {
-		case ch <- event:
+		case sub.events <- event:
 		default:
-			h.removeSubscriberLocked(event.WorkspaceID, ch)
+			h.removeSubscriberLocked(event.WorkspaceID, sub)
 		}
 	}
 }

--- a/apps/api/internal/realtime/hub_test.go
+++ b/apps/api/internal/realtime/hub_test.go
@@ -11,7 +11,8 @@ import (
 func TestHubSubscribePublishAndUnsubscribe(t *testing.T) {
 	t.Parallel()
 	hub := NewHub()
-	events, unsubscribe := hub.Subscribe("wsp_1")
+	eventsSubscription, unsubscribe := hub.Subscribe("wsp_1")
+	events := eventsSubscription.Events
 	event := store.Event{ID: "evt_1", WorkspaceID: "wsp_1", Type: "message.created"}
 	hub.Publish(event)
 
@@ -42,9 +43,12 @@ func TestHubSubscribePublishAndUnsubscribe(t *testing.T) {
 func TestHubOverflowClosesOnlySlowSubscriber(t *testing.T) {
 	t.Parallel()
 	hub := NewHub()
-	slow, unsubscribeSlow := hub.Subscribe("wsp_1")
-	healthy, unsubscribeHealthy := hub.Subscribe("wsp_1")
-	isolated, unsubscribeIsolated := hub.Subscribe("wsp_2")
+	slowSubscription, unsubscribeSlow := hub.Subscribe("wsp_1")
+	slow := slowSubscription.Events
+	healthySubscription, unsubscribeHealthy := hub.Subscribe("wsp_1")
+	healthy := healthySubscription.Events
+	isolatedSubscription, unsubscribeIsolated := hub.Subscribe("wsp_2")
+	isolated := isolatedSubscription.Events
 	defer unsubscribeHealthy()
 	defer unsubscribeIsolated()
 
@@ -108,5 +112,41 @@ func receiveEvent(t *testing.T, events <-chan store.Event) store.Event {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for event")
 		return store.Event{}
+	}
+}
+
+func TestDurableWakeCoalescesWithoutPrivatePayload(t *testing.T) {
+	hub := NewHub()
+	sub, unsubscribe := hub.Subscribe("workspace")
+	defer unsubscribe()
+	for i := 0; i < subscriberBufferSize*2; i++ {
+		hub.Publish(store.Event{WorkspaceID: "workspace", Cursor: fmt.Sprintf("cur_%d", i), RecipientUserIDs: []string{"private-user"}, Payload: "private"})
+	}
+	select {
+	case <-sub.Wake:
+	default:
+		t.Fatal("missing durable wake")
+	}
+	select {
+	case <-sub.Wake:
+		t.Fatal("durable wakes were not coalesced")
+	default:
+	}
+	select {
+	case event := <-sub.Events:
+		t.Fatalf("private receipt sent to ephemeral queue: %#v", event)
+	default:
+	}
+	select {
+	case <-sub.Done:
+		t.Fatal("durable burst overflowed subscription")
+	default:
+	}
+	// Once a drain consumes a wake, a publication during that drain must remain queued.
+	hub.Publish(store.Event{WorkspaceID: "workspace", Cursor: "cur_next"})
+	select {
+	case <-sub.Wake:
+	default:
+		t.Fatal("wake during drain lost")
 	}
 }

--- a/apps/api/internal/store/event_cursor.go
+++ b/apps/api/internal/store/event_cursor.go
@@ -1,0 +1,35 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// EventCursorAfter keeps the candidate's entropy while placing it above the
+// persisted workspace frontier. Callers must serialize appends through commit.
+func EventCursorAfter(candidate, frontier string) (string, error) {
+	if candidate > frontier {
+		return candidate, nil
+	}
+	id, err := ulid.ParseStrict(strings.TrimPrefix(candidate, "cur_"))
+	if err != nil {
+		return "", fmt.Errorf("event cursor candidate: %w", err)
+	}
+	previous, err := ulid.ParseStrict(strings.TrimPrefix(frontier, "cur_"))
+	if err != nil {
+		return "", fmt.Errorf("event cursor frontier: %w", err)
+	}
+	// Reuse the frontier millisecond when fresh entropy already sorts above it.
+	// Otherwise advance just one millisecond, preserving cross-workspace entropy.
+	if err := id.SetTime(previous.Time()); err != nil {
+		return "", err
+	}
+	if id.Compare(previous) <= 0 {
+		if err := id.SetTime(previous.Time() + 1); err != nil {
+			return "", err
+		}
+	}
+	return "cur_" + strings.ToLower(id.String()), nil
+}

--- a/apps/api/internal/store/event_cursor_test.go
+++ b/apps/api/internal/store/event_cursor_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+)
+
+func TestEventCursorAfter(t *testing.T) {
+	cursor := func(ms uint64, entropy byte) string {
+		id := ulid.ULID{}
+		if err := id.SetTime(ms); err != nil {
+			t.Fatal(err)
+		}
+		id[15] = entropy
+		return "cur_" + strings.ToLower(id.String())
+	}
+	for _, tc := range []struct {
+		name                      string
+		candidate, frontier, want string
+	}{
+		{"empty", cursor(100, 1), "", cursor(100, 1)},
+		{"already later", cursor(101, 1), cursor(100, 255), cursor(101, 1)},
+		{"equal", cursor(100, 1), cursor(100, 1), cursor(101, 1)},
+		{"lower entropy", cursor(100, 1), cursor(100, 2), cursor(101, 1)},
+		{"older clock higher entropy", cursor(99, 2), cursor(100, 1), cursor(100, 2)},
+		{"older clock lower entropy", cursor(99, 1), cursor(100, 2), cursor(101, 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := EventCursorAfter(tc.candidate, tc.frontier)
+			if err != nil || got != tc.want {
+				t.Fatalf("got %s, %v; want %s", got, err, tc.want)
+			}
+			if _, err := ulid.ParseStrict(strings.TrimPrefix(got, "cur_")); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+	maximum := cursor(ulid.MaxTime(), 255)
+	if _, err := EventCursorAfter(maximum, maximum); err == nil {
+		t.Fatal("expected timestamp exhaustion error")
+	}
+}

--- a/apps/api/internal/store/postgres/event_order_test.go
+++ b/apps/api/internal/store/postgres/event_order_test.go
@@ -1,0 +1,221 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+type eventOrderFixture struct {
+	st        *Store
+	owner     store.User
+	workspace store.Workspace
+	channel   store.Channel
+}
+
+func newEventOrderFixture(t *testing.T) eventOrderFixture {
+	t.Helper()
+	ctx := t.Context()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "event-order@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return eventOrderFixture{st, owner, workspaces[0], channels[0]}
+}
+
+type eventOrderResult struct {
+	events []store.Event
+	err    error
+}
+
+func awaitEventOrderResult(t *testing.T, ctx context.Context, result <-chan eventOrderResult) []store.Event {
+	t.Helper()
+	select {
+	case got := <-result:
+		if got.err != nil {
+			t.Fatal(got.err)
+		}
+		return got.events
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+		return nil
+	}
+}
+
+func TestPostgresEventCommitOrder(t *testing.T) {
+	for _, scenario := range []string{"commit", "rollback", "private", "reply"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newEventOrderFixture(t)
+			ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+			defer cancel()
+			root, baseline, err := f.st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: f.channel.ID, AuthorID: f.owner.ID, Body: "reply root"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx := mustBeginPostgresTx(t, ctx, f.st.db)
+			var recipients []string
+			if scenario == "private" {
+				recipients = []string{f.owner.ID}
+			}
+			first, err := insertEventWithRecipients(ctx, tx, f.workspace.ID, "", "workspace.updated", nil, map[string]string{"workspace_id": f.workspace.ID}, recipients)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan eventOrderResult, 1)
+			go func() {
+				if scenario == "reply" {
+					_, _, events, err := f.st.CreateThreadReply(ctx, store.CreateThreadReplyInput{RootMessageID: root.ID, AuthorID: f.owner.ID, Body: "two-event reply"})
+					done <- eventOrderResult{events, err}
+				} else {
+					_, event, err := f.st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: f.channel.ID, AuthorID: f.owner.ID, Body: "later transaction"})
+					done <- eventOrderResult{[]store.Event{event}, err}
+				}
+			}()
+			waitForBlockedPostgresQuery(t, ctx, f.st.db, "LockWorkspaceEventLog")
+			if scenario == "rollback" {
+				err = tx.Rollback()
+			} else {
+				err = tx.Commit()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			later := awaitEventOrderResult(t, ctx, done)
+			if len(later) == 0 {
+				t.Fatal("missing later events")
+			}
+			if scenario != "rollback" && later[0].Cursor <= first.Cursor {
+				t.Fatalf("commit order inverted: %s then %s", first.Cursor, later[0].Cursor)
+			}
+			if scenario == "reply" && (len(later) != 2 || later[0].Cursor >= later[1].Cursor) {
+				t.Fatalf("reply batch not ordered: %#v", later)
+			}
+			replay, err := f.st.ListEventsAfter(ctx, f.workspace.ID, f.owner.ID, baseline.Cursor, 20)
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := later
+			if scenario != "rollback" {
+				want = append([]store.Event{first}, later...)
+			}
+			if len(replay) != len(want) {
+				t.Fatalf("replay has %d events, want %d", len(replay), len(want))
+			}
+			for i := range want {
+				if replay[i].ID != want[i].ID {
+					t.Fatalf("replay %d=%s want %s", i, replay[i].ID, want[i].ID)
+				}
+			}
+		})
+	}
+}
+
+func TestPostgresEventLogLeavesOtherWorkspacesIndependent(t *testing.T) {
+	f := newEventOrderFixture(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	other, err := f.st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Independent"}, f.owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx := mustBeginPostgresTx(t, ctx, f.st.db)
+	first, err := insertEvent(ctx, tx, f.workspace.ID, "", "workspace.updated", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The second workspace must commit without releasing the first workspace's fence.
+	_, second, err := f.st.CreateChannel(ctx, store.CreateChannelInput{WorkspaceID: other.ID, UserID: f.owner.ID, Name: "independent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Cursor == first.Cursor {
+		t.Fatal("cross-workspace cursor collision")
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPostgresEventParentLocksPrecedeLogLock(t *testing.T) {
+	for _, parent := range []string{"workspace", "recipient"} {
+		t.Run(parent, func(t *testing.T) {
+			f := newEventOrderFixture(t)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			tx := mustBeginPostgresTx(t, ctx, f.st.db)
+			query, id, fragment := `SELECT id FROM workspaces WHERE id=$1 FOR UPDATE`, f.workspace.ID, "LockEventWorkspace"
+			if parent == "recipient" {
+				query, id, fragment = `SELECT id FROM users WHERE id=$1 FOR UPDATE`, f.owner.ID, "LockEventRecipient"
+			}
+			var locked string
+			if err := tx.QueryRowContext(ctx, query, id).Scan(&locked); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan eventOrderResult, 1)
+			go func() {
+				secondTx, err := f.st.db.BeginTx(ctx, nil)
+				if err != nil {
+					done <- eventOrderResult{err: err}
+					return
+				}
+				defer secondTx.Rollback()
+				event, err := insertEventWithRecipients(ctx, secondTx, f.workspace.ID, "", "workspace.updated", nil, nil, []string{f.owner.ID})
+				if err == nil {
+					err = secondTx.Commit()
+				}
+				done <- eventOrderResult{[]store.Event{event}, err}
+			}()
+			waitForBlockedPostgresQuery(t, ctx, f.st.db, fragment)
+			// If the waiting append owned the log fence, this parent owner would deadlock.
+			first, err := insertEventWithRecipients(ctx, tx, f.workspace.ID, "", "workspace.updated", nil, nil, []string{f.owner.ID})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := tx.Commit(); err != nil {
+				t.Fatal(err)
+			}
+			second := awaitEventOrderResult(t, ctx, done)
+			if second[0].Cursor <= first.Cursor {
+				t.Fatalf("parent owner lost event order: %s then %s", first.Cursor, second[0].Cursor)
+			}
+		})
+	}
+}
+
+func TestPostgresEventCursorFollowsPrivateFrontier(t *testing.T) {
+	f := newEventOrderFixture(t)
+	ctx := t.Context()
+	tx := mustBeginPostgresTx(t, ctx, f.st.db)
+	private, err := insertEventWithRecipients(ctx, tx, f.workspace.ID, "", "workspace.updated", nil, nil, []string{f.owner.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	const frontier = "cur_7zzzzzzzzz0000000000000000"
+	if _, err := f.st.db.ExecContext(ctx, `UPDATE events SET cursor=$1 WHERE id=$2`, frontier, private.ID); err != nil {
+		t.Fatal(err)
+	}
+	_, event, err := f.st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: f.channel.ID, AuthorID: f.owner.ID, Body: "after private frontier"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Cursor <= frontier {
+		t.Fatalf("cursor %s did not follow private frontier %s", event.Cursor, frontier)
+	}
+}

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -288,9 +289,34 @@ func insertEventWithRecipientsAndMentions(ctx context.Context, tx *sql.Tx, works
 	if err != nil {
 		return store.Event{}, err
 	}
+	q := storedb.New(tx)
+	// Appending finalizes the transaction: domain writes and any other blocking
+	// locks must precede it. Acquire FK parent locks before the workspace fence,
+	// so a parent FOR UPDATE owner can still append and commit without deadlock.
+	if _, err := q.LockEventWorkspace(ctx, workspaceID); err != nil {
+		return store.Event{}, err
+	}
+	slices.Sort(recipients)
+	for _, userID := range recipients {
+		if _, err := q.LockEventRecipient(ctx, userID); err != nil {
+			return store.Event{}, err
+		}
+	}
+	if err := q.LockWorkspaceEventLog(ctx, workspaceID); err != nil {
+		return store.Event{}, err
+	}
+	// Read Committed gives this statement a fresh snapshot after the fence wait.
+	frontier, err := q.LatestWorkspaceEventCursor(ctx, workspaceID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return store.Event{}, err
+	}
+	cursor, err := store.EventCursorAfter(newID("cur"), frontier)
+	if err != nil {
+		return store.Event{}, err
+	}
 	event := store.Event{
 		ID:               newID("evt"),
-		Cursor:           newID("cur"),
+		Cursor:           cursor,
 		Type:             eventType,
 		WorkspaceID:      workspaceID,
 		ChannelID:        channelID,
@@ -304,7 +330,6 @@ func insertEventWithRecipientsAndMentions(ctx context.Context, tx *sql.Tx, works
 	if len(recipients) > 0 {
 		isPrivate = 1
 	}
-	q := storedb.New(tx)
 	if err := q.InsertEvent(ctx, storedb.InsertEventParams{
 		ID:               event.ID,
 		Cursor:           event.Cursor,

--- a/apps/api/internal/store/postgres/moderation.go
+++ b/apps/api/internal/store/postgres/moderation.go
@@ -229,6 +229,10 @@ func (s *Store) ListWorkspaceMembers(ctx context.Context, workspaceID, actorUser
 	if err := requireModeratorTx(ctx, tx, workspaceID, actorUserID); err != nil {
 		return nil, err
 	}
+	return listWorkspaceMembersTx(ctx, tx, workspaceID)
+}
+
+func listWorkspaceMembersTx(ctx context.Context, tx *sql.Tx, workspaceID string) ([]store.MemberModeration, error) {
 	rows, err := storedb.New(tx).ListWorkspaceMembersForModeration(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -377,21 +381,19 @@ func (s *Store) UpdateMemberModeration(ctx context.Context, input store.UpdateMe
 	if err != nil {
 		return store.MemberModeration{}, store.Event{}, err
 	}
-	event, err := insertEventWithRecipients(ctx, tx, input.WorkspaceID, "", "member.moderation_updated", nil, map[string]string{"user_id": input.TargetUserID, "role": targetRole}, recipients)
-	if err != nil {
-		return store.MemberModeration{}, store.Event{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return store.MemberModeration{}, store.Event{}, err
-	}
-	members, err := s.ListWorkspaceMembers(ctx, input.WorkspaceID, input.ActorUserID)
+	members, err := listWorkspaceMembersTx(ctx, tx, input.WorkspaceID)
 	if err != nil {
 		return store.MemberModeration{}, store.Event{}, err
 	}
 	for _, member := range members {
-		if member.User.ID == input.TargetUserID {
-			return member, event, nil
+		if member.User.ID != input.TargetUserID {
+			continue
 		}
+		event, err := insertEventWithRecipients(ctx, tx, input.WorkspaceID, "", "member.moderation_updated", nil, map[string]string{"user_id": input.TargetUserID, "role": targetRole}, recipients)
+		if err != nil {
+			return store.MemberModeration{}, store.Event{}, err
+		}
+		return member, event, tx.Commit()
 	}
 	return store.MemberModeration{}, store.Event{}, sql.ErrNoRows
 }

--- a/apps/api/internal/store/postgres/moderation_test.go
+++ b/apps/api/internal/store/postgres/moderation_test.go
@@ -112,3 +112,46 @@ func TestMessageNonceRecoveryFollowsCurrentAccess(t *testing.T) {
 		t.Fatalf("expected replayed hidden channel nonce to be blocked, got %v", err)
 	}
 }
+
+func TestModerationHydrationFailureRollsBack(t *testing.T) {
+	ctx := t.Context()
+	st := newIsolatedPostgresTestStore(t)
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "hydrate-owner@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace := workspaces[0]
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "hydrate-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.LatestEventCursor(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only guest quota hydration needs this table; moderation authorization and writes still work.
+	if _, err := st.db.ExecContext(ctx, `DROP TABLE slash_command_invocations`); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: owner.ID, TargetUserID: member.ID, Role: store.WorkspaceRoleGuest}); err == nil {
+		t.Fatal("expected quota hydration failure")
+	}
+	role, err := st.memberRole(ctx, workspace.ID, member.ID)
+	if err != nil || role != store.WorkspaceRoleMember {
+		t.Fatalf("failed moderation committed role %q: %v", role, err)
+	}
+	after, err := st.LatestEventCursor(ctx, workspace.ID, owner.ID)
+	if err != nil || after != before {
+		t.Fatalf("failed moderation committed an event: before=%s after=%s error=%v", before, after, err)
+	}
+}

--- a/apps/api/internal/store/postgres/sqlc/queries.sql
+++ b/apps/api/internal/store/postgres/sqlc/queries.sql
@@ -1793,3 +1793,15 @@ LIMIT 1;
 SELECT workspace_id, COALESCE(channel_id, '') AS channel_id
 FROM topics
 WHERE id = sqlc.arg(topic_id) AND archived_at IS NULL;
+
+-- name: LatestWorkspaceEventCursor :one
+SELECT cursor FROM events WHERE workspace_id = sqlc.arg(workspace_id) ORDER BY cursor DESC LIMIT 1;
+
+-- name: LockEventWorkspace :one
+SELECT id FROM workspaces WHERE id = sqlc.arg(workspace_id) FOR KEY SHARE;
+
+-- name: LockEventRecipient :one
+SELECT id FROM users WHERE id = sqlc.arg(user_id) FOR KEY SHARE;
+
+-- name: LockWorkspaceEventLog :exec
+SELECT pg_advisory_xact_lock(hashtext('clickclack.events'), hashtext(sqlc.arg(workspace_id)::text));

--- a/apps/api/internal/store/postgres/storedb/queries.sql.go
+++ b/apps/api/internal/store/postgres/storedb/queries.sql.go
@@ -3039,6 +3039,17 @@ func (q *Queries) LatestEventCursor(ctx context.Context, arg LatestEventCursorPa
 	return cursor, err
 }
 
+const latestWorkspaceEventCursor = `-- name: LatestWorkspaceEventCursor :one
+SELECT cursor FROM events WHERE workspace_id = $1 ORDER BY cursor DESC LIMIT 1
+`
+
+func (q *Queries) LatestWorkspaceEventCursor(ctx context.Context, workspaceID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, latestWorkspaceEventCursor, workspaceID)
+	var cursor string
+	err := row.Scan(&cursor)
+	return cursor, err
+}
+
 const listBotCommandsForBot = `-- name: ListBotCommandsForBot :many
 SELECT id, workspace_id, bot_user_id, command, description, args_hint, created_at, updated_at
 FROM bot_commands
@@ -4862,6 +4873,28 @@ func (q *Queries) LockChannelForUpdate(ctx context.Context, channelID string) (s
 	return id, err
 }
 
+const lockEventRecipient = `-- name: LockEventRecipient :one
+SELECT id FROM users WHERE id = $1 FOR KEY SHARE
+`
+
+func (q *Queries) LockEventRecipient(ctx context.Context, userID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, lockEventRecipient, userID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
+const lockEventWorkspace = `-- name: LockEventWorkspace :one
+SELECT id FROM workspaces WHERE id = $1 FOR KEY SHARE
+`
+
+func (q *Queries) LockEventWorkspace(ctx context.Context, workspaceID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, lockEventWorkspace, workspaceID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
+}
+
 const lockMessageForPinning = `-- name: LockMessageForPinning :one
 SELECT id FROM messages WHERE id = $1 FOR UPDATE
 `
@@ -4885,6 +4918,15 @@ func (q *Queries) LockMessageForReaction(ctx context.Context, messageID string) 
 	var id string
 	err := row.Scan(&id)
 	return id, err
+}
+
+const lockWorkspaceEventLog = `-- name: LockWorkspaceEventLog :exec
+SELECT pg_advisory_xact_lock(hashtext('clickclack.events'), hashtext($1::text))
+`
+
+func (q *Queries) LockWorkspaceEventLog(ctx context.Context, workspaceID string) error {
+	_, err := q.db.ExecContext(ctx, lockWorkspaceEventLog, workspaceID)
+	return err
 }
 
 const lockWorkspaceForUpdate = `-- name: LockWorkspaceForUpdate :exec

--- a/apps/api/internal/store/sqlite/event_order_test.go
+++ b/apps/api/internal/store/sqlite/event_order_test.go
@@ -1,0 +1,80 @@
+package sqlite
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func TestEventCursorFollowsPrivateFrontierAfterReopen(t *testing.T) {
+	ctx := context.Background()
+	dsn := "sqlite://" + filepath.Join(t.TempDir(), "events.db")
+	st, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Owner", "frontier@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: owner.ID, Body: "before reopen"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, private, err := st.MarkChannelRead(ctx, channels[0].ID, owner.ID, *message.ChannelSeq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A previous process can leave a cursor ahead of this process's clock/entropy.
+	future := "cur_" + strings.ToLower(ulid.MustNew(ulid.Timestamp(time.Now().Add(time.Hour)), nil).String())
+	result, err := st.db.ExecContext(ctx, `UPDATE events SET cursor = ? WHERE id = ?`, future, private.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows, err := result.RowsAffected(); err != nil || rows != 1 {
+		t.Fatalf("seeded frontier rows=%d, error=%v", rows, err)
+	}
+	if err := st.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reopened.Close()
+	member, err := reopened.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "frontier-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reopened.AddWorkspaceMember(ctx, workspaces[0].ID, member.ID, "member"); err != nil {
+		t.Fatal(err)
+	}
+	_, event, err := reopened.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: member.ID, Body: "after reopen"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if event.Cursor <= future {
+		t.Fatalf("new cursor %s did not follow private persisted frontier %s", event.Cursor, future)
+	}
+	events, err := reopened.ListEventsAfter(ctx, workspaces[0].ID, owner.ID, future, 10)
+	if err != nil || len(events) != 1 || events[0].ID != event.ID {
+		t.Fatalf("replay lost post-reopen event: %#v, %v", events, err)
+	}
+}

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -283,9 +283,19 @@ func insertEventWithRecipientsAndMentions(ctx context.Context, tx *sql.Tx, works
 	if err != nil {
 		return store.Event{}, err
 	}
+	q := storedb.New(tx)
+	// The immediate write transaction serializes this frontier read through commit.
+	frontier, err := q.LatestWorkspaceEventCursor(ctx, workspaceID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return store.Event{}, err
+	}
+	cursor, err := store.EventCursorAfter(newID("cur"), frontier)
+	if err != nil {
+		return store.Event{}, err
+	}
 	event := store.Event{
 		ID:               newID("evt"),
-		Cursor:           newID("cur"),
+		Cursor:           cursor,
 		Type:             eventType,
 		WorkspaceID:      workspaceID,
 		ChannelID:        channelID,
@@ -299,7 +309,6 @@ func insertEventWithRecipientsAndMentions(ctx context.Context, tx *sql.Tx, works
 	if len(recipients) > 0 {
 		isPrivate = 1
 	}
-	q := storedb.New(tx)
 	if err := q.InsertEvent(ctx, storedb.InsertEventParams{
 		ID:               event.ID,
 		Cursor:           event.Cursor,

--- a/apps/api/internal/store/sqlite/moderation.go
+++ b/apps/api/internal/store/sqlite/moderation.go
@@ -221,6 +221,10 @@ func (s *Store) ListWorkspaceMembers(ctx context.Context, workspaceID, actorUser
 	if err := requireModeratorTx(ctx, tx, workspaceID, actorUserID); err != nil {
 		return nil, err
 	}
+	return listWorkspaceMembersTx(ctx, tx, workspaceID)
+}
+
+func listWorkspaceMembersTx(ctx context.Context, tx *sql.Tx, workspaceID string) ([]store.MemberModeration, error) {
 	rows, err := storedb.New(tx).ListWorkspaceMembersForModeration(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -358,21 +362,19 @@ func (s *Store) UpdateMemberModeration(ctx context.Context, input store.UpdateMe
 	if err != nil {
 		return store.MemberModeration{}, store.Event{}, err
 	}
-	event, err := insertEventWithRecipients(ctx, tx, input.WorkspaceID, "", "member.moderation_updated", nil, map[string]string{"user_id": input.TargetUserID, "role": targetRole}, recipients)
-	if err != nil {
-		return store.MemberModeration{}, store.Event{}, err
-	}
-	if err := tx.Commit(); err != nil {
-		return store.MemberModeration{}, store.Event{}, err
-	}
-	members, err := s.ListWorkspaceMembers(ctx, input.WorkspaceID, input.ActorUserID)
+	members, err := listWorkspaceMembersTx(ctx, tx, input.WorkspaceID)
 	if err != nil {
 		return store.MemberModeration{}, store.Event{}, err
 	}
 	for _, member := range members {
-		if member.User.ID == input.TargetUserID {
-			return member, event, nil
+		if member.User.ID != input.TargetUserID {
+			continue
 		}
+		event, err := insertEventWithRecipients(ctx, tx, input.WorkspaceID, "", "member.moderation_updated", nil, map[string]string{"user_id": input.TargetUserID, "role": targetRole}, recipients)
+		if err != nil {
+			return store.MemberModeration{}, store.Event{}, err
+		}
+		return member, event, tx.Commit()
 	}
 	return store.MemberModeration{}, store.Event{}, sql.ErrNoRows
 }

--- a/apps/api/internal/store/sqlite/moderation_test.go
+++ b/apps/api/internal/store/sqlite/moderation_test.go
@@ -635,3 +635,33 @@ func TestGuestSearchOnlyReturnsWaitingRoomMessages(t *testing.T) {
 		t.Fatalf("expected explicit hidden channel search to fail, got %v", err)
 	}
 }
+
+func TestModerationHydrationFailureRollsBack(t *testing.T) {
+	ctx, st, owner, workspace, _ := seededStore(t)
+	member, err := st.CreateUser(ctx, store.CreateUserInput{DisplayName: "Member", Email: "hydrate-member@example.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddWorkspaceMember(ctx, workspace.ID, member.ID, store.WorkspaceRoleMember); err != nil {
+		t.Fatal(err)
+	}
+	before, err := st.LatestEventCursor(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only guest quota hydration needs this table; moderation authorization and writes still work.
+	if _, err := st.db.ExecContext(ctx, `DROP TABLE slash_command_invocations`); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := st.UpdateMemberModeration(ctx, store.UpdateMemberModerationInput{WorkspaceID: workspace.ID, ActorUserID: owner.ID, TargetUserID: member.ID, Role: store.WorkspaceRoleGuest}); err == nil {
+		t.Fatal("expected quota hydration failure")
+	}
+	role, err := st.memberRole(ctx, workspace.ID, member.ID)
+	if err != nil || role != store.WorkspaceRoleMember {
+		t.Fatalf("failed moderation committed role %q: %v", role, err)
+	}
+	after, err := st.LatestEventCursor(ctx, workspace.ID, owner.ID)
+	if err != nil || after != before {
+		t.Fatalf("failed moderation committed an event: before=%s after=%s error=%v", before, after, err)
+	}
+}

--- a/apps/api/internal/store/sqlite/sqlc/queries.sql
+++ b/apps/api/internal/store/sqlite/sqlc/queries.sql
@@ -1714,3 +1714,6 @@ LIMIT 1;
 SELECT workspace_id, COALESCE(channel_id, '') AS channel_id
 FROM topics
 WHERE id = sqlc.arg(topic_id) AND archived_at IS NULL;
+
+-- name: LatestWorkspaceEventCursor :one
+SELECT cursor FROM events WHERE workspace_id = sqlc.arg(workspace_id) ORDER BY cursor DESC LIMIT 1;

--- a/apps/api/internal/store/sqlite/storedb/queries.sql.go
+++ b/apps/api/internal/store/sqlite/storedb/queries.sql.go
@@ -3028,6 +3028,17 @@ func (q *Queries) LatestEventCursor(ctx context.Context, arg LatestEventCursorPa
 	return cursor, err
 }
 
+const latestWorkspaceEventCursor = `-- name: LatestWorkspaceEventCursor :one
+SELECT cursor FROM events WHERE workspace_id = ?1 ORDER BY cursor DESC LIMIT 1
+`
+
+func (q *Queries) LatestWorkspaceEventCursor(ctx context.Context, workspaceID string) (string, error) {
+	row := q.db.QueryRowContext(ctx, latestWorkspaceEventCursor, workspaceID)
+	var cursor string
+	err := row.Scan(&cursor)
+	return cursor, err
+}
+
 const listBotCommandsForBot = `-- name: ListBotCommandsForBot :many
 SELECT id, workspace_id, bot_user_id, command, description, args_hint, created_at, updated_at
 FROM bot_commands

--- a/docs/features/realtime.md
+++ b/docs/features/realtime.md
@@ -8,20 +8,22 @@ read_when:
 # Realtime
 
 The realtime layer is a notification pipe over WebSocket plus a recovery
-endpoint over HTTP. SQLite is the source of truth; when live delivery cannot
-keep up, the server disconnects the websocket so the client can replay.
+endpoint over HTTP. The durable log in SQLite or PostgreSQL is the source of
+truth for both replay and live delivery; the hub only wakes its readers.
 
 ## Components
 
 - `apps/api/internal/realtime/hub.go` — in-process pub/sub keyed by
-  `workspace_id`. Buffered per-subscriber channel (32 events) with non-blocking
-  send; overflow removes and closes only the slow subscriber.
+  `workspace_id`. Durable publications coalesce into one pending wake per
+  subscriber, without carrying private payloads. Cursorless ephemeral events
+  use a separate 32-event buffer; overflow closes only the slow subscriber.
 - `events` table — append-only log scoped to a workspace, with a sortable
   `cursor`.
 - `event_recipients` table — optional per-event recipient rows for durable
   private events such as DMs and read receipts.
 - `httpapi.websocket` — accepts a connection, validates membership, drains
-  backlog from `events`, then forwards live publishes from the hub.
+  `events` in cursor order on startup and on each durable wake. It forwards
+  authorized cursorless ephemeral events directly from the hub.
 
 ## Endpoints
 
@@ -33,11 +35,13 @@ POST /api/realtime/ephemeral
 
 - `GET /ws` upgrades to a WebSocket. On connect it captures the latest visible
   durable-event cursor, pages forward from `after_cursor` until reaching that
-  fixed tail, then streams live publishes until the client disconnects. Events
-  created after the captured tail stay on the live path instead of extending
-  replay indefinitely. Connect-time replay is capped at 5,000 events; larger
+  fixed tail. Each live wake repeats that same drain with a new finite tail;
+  a wake arriving during a drain stays pending. Each drain is capped at 5,000 events; larger
   gaps close with application code `4001` so the client can perform an
-  authoritative HTTP resync. Membership is rechecked on every connect.
+  authoritative HTTP resync. Membership is checked on connect and current
+  access is rechecked before delivery. The output-only socket handles ping,
+  pong, and close frames and releases its subscription on peer disconnect;
+  clients send ephemeral input through HTTP.
 - `GET /events` exposes durable replay in pull form. User-private durable
   events, such as read receipts, are filtered the same way as the WebSocket
   stream. Pass `include_tail=true` when a fresh client needs to skip retained
@@ -75,6 +79,28 @@ Inserted in the same transaction as the underlying mutation:
 - `reaction.added`, `reaction.removed`
 - `pin.added`, `pin.removed`
 - `member.moderation_updated`
+
+The common append helper is the transaction's finalization boundary: complete
+all domain writes and acquire their locks before the first append. PostgreSQL
+locks the referenced workspace and sorted recipient users with `FOR KEY SHARE`
+before acquiring a workspace advisory transaction lock. It then reads the
+unfiltered persisted frontier in a fresh Read Committed statement. The fence
+is held through commit, so a later cursor cannot commit ahead of an earlier
+one. Multi-event transactions reuse the workspace and recipients. SQLite's
+immediate write transaction provides the equivalent serialization.
+
+Both stores preserve the new ULID candidate's entropy and allocate a cursor
+strictly above the workspace frontier, including private events. If a reopened
+process or clock adjustment produces a lower candidate, its timestamp is moved
+to the frontier millisecond, or one millisecond later if needed; exhaustion
+fails the transaction. Cursors are opaque ordering tokens, not wall-clock times.
+Ordinary IDs and the event's `created_at` timestamp retain their existing meaning.
+
+Even private publications wake every subscriber in the workspace: an earlier
+public event may have committed before its handler published. SQL visibility
+filters decide which rows each reader receives. Outgoing subscriptions instead
+consume only original mutation receipts, whose recipient metadata excludes
+private callbacks. Replaying a socket never invokes an outgoing callback.
 
 Direct messages also publish into the workspace event stream so DM lists stay
 fresh, but they are persisted with recipient rows and replay only to direct
@@ -127,18 +153,17 @@ progress while retaining targetless, workspace-wide presence events.
   in a hidden tab do not block subsequent events. Live chat stays pinned as
   successive messages grow an existing group, including after the tab resumes.
 - The client sends `after_cursor` on every connect/reconnect.
-- On WebSocket connect, the server pages durable events with a higher `cursor`
-  until it reaches the visible tail captured for that connection. If replay is
+- On WebSocket connect and each live wake, the server pages durable events with
+  a higher `cursor` until it reaches the visible tail captured for that drain. If replay is
   interrupted, the client can reconnect with the last cursor it actually
   processed and resume from there. If the 5,000-event work budget is exhausted,
   the server closes with code `4001`; the web client clears its stale cursor,
   captures a fresh tail, completes an authoritative projection resync, and then
   resumes live delivery.
-- The websocket itself does not drop durable events — they are always in
-  `events`. If a subscriber's buffered hub channel overflows, the server closes
-  that websocket with a retryable status and instructs the client to reconnect
-  with its last `after_cursor` so durable events can be replayed. Ephemeral
-  events are not recoverable.
+- A durable burst coalesces wakeups without losing log rows. If a subscriber's
+  ephemeral queue overflows, or a socket write cannot finish within its timeout,
+  the connection closes so the client can reconnect with its last processed
+  `after_cursor`. Ephemeral events are not recoverable.
 - Operators can prune old durable events with
   `clickclack admin events prune`. Message history is not stored in the event
   log, so clients with cursors outside the retained window should reload


### PR DESCRIPTION
A client could checkpoint event B and permanently miss an earlier event A when A's handler published late. PostgreSQL also allowed B's later cursor to commit while A remained uncommitted. Both broke cursor-based recovery even though A eventually existed in the durable log.

This change makes the durable log own WebSocket ordering. Startup replay and live wakeups use one authorized, finite-tail drain. The hub coalesces payload-free durable wakeups, including private publications; SQL visibility filters and current-access checks decide what reaches each socket. Cursorless ephemeral delivery keeps its bounded queue and revocation behavior. `CloseRead` handles idle ping/close frames and releases disconnected subscriptions.

The common PostgreSQL append helper acquires workspace and sorted recipient `FOR KEY SHARE` locks before a workspace advisory transaction lock held through commit. It then reads the unfiltered persisted frontier in a fresh statement. Both stores allocate an opaque ULID cursor above that frontier while preserving fresh entropy; SQLite already serializes writes. Append callers finish domain writes and other blocking locks before this boundary. No schema, configuration, dependency, or cross-process live fanout changes.

Original mutation receipts still own outgoing callbacks, preserving private-recipient filtering and avoiding replay duplicates. Attachment updates now use that owner. Moderation reuses its member projection inside the transaction, so failed response hydration rolls back rather than suppressing the committed event's sole wakeup.

Validation:

- Independent real HTTP/WebSocket before/after: held A publication, checkpoint B, reconnect, release A. Baseline delivered A zero times; candidate delivers it once. Idle ping/disconnect regressions also fail before and pass after.
- Independent PostgreSQL 17/HTTP barrier: baseline let B commit while A was held before commit; the candidate keeps B blocked until A completes, with A's cursor before B's.
- Real PostgreSQL transaction barriers cover commit, rollback, private/public events, a two-event reply, another workspace's independence, and workspace/user parent-lock ordering. SQLite reopen/private-frontier and equal/lower cursor cases pass.
- Existing replay privacy, demotion, pruning, pagination and cap checks pass, together with durable burst coalescing, retained wakeups, ephemeral overflow/reconnect, callback privacy/idempotence, and both stores' moderation rollback regressions.
- Full `pnpm check` with isolated PostgreSQL enabled, focused Go race tests, embedded asset build, and required isolated review passed. Review scope: P0, no findings. Coverage passed at 86.1%; dead-code analysis passed. Exact-head [CI33356717845](https://github.com/openclaw/clickclack/actions/runs/33356717845) passed Go, TypeScript, full Playwright and Docker; [desktop33356717814](https://github.com/openclaw/clickclack/actions/runs/33356717814) passed all three platforms.

Independent binary proof: SHA-256 `d7e89290850e76c34340beec2c3b5ea4bd8fb6e7a43b005e3ee93ca01742f506`. The hub remains single-process; this does not add multi-server live delivery or callback retries.

Human production: +233/-103 lines; tests: +953/-122; generated SQL: +53; docs/changelog: +43/-16. Generated SQL comes from `pnpm generate:sqlc`.

<details>
<summary>Inspected runtime evidence: actual HTTP/WebSocket and PostgreSQL before/after</summary>

Baseline source: `286588e43c41c853b3399644826e78e0b6a85435`, binary SHA-256 `e205a3546e847a21f66c7ba84bdacf0d4dc2b103ce6301cf947f4be3e8b186f1`. Candidate production source: `80c00edd7c762406492fd5580ed0cf2aea45836a`, binary SHA-256 `d7e89290850e76c34340beec2c3b5ea4bd8fb6e7a43b005e3ee93ca01742f506` (built before the commit, with the same production files).

These are runtime test excerpts and HTTP proof receipts, using task-owned synthetic data. Independent verification ran the same held-publication and idle-control tests before and after the repair. Request-log noise and synthetic cursor values are omitted from the excerpt; the failure text is preserved.

Before, on clean baseline:

```text
--- FAIL: TestRootRealtimeReconnectDoesNotLoseLatePublication (0.11s)
    committed event A was delivered 0 times across checkpoint and reconnect; want once
FAIL github.com/openclaw/clickclack/apps/api/internal/httpapi 0.139s

--- FAIL: TestRootRealtimeIdleConnectionControlFrames (2.10s)
    --- FAIL: TestRootRealtimeIdleConnectionControlFrames/ping (1.05s)
        idle realtime socket did not answer ping: failed to ping: failed to wait for pong: context deadline exceeded
    --- FAIL: TestRootRealtimeIdleConnectionControlFrames/disconnect (1.05s)
        idle realtime handler remained subscribed after peer disconnected
FAIL github.com/openclaw/clickclack/apps/api/internal/httpapi 2.118s
```

After, independent verification of the unchanged three cases against the candidate production source:

```text
ok  github.com/openclaw/clickclack/apps/api/internal/httpapi 0.178s
```

The checked-in equivalent [held-publication regression](https://github.com/openclaw/clickclack/blob/80c00edd7c762406492fd5580ed0cf2aea45836a/apps/api/internal/httpapi/realtime_order_test.go#L68) uses actual SQLite, HTTP requests and WebSocket reads. It holds A only after its transaction commits, posts B, consumes through B's cursor, reconnects, releases A, and consumes through a subsequent real message. It asserts that A was observed exactly once across both connections. The fix delivers A **before checkpointing B**; releasing A later must not duplicate it. This is not a claim that a client may safely receive A below an already checkpointed B. [Idle control coverage](https://github.com/openclaw/clickclack/blob/80c00edd7c762406492fd5580ed0cf2aea45836a/apps/api/internal/httpapi/realtime_control_test.go) checks a real ping/pong exchange and handler completion after peer disconnect.

Independent PostgreSQL 17 + actual HTTP receipt, before:

```json
{
  "proof": "real PostgreSQL17 and HTTP message creation, trigger holds actual append before commit",
  "same_workspace_commit_order_serialized": false,
  "cursor_a_before_b": true,
  "b_committed_while_a_uncommitted": true
}
```

Same HTTP barrier and synthetic database, candidate binary:

```json
{
  "proof": "real PostgreSQL17 and HTTP message creation, trigger holds actual append before commit",
  "same_workspace_commit_order_serialized": true,
  "cursor_a_before_b": true,
  "b_committed_while_a_uncommitted": false
}
```

The PostgreSQL proof holds A at its actual event insert with a temporary test-database trigger, issues B through HTTP in another channel of the same workspace, and checks whether B can commit before releasing A. The trigger is removed after the run. The checked-in [real PostgreSQL barriers](https://github.com/openclaw/clickclack/blob/80c00edd7c762406492fd5580ed0cf2aea45836a/apps/api/internal/store/postgres/event_order_test.go) additionally inspect blocked database queries and verify persisted replay order after commit/rollback.

Focused reproduction from this branch:

```sh
go test ./apps/api/internal/httpapi -run 'TestRealtime(ReconnectDoesNotLoseLatePublication|IdleConnectionControlFrames)$' -count=1
go test ./apps/api/internal/store/postgres -run '^TestPostgresEvent' -count=1
```

The PostgreSQL command requires the existing documented `CLICKCLACK_POSTGRES_TEST_DSN` test setting and uses isolated schemas. Full exact-head CI links above independently expose the complete passing test/build logs.

</details>

### Observed WebSocket delivery order

Fresh trace recorded at 2026-08-31 04:29 UTC against the production source of 80c00edd7c762406492fd5580ed0cf2aea45836a. This is an observation-only local overlay of the checked-in HTTP/WebSocket regression: real SQLite transactions, HTTP handlers, and WebSocket connections, with extra log lines and unchanged assertions. No production source changed for this capture. All identifiers below belong to synthetic test data.

```text
--- PASS: TestRootRealtimeIdleConnectionControlFrames (0.07s)
A committed; handler publication held: id=evt_01m1b18872g9htf1r64wttwtzy cursor=cur_01m1b18872g9htf1r64v8fv315
B published: id=evt_01m1b188737b3ra83smj2ckdjh cursor=cur_01m1b188737b3ra83smek5xzmv
first socket received: id=evt_01m1b18872g9htf1r64wttwtzy cursor=cur_01m1b18872g9htf1r64v8fv315
first socket received: id=evt_01m1b188737b3ra83smj2ckdjh cursor=cur_01m1b188737b3ra83smek5xzmv
reconnect from B checkpoint=cur_01m1b188737b3ra83smek5xzmv
A handler publication released after reconnect
reconnected socket received: id=evt_01m1b188760nj2f4qm06yeqs68 cursor=cur_01m1b188760nj2f4qm04pfvmj4
total A deliveries across both sockets=1; expected=1
--- PASS: TestRootRealtimeReconnectDoesNotLoseLatePublication (0.04s)
```

A is delivered before the client checkpoints B. Reconnecting from B and then releasing A's delayed handler publication produces no duplicate A; the next received event is the sentinel created after that handler completes. The assertion counts A across both connections.
