### PR TITLE
fix: resolve CLI workspace and channel together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed CLI status pairing a channel with the wrong workspace and silently treating discovery failures as empty selections.
+
 - Fixed channel-list refreshes hiding live messages and notifications, and prevented duplicate message alerts after realtime recovery.
 
 - Fixed profile and notification saves overwriting changes from another tab, and aligned SDK account updates with the API's partial settings contract.

--- a/apps/api/cmd/clickclack/client.go
+++ b/apps/api/cmd/clickclack/client.go
@@ -193,6 +193,11 @@ func (c apiClient) listWorkspacesContext(ctx context.Context) ([]store.Workspace
 	return result.Workspaces, nil
 }
 
+var (
+	errNoWorkspaces = errors.New("no workspaces visible")
+	errNoChannels   = errors.New("no channels visible")
+)
+
 func (c apiClient) resolveWorkspace() (store.Workspace, error) {
 	return c.resolveWorkspaceContext(context.Background())
 }
@@ -205,7 +210,7 @@ func (c apiClient) resolveWorkspaceContext(ctx context.Context) (store.Workspace
 	needle := strings.TrimSpace(c.opts.Workspace)
 	if needle == "" {
 		if len(items) == 0 {
-			return store.Workspace{}, errors.New("no workspaces visible")
+			return store.Workspace{}, errNoWorkspaces
 		}
 		return items[0], nil
 	}
@@ -231,66 +236,47 @@ func (c apiClient) listChannelsContext(ctx context.Context, workspaceID string) 
 	return result.Channels, nil
 }
 
-func (c apiClient) resolveChannel() (store.Channel, error) {
+func (c apiClient) resolveChannel() (store.Workspace, store.Channel, error) {
 	return c.resolveChannelContext(context.Background())
 }
 
-func (c apiClient) resolveChannelContext(ctx context.Context) (store.Channel, error) {
+func (c apiClient) resolveChannelContext(ctx context.Context) (store.Workspace, store.Channel, error) {
 	needle := strings.TrimSpace(c.opts.Channel)
-	if strings.HasPrefix(needle, "chn_") {
-		workspaces, err := c.channelSearchWorkspacesContext(ctx)
-		if err != nil {
-			return store.Channel{}, err
-		}
-		for _, workspace := range workspaces {
-			items, err := c.listChannelsContext(ctx, workspace.ID)
-			if err != nil {
-				return store.Channel{}, err
-			}
-			for _, item := range items {
-				if item.ID == needle {
-					return item, nil
-				}
-			}
-		}
-		return store.Channel{}, fmt.Errorf("channel %q not found", needle)
+	byID := strings.HasPrefix(needle, "chn_")
+	var workspaces []store.Workspace
+	var err error
+	if byID && strings.TrimSpace(c.opts.Workspace) == "" {
+		workspaces, err = c.listWorkspacesContext(ctx)
+	} else {
+		var workspace store.Workspace
+		workspace, err = c.resolveWorkspaceContext(ctx)
+		workspaces = []store.Workspace{workspace}
 	}
-	workspace, err := c.resolveWorkspaceContext(ctx)
 	if err != nil {
-		return store.Channel{}, err
+		return store.Workspace{}, store.Channel{}, err
 	}
-	items, err := c.listChannelsContext(ctx, workspace.ID)
-	if err != nil {
-		return store.Channel{}, err
-	}
+	name := strings.TrimPrefix(needle, "#")
 	if needle == "" {
+		name = "general"
+	}
+	for _, workspace := range workspaces {
+		items, err := c.listChannelsContext(ctx, workspace.ID)
+		if err != nil {
+			return workspace, store.Channel{}, err
+		}
 		for _, item := range items {
-			if item.Name == "general" {
-				return item, nil
+			if item.ID == needle || !byID && item.Name == name {
+				return workspace, item, nil
 			}
 		}
-		if len(items) == 0 {
-			return store.Channel{}, errors.New("no channels visible")
-		}
-		return items[0], nil
-	}
-	for _, item := range items {
-		if item.ID == needle || item.Name == strings.TrimPrefix(needle, "#") {
-			return item, nil
+		if needle == "" {
+			if len(items) == 0 {
+				return workspace, store.Channel{}, errNoChannels
+			}
+			return workspace, items[0], nil
 		}
 	}
-	return store.Channel{}, fmt.Errorf("channel %q not found", needle)
-}
-
-func (c apiClient) channelSearchWorkspacesContext(ctx context.Context) ([]store.Workspace, error) {
-	if strings.TrimSpace(c.opts.Workspace) != "" {
-		workspace, err := c.resolveWorkspaceContext(ctx)
-		if err != nil {
-			return nil, err
-		}
-		return []store.Workspace{workspace}, nil
-	}
-	return c.listWorkspacesContext(ctx)
+	return store.Workspace{}, store.Channel{}, fmt.Errorf("channel %q not found", needle)
 }
 
 func (c apiClient) get(path string, out any) error {

--- a/apps/api/cmd/clickclack/client_commands.go
+++ b/apps/api/cmd/clickclack/client_commands.go
@@ -96,13 +96,9 @@ func (c apiClient) status(args []string) error {
 	if err != nil {
 		return err
 	}
-	workspace, workspaceErr := c.resolveWorkspace()
-	if workspaceErr != nil && strings.TrimSpace(c.opts.Workspace) != "" {
-		return workspaceErr
-	}
-	channel, channelErr := c.resolveChannel()
-	if channelErr != nil && strings.TrimSpace(c.opts.Channel) != "" {
-		return channelErr
+	workspace, channel, err := c.resolveChannel()
+	if err != nil && (strings.TrimSpace(c.opts.Channel) != "" || !errors.Is(err, errNoWorkspaces) && !errors.Is(err, errNoChannels)) {
+		return err
 	}
 	return c.write(map[string]any{"server": c.opts.Server, "user": user, "workspace": workspace, "channel": channel}, "", fmt.Sprintf("server\t%s\nuser\t%s\nworkspace\t%s\nchannel\t%s\n", c.opts.Server, user.ID, workspace.ID, channel.ID))
 }
@@ -184,7 +180,7 @@ func (c apiClient) send(args []string) error {
 	if err != nil {
 		return err
 	}
-	channel, err := c.resolveChannel()
+	_, channel, err := c.resolveChannel()
 	if err != nil {
 		return err
 	}
@@ -209,7 +205,7 @@ func (c apiClient) messagesList(args []string) error {
 		return err
 	}
 	c = c.withOptions(opts, true)
-	channel, err := c.resolveChannel()
+	_, channel, err := c.resolveChannel()
 	if err != nil {
 		return err
 	}

--- a/apps/api/cmd/clickclack/fakeco_canary.go
+++ b/apps/api/cmd/clickclack/fakeco_canary.go
@@ -105,7 +105,7 @@ func (c apiClient) runCanary(parent context.Context, options canaryOptions) (can
 	if user.Kind != "human" {
 		return canaryResult{}, errors.New("canary requires a human session token because OpenClaw ignores bot-authored messages")
 	}
-	channel, err := c.resolveChannelContext(ctx)
+	_, channel, err := c.resolveChannelContext(ctx)
 	if err != nil {
 		return canaryResult{}, fmt.Errorf("resolve canary channel: %w", err)
 	}

--- a/apps/api/cmd/clickclack/main_test.go
+++ b/apps/api/cmd/clickclack/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -526,29 +527,128 @@ func TestMessagesListOmitsAfterSeqUntilExplicitlySet(t *testing.T) {
 	}
 }
 
-func TestStatusFailsForExplicitMissingWorkspaceOrChannel(t *testing.T) {
+func TestStatusSelectsMatchingWorkspaceAndChannel(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/me":
 			_ = json.NewEncoder(w).Encode(map[string]any{"user": store.User{ID: "usr_1", DisplayName: "User"}})
 		case "/api/workspaces":
-			_ = json.NewEncoder(w).Encode(map[string]any{"workspaces": []store.Workspace{{ID: "wsp_1", Slug: "one", Name: "One"}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"workspaces": []store.Workspace{
+				{ID: "wsp_1", Slug: "one", Name: "One"}, {ID: "wsp_2", Slug: "two", Name: "Two"},
+			}})
 		case "/api/workspaces/wsp_1/channels":
-			_ = json.NewEncoder(w).Encode(map[string]any{"channels": []store.Channel{{ID: "chn_1", WorkspaceID: "wsp_1", Name: "general"}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"channels": []store.Channel{
+				{ID: "chn_misc", WorkspaceID: "wsp_1", Name: "misc"}, {ID: "chn_1", WorkspaceID: "wsp_1", Name: "general"},
+			}})
+		case "/api/workspaces/wsp_2/channels":
+			_ = json.NewEncoder(w).Encode(map[string]any{"channels": []store.Channel{{ID: "chn_2", WorkspaceID: "wsp_2", Name: "proof"}}})
 		default:
 			http.NotFound(w, r)
 		}
 	}))
 	t.Cleanup(server.Close)
 
-	c := apiClient{opts: clientOptions{Server: server.URL, UserID: "usr_1", Workspace: "missing", Plain: true}, http: server.Client()}
-	if err := c.status(nil); err == nil || !strings.Contains(err.Error(), `workspace "missing" not found`) {
-		t.Fatalf("expected missing workspace error, got %v", err)
+	for _, tt := range []struct {
+		name, workspace, channel, wantWorkspace, wantChannel, wantError string
+	}{
+		{name: "general default", wantWorkspace: "wsp_1", wantChannel: "chn_1"},
+		{name: "first channel default", workspace: "TWO", wantWorkspace: "wsp_2", wantChannel: "chn_2"},
+		{name: "channel ID across workspaces", channel: "chn_2", wantWorkspace: "wsp_2", wantChannel: "chn_2"},
+		{name: "channel name", workspace: "two", channel: "proof", wantWorkspace: "wsp_2", wantChannel: "chn_2"},
+		{name: "hash name", workspace: "wsp_2", channel: "#proof", wantWorkspace: "wsp_2", wantChannel: "chn_2"},
+		{name: "workspace constrains ID", workspace: "wsp_1", channel: "chn_2", wantError: `channel "chn_2" not found`},
+		{name: "missing workspace", workspace: "missing", wantError: `workspace "missing" not found`},
+		{name: "missing channel", workspace: "wsp_1", channel: "missing", wantError: `channel "missing" not found`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := apiClient{opts: clientOptions{Server: server.URL, UserID: "usr_1", Workspace: tt.workspace, Channel: tt.channel, JSON: true}, http: server.Client()}
+			var err error
+			output := captureStdout(t, func() error { err = c.status(nil); return nil })
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) || output != "" {
+					t.Fatalf("expected %q without stdout, got %v, %q", tt.wantError, err, output)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			var result struct {
+				Workspace store.Workspace `json:"workspace"`
+				Channel   store.Channel   `json:"channel"`
+			}
+			if err := json.Unmarshal([]byte(output), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Workspace.ID != tt.wantWorkspace || result.Channel.ID != tt.wantChannel || result.Channel.WorkspaceID != result.Workspace.ID {
+				t.Fatalf("mismatched selection: workspace=%s channel=%s channel workspace=%s", result.Workspace.ID, result.Channel.ID, result.Channel.WorkspaceID)
+			}
+		})
 	}
+}
 
-	c = apiClient{opts: clientOptions{Server: server.URL, UserID: "usr_1", Workspace: "wsp_1", Channel: "missing", Plain: true}, http: server.Client()}
-	if err := c.status(nil); err == nil || !strings.Contains(err.Error(), `channel "missing" not found`) {
-		t.Fatalf("expected missing channel error, got %v", err)
+func TestStatusDistinguishesEmptyListsFromDiscoveryErrors(t *testing.T) {
+	for _, owner := range []string{"workspaces", "channels"} {
+		for _, tt := range []struct {
+			name, body, wantError string
+			code                  int
+		}{
+			{name: "empty", code: http.StatusOK, body: fmt.Sprintf(`{"%s":[]}`, owner)},
+			{name: "forbidden", code: http.StatusForbidden, body: `{"error":"denied"}`, wantError: "403 Forbidden: denied"},
+			{name: "unavailable", code: http.StatusServiceUnavailable, body: `{"error":"unavailable"}`, wantError: "503 Service Unavailable: unavailable"},
+			{name: "malformed", code: http.StatusOK, body: "not-json", wantError: "invalid character"},
+		} {
+			t.Run(owner+"/"+tt.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					if r.URL.Path == "/api/"+owner || owner == "channels" && r.URL.Path == "/api/workspaces/wsp_1/channels" {
+						w.WriteHeader(tt.code)
+						_, _ = io.WriteString(w, tt.body)
+						return
+					}
+					switch r.URL.Path {
+					case "/api/me":
+						_, _ = io.WriteString(w, `{"user":{"id":"usr_1"}}`)
+					case "/api/workspaces":
+						_, _ = io.WriteString(w, `{"workspaces":[{"id":"wsp_1"}]}`)
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				t.Cleanup(server.Close)
+				c := apiClient{opts: clientOptions{Server: server.URL, UserID: "usr_1", JSON: true}, http: server.Client()}
+				var err error
+				output := captureStdout(t, func() error { err = c.status(nil); return nil })
+				if tt.wantError != "" {
+					if err == nil || !strings.Contains(err.Error(), tt.wantError) || output != "" {
+						t.Fatalf("expected %q without stdout, got %v, %q", tt.wantError, err, output)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				var result struct {
+					Workspace store.Workspace `json:"workspace"`
+					Channel   store.Channel   `json:"channel"`
+				}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Fatal(err)
+				}
+				wantWorkspace := ""
+				if owner == "channels" {
+					wantWorkspace = "wsp_1"
+				}
+				if result.Workspace.ID != wantWorkspace || result.Channel.ID != "" {
+					t.Fatalf("unexpected empty selection: %#v", result)
+				}
+				c.opts.Channel = "general"
+				output = captureStdout(t, func() error { err = c.status(nil); return nil })
+				if err == nil || output != "" {
+					t.Fatalf("explicit channel must fail on an empty list without stdout, got %v, %q", err, output)
+				}
+			})
+		}
 	}
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -262,6 +262,11 @@ clickclack --server http://localhost:8080 --token sst_... threads open msg_... -
 `workspaces list` prints `id slug name` in human mode. `channels list` prints
 `id name kind`. `messages list` prints `seq id author body`.
 
+`status` reports the workspace that contains the selected channel, including
+channel IDs resolved across workspaces. Successful empty workspace or channel
+lists produce an empty selection when no channel is requested; discovery
+failures (including HTTP and malformed-response errors) fail the command.
+
 ## Client writes
 
 ```sh

--- a/tests/e2e/workspace-members.spec.ts
+++ b/tests/e2e/workspace-members.spec.ts
@@ -334,8 +334,9 @@ test("embedded channel recovers newer messages from its message window", async (
     .toBeTruthy();
   await page.locator(".messages-scroll").dispatchEvent("wheel", { deltaY: 100 });
   await page.screenshot({ path: testInfo.outputPath("newer-messages.png") });
+  // Initial scroll and the bootstrap replacement can recover the same cursor.
   await expect
-    .poll(() => ({ newer, errors }))
+    .poll(() => ({ newer: [...new Set(newer)], errors }))
     .toEqual({ newer: [String(data.root.channel_seq)], errors: [] });
   await expect(page.locator(`[data-message-id="${next.id}"]`)).toContainText(
     "Newer synthetic message",


### PR DESCRIPTION
`status --channel <ID>` could report a channel from one workspace alongside an independently selected workspace. It also treated failed default workspace/channel discovery as a successful empty selection, so HTTP 403/503 and malformed JSON produced exit 0.

The existing resolver now selects its workspace scope once, traverses channels once, and returns the matched workspace and channel together. This removes the duplicate search helper and `status`'s independent workspace lookup. Successful empty lists remain valid for default selection; explicit missing selectors and discovery errors fail the command. Channel IDs, workspace constraints, names/`#name`, `general`/first-channel defaults, and context-aware canary cancellation keep their existing contracts.

Validation:

- The new status regressions fail before the change for the cross-workspace mismatch and all six HTTP/JSON error cases. The final focused status, message-list, and canary tests pass: `go test ./apps/api/cmd/clickclack -run '^(TestStatus|TestMessagesList|TestRunCanary)' -count=1`.
- Real CLI processes against the same synthetic standalone API at `127.0.0.1:19494` show the before/after workspace mismatch becoming a consistent pair. A bounded forwarding proxy at `127.0.0.1:19498` changes only the selected discovery response: 403, 503, and malformed JSON now exit 1; successful empty workspace/channel lists still exit 0.
- `pnpm fmt:go:check` and `git diff --check` pass. Docs and changelog describe the corrected behavior. Required isolated Codex review of the complete diff passed with no findings at the requested P0 threshold. Independent maintainer verification also confirms the correct pair against the original synthetic fixture. Final-head CI passed after the recorded browser-job retry below.

Candidate SHA-256: `eda02ca5bbe84b899848f14b57ff43eb310b8862beb5bf42a7bee315b5ed854d`, built with `go build -o <candidate> ./apps/api/cmd/clickclack`. The API and embedded web assets are unchanged; this is a client-only repair.

Production: **18 lines removed net**. Tests: net +101. Docs/changelog: +7. No schema, dependencies, or generated assets changed.

Captured real-process evidence (synthetic IDs; JSON narrowed to the selection fields):

```text
$ /tmp/clickclack-deslop-20260831/upload-owner-candidate status --server http://127.0.0.1:19494 --user usr_01m1bffevbs5zf6tyet3w1mhkk --channel chn_01m1bgwymrh6sja1ddd4yb5ejq --json
exit: 0
{"workspace.id": "wsp_01m1bffevdzrpkbpp6h83a60sv", "channel.id": "chn_01m1bgwymrh6sja1ddd4yb5ejq", "channel.workspace_id": "wsp_01m1bgwympk88821cb1607zmvj", "consistent": false}
$ /tmp/clickclack-deslop-20260831/cli-candidate status --server http://127.0.0.1:19494 --user usr_01m1bffevbs5zf6tyet3w1mhkk --channel chn_01m1bgwymrh6sja1ddd4yb5ejq --json
exit: 0
{"workspace.id": "wsp_01m1bgwympk88821cb1607zmvj", "channel.id": "chn_01m1bgwymrh6sja1ddd4yb5ejq", "channel.workspace_id": "wsp_01m1bgwympk88821cb1607zmvj", "consistent": true}
```

The same real CLI was then invoked through the bounded forwarding proxy. All other responses came from the same standalone API; the injected list response is named below. These are captured exit codes and stderr, not unit-test assertions:

```text
before:
  workspaces_forbidden: exit=0, stderr=""
  workspaces_unavailable: exit=0, stderr=""
  workspaces_malformed: exit=0, stderr=""
  workspaces_empty: exit=0, stderr=""
  channels_forbidden: exit=0, stderr=""
  channels_unavailable: exit=0, stderr=""
  channels_malformed: exit=0, stderr=""
  channels_empty: exit=0, stderr=""
after:
  workspaces_forbidden: exit=1, stderr="2026/08/31 02:11:16 403 Forbidden: synthetic denied"
  workspaces_unavailable: exit=1, stderr="2026/08/31 02:11:16 503 Service Unavailable: synthetic unavailable"
  workspaces_malformed: exit=1, stderr="2026/08/31 02:11:16 invalid character 'o' in literal null (expecting 'u')"
  workspaces_empty: exit=0, stderr=""
  channels_forbidden: exit=1, stderr="2026/08/31 02:11:16 403 Forbidden: synthetic denied"
  channels_unavailable: exit=1, stderr="2026/08/31 02:11:16 503 Service Unavailable: synthetic unavailable"
  channels_malformed: exit=1, stderr="2026/08/31 02:11:16 invalid character 'o' in literal null (expecting 'u')"
  channels_empty: exit=0, stderr=""
```

The initial CI run passed backend/PostgreSQL, coverage, dead-code, TypeScript/build, and Docker checks; 228 browser tests passed and one existing embed recovery test failed because it counted a valid repeated cursor across initial loading and bootstrap replacement as an extra request. The fixture assertion now checks distinct cursor values while still requiring the correct cursor, zero page errors, and the actual recovered row. Exact request-cardinality checks remain in the neighboring recovery-generation test. Both retained embed cases pass against the standalone server, and the required isolated test-delta review is clean. The next run passed this embed test but hit the existing paused-frame live-scroll read-marker assertion (34 instead of 36). The exact unchanged scenario passed locally in 2.6 seconds; one failed-job retry on the same commit then passed. This does not establish that timing failure's cause. Final-head CI is green, with no change to the read-marker assertion or timeout.
