### PR TITLE
refactor: remove unused unreserved upload creation

### DIFF
--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	postgresstore "github.com/openclaw/clickclack/apps/api/internal/store/postgres"
 	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 	"github.com/openclaw/clickclack/apps/api/internal/uploadstore"
 )
 
@@ -750,7 +751,7 @@ func TestCleanupPendingUploadObjectsDrainsBeyondDefaultBatch(t *testing.T) {
 			t.Fatal(err)
 		}
 		storagePaths = append(storagePaths, saved.Path)
-		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 			WorkspaceID: workspace.ID,
 			OwnerID:     ownerID,
 			Filename:    fmt.Sprintf("batch-%03d.txt", i),
@@ -1704,7 +1705,7 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 		http.StatusBadRequest,
 	)
 	// Attachments use the same signed callback owner as other message updates.
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "callback.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: filepath.Join(dataDir, "callback.txt")})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "callback.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: filepath.Join(dataDir, "callback.txt")})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3214,7 +3215,7 @@ func TestUploadNonceReplaysWithoutConsumingStorageOrQuota(t *testing.T) {
 		t.Fatalf("unexpected missing nonce response: status=%s headers=%v", missingResponse.Status, missingResponse.Header)
 	}
 	for i := int64(1); i < store.UploadQuotaCountPerUserWorkspace; i++ {
-		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 			WorkspaceID: workspace.ID,
 			OwnerID:     owner.ID,
 			Filename:    fmt.Sprintf("quota-%d.txt", i),
@@ -3286,7 +3287,7 @@ func TestConcurrentUploadNonceReplayClaimsNonceBeforeQuota(t *testing.T) {
 	}
 	workspace := workspaces[0]
 	for i := int64(1); i < store.UploadQuotaCountPerUserWorkspace; i++ {
-		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 			WorkspaceID: workspace.ID,
 			OwnerID:     owner.ID,
 			Filename:    fmt.Sprintf("quota-%d.txt", i),
@@ -3437,7 +3438,7 @@ func TestBotGenericRoutesRequireDMScopeForDirectMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     bot.ID,
 		Filename:    "dm.txt",
@@ -3517,7 +3518,7 @@ func TestBotGenericRoutesRequireDMScopeForDirectMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	writeUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	writeUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     writeBot.ID,
 		Filename:    "retry.txt",
@@ -3540,7 +3541,7 @@ func TestBotGenericRoutesRequireDMScopeForDirectMessages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	otherDMUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	otherDMUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     writeBot.ID,
 		Filename:    "other-dm.txt",

--- a/apps/api/internal/store/postgres/mutations_test.go
+++ b/apps/api/internal/store/postgres/mutations_test.go
@@ -256,24 +256,30 @@ func TestWorkspaceDeleteLockBlocksNewUploads(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	input := store.CreateUploadInput{
+		WorkspaceID: workspace.ID,
+		OwnerID:     owner.ID,
+		Filename:    "racing.txt",
+		ContentType: "text/plain",
+		ByteSize:    1,
+		StoragePath: "memory://racing.txt",
+	}
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "", input.ByteSize)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	tx, err := st.db.BeginTx(ctx, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer tx.Rollback()
 	if err := storedb.New(tx).LockWorkspaceForUpdate(ctx, workspace.ID); err != nil {
 		t.Fatal(err)
 	}
 	result := make(chan error, 1)
 	go func() {
-		_, err := st.CreateUpload(ctx, store.CreateUploadInput{
-			WorkspaceID: workspace.ID,
-			OwnerID:     owner.ID,
-			Filename:    "racing.txt",
-			ContentType: "text/plain",
-			ByteSize:    1,
-			StoragePath: "memory://racing.txt",
-		})
+		_, err := st.CreateReservedUpload(ctx, reservation.ID, input)
 		result <- err
 	}()
 	select {

--- a/apps/api/internal/store/postgres/thread_pages_test.go
+++ b/apps/api/internal/store/postgres/thread_pages_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
@@ -51,7 +52,7 @@ func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: root.WorkspaceID, OwnerID: owner.ID, Filename: "thread.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: t.TempDir() + "/thread.txt"})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: root.WorkspaceID, OwnerID: owner.ID, Filename: "thread.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: t.TempDir() + "/thread.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -12,55 +12,6 @@ import (
 
 const uploadQuotaReservationTTL = 15 * time.Minute
 
-func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput) (store.Upload, error) {
-	nonce, err := normalizeClientNonce(input.Nonce)
-	if err != nil {
-		return store.Upload{}, err
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return store.Upload{}, err
-	}
-	defer tx.Rollback()
-	if err := lockUploadQuotaTx(ctx, tx, input.WorkspaceID, input.OwnerID); err != nil {
-		return store.Upload{}, err
-	}
-	if err := canCreateUploadTx(ctx, tx, input.WorkspaceID, input.OwnerID, input.ByteSize); err != nil {
-		return store.Upload{}, err
-	}
-	upload := store.Upload{
-		ID:          newID("upl"),
-		WorkspaceID: input.WorkspaceID,
-		OwnerID:     input.OwnerID,
-		Nonce:       nonce,
-		Filename:    input.Filename,
-		ContentType: input.ContentType,
-		ByteSize:    input.ByteSize,
-		Width:       input.Width,
-		Height:      input.Height,
-		DurationMS:  input.DurationMS,
-		StoragePath: input.StoragePath,
-		CreatedAt:   now(),
-	}
-	if err := s.q.WithTx(tx).InsertUpload(ctx, storedb.InsertUploadParams{
-		ID:          upload.ID,
-		WorkspaceID: upload.WorkspaceID,
-		OwnerID:     upload.OwnerID,
-		ClientNonce: upload.Nonce,
-		Filename:    upload.Filename,
-		ContentType: upload.ContentType,
-		ByteSize:    upload.ByteSize,
-		Width:       int64(upload.Width),
-		Height:      int64(upload.Height),
-		DurationMs:  int64(upload.DurationMS),
-		StoragePath: upload.StoragePath,
-		CreatedAt:   upload.CreatedAt,
-	}); err != nil {
-		return store.Upload{}, err
-	}
-	return upload, tx.Commit()
-}
-
 func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
 	normalizedNonce, err := normalizeClientNonce(nonce)
 	if err != nil {
@@ -255,35 +206,6 @@ func (s *Store) UploadQuota(ctx context.Context, workspaceID, userID string) (st
 		return store.UploadQuota{}, err
 	}
 	return uploadQuotaTx(ctx, tx, workspaceID, userID)
-}
-
-func (s *Store) CanCreateUpload(ctx context.Context, workspaceID, userID string, byteSize int64) error {
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	if err := lockUploadQuotaTx(ctx, tx, workspaceID, userID); err != nil {
-		return err
-	}
-	return canCreateUploadTx(ctx, tx, workspaceID, userID, byteSize)
-}
-
-func canCreateUploadTx(ctx context.Context, tx *sql.Tx, workspaceID, userID string, byteSize int64) error {
-	if byteSize < 0 {
-		return errors.New("upload byte size must be non-negative")
-	}
-	if err := requireMembershipTx(ctx, tx, workspaceID, userID); err != nil {
-		return err
-	}
-	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, userID); err != nil {
-		return err
-	}
-	quota, err := uploadQuotaTx(ctx, tx, workspaceID, userID)
-	if err != nil {
-		return err
-	}
-	return quota.CanFit(byteSize)
 }
 
 func lockUploadQuotaTx(ctx context.Context, tx *sql.Tx, workspaceID, userID string) error {

--- a/apps/api/internal/store/sqlite/chat_test.go
+++ b/apps/api/internal/store/sqlite/chat_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestStoreChatThreadsSearchUploadsAndEvents(t *testing.T) {
@@ -172,7 +173,7 @@ func TestStoreChatThreadsSearchUploadsAndEvents(t *testing.T) {
 		t.Fatal("expected events with empty cursor")
 	}
 
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "note.txt",
@@ -543,7 +544,7 @@ func TestStoreAccessErrors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspaces[0].ID, OwnerID: owner.ID, Filename: "x", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/x"})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspaces[0].ID, OwnerID: owner.ID, Filename: "x", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/x"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -860,7 +861,7 @@ func TestStoreBranchCases(t *testing.T) {
 	if defaultChannel.Name != "general" || defaultChannel.Kind != "public" {
 		t.Fatalf("unexpected default channel: %#v", defaultChannel)
 	}
-	otherUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: secondWorkspace.ID, OwnerID: owner.ID, Filename: "other", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/other"})
+	otherUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: secondWorkspace.ID, OwnerID: owner.ID, Filename: "other", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/other"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/sqlite/fault_test.go
+++ b/apps/api/internal/store/sqlite/fault_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestStoreFaultBranches(t *testing.T) {
@@ -94,7 +95,7 @@ func TestStoreFaultBranches(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "x", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/x"})
+		upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "x", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/x"})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/apps/api/internal/store/sqlite/message_privacy_scaling_test.go
+++ b/apps/api/internal/store/sqlite/message_privacy_scaling_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestMessagePrivacyScalingPrivacyAndDMThreads(t *testing.T) {
@@ -184,14 +185,14 @@ func TestMessagePrivacyScalingPrivacyAndDMThreads(t *testing.T) {
 	if _, err := st.AddReaction(ctx, store.CreateReactionInput{MessageID: dmMessage.ID, UserID: workspaceOnly.ID, Emoji: "nope"}); err == nil {
 		t.Fatal("expected non-DM member to be blocked from reacting to a DM message")
 	}
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "dm.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/dm.txt"})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "dm.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/dm.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, err := st.AttachUpload(ctx, store.AttachUploadInput{MessageID: dmMessage.ID, UploadID: upload.ID, UserID: workspaceOnly.ID}); err == nil {
 		t.Fatal("expected non-DM member to be blocked from attaching to a DM message")
 	}
-	privateUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "private.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/private.txt"})
+	privateUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "private.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/private.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,7 +333,7 @@ func TestDeletedMessageAttachmentsAreHidden(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	channelUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "channel.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/channel.txt"})
+	channelUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "channel.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/channel.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +371,7 @@ func TestDeletedMessageAttachmentsAreHidden(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dmUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "dm.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/dm.txt"})
+	dmUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "dm.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/dm.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +485,7 @@ func TestMessagePrivacyScalingChannelAndUploadVisibilityCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "shared.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/shared.txt"})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: owner.ID, Filename: "shared.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/shared.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -514,7 +515,7 @@ func TestMessagePrivacyScalingChannelAndUploadVisibilityCoverage(t *testing.T) {
 	if _, err := st.AttachUpload(ctx, store.AttachUploadInput{MessageID: memberMessage.ID, UploadID: upload.ID, UserID: member.ID}); err != nil {
 		t.Fatal(err)
 	}
-	demotedUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: member.ID, Filename: "demoted.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/demoted.txt"})
+	demotedUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: member.ID, Filename: "demoted.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/demoted.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -532,7 +533,7 @@ func TestMessagePrivacyScalingChannelAndUploadVisibilityCoverage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	otherUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: otherWorkspace.ID, OwnerID: owner.ID, Filename: "other.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/other.txt"})
+	otherUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: otherWorkspace.ID, OwnerID: owner.ID, Filename: "other.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: "/tmp/other.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/sqlite/moderation_test.go
+++ b/apps/api/internal/store/sqlite/moderation_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestGuestWaitingRoomModeration(t *testing.T) {
@@ -219,7 +220,7 @@ func TestGuestWaitingRoomModeration(t *testing.T) {
 	if _, _, err := st.UpdateChannel(ctx, store.UpdateChannelInput{ChannelID: generalChannelID, UserID: guest.ID, Name: "renamed"}); !errors.Is(err, store.ErrModerationRestricted) {
 		t.Fatalf("expected block to stop channel updates, got %v", err)
 	}
-	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: guest.ID, Filename: "blocked.txt", ContentType: "text/plain", ByteSize: 7, StoragePath: "blocked.txt"}); !errors.Is(err, store.ErrModerationRestricted) {
+	if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: workspace.ID, OwnerID: guest.ID, Filename: "blocked.txt", ContentType: "text/plain", ByteSize: 7, StoragePath: "blocked.txt"}); !errors.Is(err, store.ErrModerationRestricted) {
 		t.Fatalf("expected block to stop upload creation, got %v", err)
 	}
 	blocked = false

--- a/apps/api/internal/store/sqlite/mutations_test.go
+++ b/apps/api/internal/store/sqlite/mutations_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestMutationsCreateDurableEvents(t *testing.T) {
@@ -345,7 +346,7 @@ func TestUpdateWorkspaceValidatesIconUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	textUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	textUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "note.txt",
@@ -356,7 +357,7 @@ func TestUpdateWorkspaceValidatesIconUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	otherUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	otherUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: otherWorkspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "other.png",
@@ -367,7 +368,7 @@ func TestUpdateWorkspaceValidatesIconUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	imageUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	imageUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "icon.png",
@@ -378,7 +379,7 @@ func TestUpdateWorkspaceValidatesIconUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	privateMemberUpload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	privateMemberUpload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     member.ID,
 		Filename:    "member-private.png",

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
 	"github.com/openclaw/clickclack/apps/api/internal/store/sqlite/storedb"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestStoreValidationAndAdminHelpers(t *testing.T) {
@@ -163,7 +164,7 @@ func TestStoreValidationAndAdminHelpers(t *testing.T) {
 	if _, _, err := st.CreateBot(ctx, store.CreateBotInput{WorkspaceID: workspace.ID, DisplayName: "Duplicate Handle", Handle: "owner-bot"}); err == nil {
 		t.Fatal("expected duplicate bot handle rejection")
 	}
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "secret.txt",
@@ -285,7 +286,7 @@ func TestUploadQuotaRejectsOwnerWorkspaceOverflow(t *testing.T) {
 		t.Fatal(err)
 	}
 	workspace := workspaces[0]
-	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "almost-full.bin",
@@ -295,10 +296,26 @@ func TestUploadQuotaRejectsOwnerWorkspaceOverflow(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := st.CanCreateUpload(ctx, workspace.ID, owner.ID, 2); !errors.Is(err, store.ErrUploadQuotaExceeded) {
+	quota, err := st.UploadQuota(ctx, workspace.ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := quota.CanFit(2); !errors.Is(err, store.ErrUploadQuotaExceeded) {
 		t.Fatalf("expected quota denial, got %v", err)
 	}
-	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	reservation, err := st.ReserveUploadQuota(ctx, workspace.ID, owner.ID, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := st.ReleaseUploadQuotaReservation(ctx, reservation.ID, owner.ID); err != nil {
+			t.Error(err)
+		}
+	})
+	if reservation.ByteSize != 1 {
+		t.Fatalf("expected reservation to clamp to remaining byte, got %d", reservation.ByteSize)
+	}
+	if _, err := st.CreateReservedUpload(ctx, reservation.ID, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Filename:    "overflow.bin",
@@ -324,7 +341,7 @@ func TestUploadNonceLookupSurvivesWorkspaceMembershipRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	workspace := workspaces[0]
-	created, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	created, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Nonce:       "stale-workspace-nonce",
@@ -364,7 +381,7 @@ func TestUploadNonceValidationCountsCharacters(t *testing.T) {
 	}
 	workspace := workspaces[0]
 	valid := strings.Repeat("é", 128)
-	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Nonce:       valid,
@@ -375,7 +392,7 @@ func TestUploadNonceValidationCountsCharacters(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("expected 128-character nonce to remain valid: %v", err)
 	}
-	if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+	if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 		WorkspaceID: workspace.ID,
 		OwnerID:     owner.ID,
 		Nonce:       strings.Repeat("é", 129),
@@ -387,7 +404,7 @@ func TestUploadNonceValidationCountsCharacters(t *testing.T) {
 		t.Fatalf("expected 129-character nonce rejection, got %v", err)
 	}
 	for _, nonce := range []string{string([]byte{0xff}), "invalid\x00nonce"} {
-		if _, err := st.CreateUpload(ctx, store.CreateUploadInput{
+		if _, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{
 			WorkspaceID: workspace.ID,
 			OwnerID:     owner.ID,
 			Nonce:       nonce,
@@ -888,7 +905,7 @@ func TestStoreClosedDatabaseErrors(t *testing.T) {
 			return err
 		}},
 		{"create upload", func() error {
-			_, err := st.CreateUpload(ctx, store.CreateUploadInput{})
+			_, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{})
 			return err
 		}},
 		{"attach upload", func() error {

--- a/apps/api/internal/store/sqlite/thread_pages_test.go
+++ b/apps/api/internal/store/sqlite/thread_pages_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
+	"github.com/openclaw/clickclack/apps/api/internal/store/storetest"
 )
 
 func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
@@ -49,7 +50,7 @@ func TestGetThreadLatestReturnsBoundedChronologicalWindow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	upload, err := st.CreateUpload(ctx, store.CreateUploadInput{WorkspaceID: root.WorkspaceID, OwnerID: owner.ID, Filename: "thread.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: t.TempDir() + "/thread.txt"})
+	upload, err := storetest.CreateUpload(ctx, st, store.CreateUploadInput{WorkspaceID: root.WorkspaceID, OwnerID: owner.ID, Filename: "thread.txt", ContentType: "text/plain", ByteSize: 1, StoragePath: t.TempDir() + "/thread.txt"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -13,52 +13,6 @@ import (
 
 const uploadQuotaReservationTTL = 15 * time.Minute
 
-func (s *Store) CreateUpload(ctx context.Context, input store.CreateUploadInput) (store.Upload, error) {
-	nonce, err := normalizeClientNonce(input.Nonce)
-	if err != nil {
-		return store.Upload{}, err
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return store.Upload{}, err
-	}
-	defer tx.Rollback()
-	if err := canCreateUploadTx(ctx, tx, input.WorkspaceID, input.OwnerID, input.ByteSize); err != nil {
-		return store.Upload{}, err
-	}
-	upload := store.Upload{
-		ID:          newID("upl"),
-		WorkspaceID: input.WorkspaceID,
-		OwnerID:     input.OwnerID,
-		Nonce:       nonce,
-		Filename:    input.Filename,
-		ContentType: input.ContentType,
-		ByteSize:    input.ByteSize,
-		Width:       input.Width,
-		Height:      input.Height,
-		DurationMS:  input.DurationMS,
-		StoragePath: input.StoragePath,
-		CreatedAt:   now(),
-	}
-	if err := s.q.WithTx(tx).InsertUpload(ctx, storedb.InsertUploadParams{
-		ID:          upload.ID,
-		WorkspaceID: upload.WorkspaceID,
-		OwnerID:     upload.OwnerID,
-		ClientNonce: upload.Nonce,
-		Filename:    upload.Filename,
-		ContentType: upload.ContentType,
-		ByteSize:    upload.ByteSize,
-		Width:       int64(upload.Width),
-		Height:      int64(upload.Height),
-		DurationMs:  int64(upload.DurationMS),
-		StoragePath: upload.StoragePath,
-		CreatedAt:   upload.CreatedAt,
-	}); err != nil {
-		return store.Upload{}, err
-	}
-	return upload, tx.Commit()
-}
-
 func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
 	normalizedNonce, err := normalizeClientNonce(nonce)
 	if err != nil {
@@ -235,32 +189,6 @@ func (s *Store) UploadQuota(ctx context.Context, workspaceID, userID string) (st
 		return store.UploadQuota{}, err
 	}
 	return uploadQuotaTx(ctx, tx, workspaceID, userID)
-}
-
-func (s *Store) CanCreateUpload(ctx context.Context, workspaceID, userID string, byteSize int64) error {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	return canCreateUploadTx(ctx, tx, workspaceID, userID, byteSize)
-}
-
-func canCreateUploadTx(ctx context.Context, tx *sql.Tx, workspaceID, userID string, byteSize int64) error {
-	if byteSize < 0 {
-		return errors.New("upload byte size must be non-negative")
-	}
-	if err := requireMembershipTx(ctx, tx, workspaceID, userID); err != nil {
-		return err
-	}
-	if err := requireNoModerationBlockTx(ctx, tx, workspaceID, userID); err != nil {
-		return err
-	}
-	quota, err := uploadQuotaTx(ctx, tx, workspaceID, userID)
-	if err != nil {
-		return err
-	}
-	return quota.CanFit(byteSize)
 }
 
 func uploadQuotaTx(ctx context.Context, tx *sql.Tx, workspaceID, userID string) (store.UploadQuota, error) {

--- a/apps/api/internal/store/storetest/uploads.go
+++ b/apps/api/internal/store/storetest/uploads.go
@@ -1,0 +1,21 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+// CreateUpload builds fixtures through the same reservation lifecycle as HTTP uploads.
+func CreateUpload(ctx context.Context, st store.Store, input store.CreateUploadInput) (store.Upload, error) {
+	reservation, err := st.ReserveUploadQuota(ctx, input.WorkspaceID, input.OwnerID, input.Nonce, input.ByteSize)
+	if err != nil {
+		return store.Upload{}, err
+	}
+	upload, err := st.CreateReservedUpload(ctx, reservation.ID, input)
+	if err != nil {
+		err = errors.Join(err, st.ReleaseUploadQuotaReservation(ctx, reservation.ID, input.OwnerID))
+	}
+	return upload, err
+}

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -1230,7 +1230,6 @@ type Store interface {
 	UpdateMemberModeration(ctx context.Context, input UpdateMemberModerationInput) (MemberModeration, Event, error)
 	UserHasNonGuestMembership(ctx context.Context, userID string) (bool, error)
 	UploadQuota(ctx context.Context, workspaceID, userID string) (UploadQuota, error)
-	CanCreateUpload(ctx context.Context, workspaceID, userID string, byteSize int64) error
 	ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (UploadQuotaReservation, error)
 	CreateReservedUpload(ctx context.Context, reservationID string, input CreateUploadInput) (Upload, error)
 	ReleaseUploadQuotaReservation(ctx context.Context, reservationID, userID string) error
@@ -1273,7 +1272,6 @@ type Store interface {
 	LatestEventCursor(ctx context.Context, workspaceID, userID string) (string, error)
 	EventCursorExists(ctx context.Context, workspaceID, userID, cursor string) (bool, error)
 	ListEventsAfter(ctx context.Context, workspaceID, userID, cursor string, limit int) ([]Event, error)
-	CreateUpload(ctx context.Context, input CreateUploadInput) (Upload, error)
 	GetUpload(ctx context.Context, uploadID, userID string) (Upload, error)
 	GetUploadByNonce(ctx context.Context, ownerID, nonce string) (Upload, error)
 	UploadHasDirectMessageAttachment(ctx context.Context, uploadID string) (bool, error)

--- a/tests/e2e/direct-message-selection.spec.ts
+++ b/tests/e2e/direct-message-selection.spec.ts
@@ -264,7 +264,7 @@ for (const switchWorkspace of [false, true]) {
       await dialog(page).getByRole("button", { name: "Cancel", exact: true }).click();
       if (switchWorkspace) {
         await page.getByRole("link", { name: other.workspace.name, exact: true }).click();
-        await expect(page).toHaveURL(new RegExp(`/app/${other.workspace.route_id}(?:/|$)`));
+        await expect(page).toHaveURL(new RegExp(`/app/${other.workspace.route_id}/[^/]+$`));
       }
       await page.getByRole("button", { name: "Start direct message" }).click();
       await dialog(page).getByLabel("Find a person").fill("keep this new recipient");


### PR DESCRIPTION
The store exposed two upload-creation paths: HTTP reserved quota before streaming and finalized the reservation, while only tests used a separate unreserved insert/preflight path. This removes `Store.CreateUpload`, `CanCreateUpload`, and their exclusive helpers from both SQLite and PostgreSQL.

Existing fixtures now compose `ReserveUploadQuota` → `CreateReservedUpload`, releasing a failed reservation. The quota regression explicitly checks that a two-byte request clamps to one remaining byte and that finalizing the original two bytes still fails. The live reservation, nonce locks, quota locks, moderation, expiry, attachment visibility, API, and schema contracts remain unchanged.

Validation:

- 19 focused SQLite owner/sibling tests pass, including quota overflow, nonce normalization/claims/expiry, moderation recheck, negative finalization, privacy, and attachment hydration.
- Five focused HTTP scenarios pass, covering cleanup batches, signed attachment callbacks/error paths, nonce replay/quota concurrency, and DM scopes.
- Three real PostgreSQL 17 tests pass: workspace deletion lock, nonce/finalization serialization, and bounded thread attachment hydration. The deletion-lock test reserves before taking the lock, then proves finalization itself waits until rollback.
- The standalone binary passes the same before/after HTTP probe on SQLite (`127.0.0.1:19494`) and PostgreSQL 17 (`127.0.0.1:19496`): create 201; nonce replay 200 with the same upload despite a deliberately non-multipart replay body; hydrated attachment; download 200 with identical bytes; outsider download 404 and upload 403.
- `pnpm fmt:go:check` and `git diff --check` pass. Independent maintainer HTTP verification also passes on both stores. Required isolated Codex review of the complete final change passed with no findings at the requested P0 threshold. Full-change and final one-line test delta reviews are clean. Final-head CI passed, including the full browser suite, PostgreSQL 17, coverage, dead-code, TypeScript/build, and Docker checks.

Candidate binary SHA-256: `792a264f3188e72434e30d042739270bec7ca551ed93e81a4aeb2c6104ccb9cd`, built with the repository's native `go build` against the unchanged embedded web assets. PostgreSQL proof uses an isolated synthetic database; no production systems are involved.

Production: **152 lines removed**. Existing tests: net +31. Shared test support: +21, imported only by test files. No user-facing behavior change or generated SQL changes.

The first CI run passed backend/PostgreSQL, coverage, dead-code, TypeScript, and Docker checks, but exposed an existing delayed-DM fixture race (228 browser tests passed). That test recorded the intermediate workspace URL before canonical channel navigation settled. Its setup now waits for the full target route; final destination, recipient, and sidebar assertions are unchanged. Both retained delayed-DM cases pass against the standalone server, and a delayed real channel-list response reproduces the original mismatch and passes with the corrected setup. This fixture adjustment is +1/-1 test line.
