### PR TITLE
refactor: share public route ID generation across stores

### DIFF
--- a/apps/api/internal/store/postgres/dms.go
+++ b/apps/api/internal/store/postgres/dms.go
@@ -112,7 +112,7 @@ func (s *Store) CreateDirectConversation(ctx context.Context, input store.Create
 	dm := store.DirectConversation{ID: newID("dm"), WorkspaceID: input.WorkspaceID, CreatedAt: now()}
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('D')
+		routeID, err := store.NewRouteID('D')
 		if err != nil {
 			return store.DirectConversation{}, err
 		}

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
 	"regexp"
 	"slices"
@@ -378,39 +377,6 @@ func newID(prefix string) string {
 	id := ulid.MustNew(ulid.Timestamp(time.Now()), idEntropy)
 	idMu.Unlock()
 	return prefix + "_" + strings.ToLower(id.String())
-}
-
-const routeIDAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
-
-func newRouteID(prefix byte) (string, error) {
-	const routeIDRandomBytes = 10
-	var raw [routeIDRandomBytes]byte
-	if _, err := rand.Read(raw[:]); err != nil {
-		return "", err
-	}
-	var out [17]byte
-	out[0] = prefix
-	bitBuffer := 0
-	bits := 0
-	pos := 1
-	for _, b := range raw {
-		bitBuffer = (bitBuffer << 8) | int(b)
-		bits += 8
-		for bits >= 5 {
-			bits -= 5
-			out[pos] = routeIDAlphabet[(bitBuffer>>bits)&31]
-			pos++
-			if bits > 0 {
-				bitBuffer &= (1 << bits) - 1
-			} else {
-				bitBuffer = 0
-			}
-		}
-	}
-	if pos != len(out) {
-		return "", fmt.Errorf("route id encoder produced %d characters", pos)
-	}
-	return string(out[:]), nil
 }
 
 func now() string {

--- a/apps/api/internal/store/postgres/members.go
+++ b/apps/api/internal/store/postgres/members.go
@@ -271,7 +271,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 		insertedWorkspace := false
 		createdWorkspace := false
 		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-			workspaceRouteID, err := newRouteID('T')
+			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
 			}
@@ -311,7 +311,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 			channelID := newID("chn")
 			insertedChannel := false
 			for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-				channelRouteID, err := newRouteID('C')
+				channelRouteID, err := store.NewRouteID('C')
 				if err != nil {
 					return store.Workspace{}, err
 				}
@@ -362,7 +362,7 @@ func (s *Store) EnsureDefaultGuestWorkspaceMember(ctx context.Context, userID, r
 		workspace = store.Workspace{ID: newID("wsp"), Name: "Guests", Slug: "guests", CreatedAt: now()}
 		insertedWorkspace := false
 		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-			workspaceRouteID, err := newRouteID('T')
+			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
 			}
@@ -425,7 +425,7 @@ func postgresEnsureNamedChannelTx(ctx context.Context, tx *sql.Tx, workspaceID, 
 		return err
 	}
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('C')
+		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return err
 		}

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -469,7 +469,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	qtx := s.q.WithTx(tx)
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('T')
+		routeID, err := store.NewRouteID('T')
 		if err != nil {
 			return store.Workspace{}, err
 		}
@@ -580,7 +580,7 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 	}
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('C')
+		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return store.Channel{}, store.Event{}, err
 		}

--- a/apps/api/internal/store/postgres/route_ids.go
+++ b/apps/api/internal/store/postgres/route_ids.go
@@ -96,7 +96,7 @@ func (s *Store) backfillTableRouteIDs(ctx context.Context, table, prefix, where 
 
 func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte) error {
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID(prefix)
+		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte
 
 func assignRouteIDTx(ctx context.Context, tx *sql.Tx, table, id string, prefix byte) error {
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID(prefix)
+		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
 		}

--- a/apps/api/internal/store/route_ids.go
+++ b/apps/api/internal/store/route_ids.go
@@ -1,0 +1,20 @@
+package store
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+)
+
+var routeIDEncoding = base32.NewEncoding("0123456789ABCDEFGHJKMNPQRSTVWXYZ").WithPadding(base32.NoPadding)
+
+// NewRouteID returns a byte prefix followed by 16 base32 characters from 80 random bits.
+func NewRouteID(prefix byte) (string, error) {
+	var raw [10]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	var out [17]byte
+	out[0] = prefix
+	routeIDEncoding.Encode(out[1:], raw[:])
+	return string(out[:]), nil
+}

--- a/apps/api/internal/store/route_ids_test.go
+++ b/apps/api/internal/store/route_ids_test.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewRouteIDFormat(t *testing.T) {
+	t.Parallel()
+	for _, prefix := range []byte{'T', 'C', 'D', 'M'} {
+		t.Run(string(prefix), func(t *testing.T) {
+			id, err := NewRouteID(prefix)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(id) != 17 || id[0] != prefix {
+				t.Fatalf("route ID %q must have prefix %q and a 16-character payload", id, prefix)
+			}
+			if strings.Trim(id[1:], "0123456789ABCDEFGHJKMNPQRSTVWXYZ") != "" {
+				t.Fatalf("route ID %q contains characters outside uppercase Crockford base32", id)
+			}
+		})
+	}
+}

--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -112,7 +112,7 @@ func (s *Store) CreateDirectConversation(ctx context.Context, input store.Create
 	dm := store.DirectConversation{ID: newID("dm"), WorkspaceID: input.WorkspaceID, CreatedAt: now()}
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('D')
+		routeID, err := store.NewRouteID('D')
 		if err != nil {
 			return store.DirectConversation{}, err
 		}

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -6,7 +6,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -357,39 +356,6 @@ func newID(prefix string) string {
 	id := ulid.MustNew(ulid.Timestamp(time.Now()), idEntropy)
 	idMu.Unlock()
 	return prefix + "_" + strings.ToLower(id.String())
-}
-
-const routeIDAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
-
-func newRouteID(prefix byte) (string, error) {
-	const routeIDRandomBytes = 10
-	var raw [routeIDRandomBytes]byte
-	if _, err := rand.Read(raw[:]); err != nil {
-		return "", err
-	}
-	var out [17]byte
-	out[0] = prefix
-	bitBuffer := 0
-	bits := 0
-	pos := 1
-	for _, b := range raw {
-		bitBuffer = (bitBuffer << 8) | int(b)
-		bits += 8
-		for bits >= 5 {
-			bits -= 5
-			out[pos] = routeIDAlphabet[(bitBuffer>>bits)&31]
-			pos++
-			if bits > 0 {
-				bitBuffer &= (1 << bits) - 1
-			} else {
-				bitBuffer = 0
-			}
-		}
-	}
-	if pos != len(out) {
-		return "", fmt.Errorf("route id encoder produced %d characters", pos)
-	}
-	return string(out[:]), nil
 }
 
 func now() string {

--- a/apps/api/internal/store/sqlite/members.go
+++ b/apps/api/internal/store/sqlite/members.go
@@ -272,7 +272,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 		insertedWorkspace := false
 		createdWorkspace := false
 		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-			workspaceRouteID, err := newRouteID('T')
+			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
 			}
@@ -341,7 +341,7 @@ func (s *Store) EnsureDefaultGuestWorkspaceMember(ctx context.Context, userID, r
 		workspace = store.Workspace{ID: newID("wsp"), Name: "Guests", Slug: "guests", CreatedAt: now()}
 		insertedWorkspace := false
 		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-			workspaceRouteID, err := newRouteID('T')
+			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
 			}
@@ -403,7 +403,7 @@ func sqliteEnsureNamedChannelTx(ctx context.Context, tx *sql.Tx, workspaceID, na
 		return err
 	}
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('C')
+		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return err
 		}

--- a/apps/api/internal/store/sqlite/route_ids.go
+++ b/apps/api/internal/store/sqlite/route_ids.go
@@ -96,7 +96,7 @@ func (s *Store) backfillTableRouteIDs(ctx context.Context, table, prefix, where 
 
 func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte) error {
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID(prefix)
+		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte
 
 func assignRouteIDTx(ctx context.Context, tx *sql.Tx, table, id string, prefix byte) error {
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID(prefix)
+		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
 		}

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -483,7 +483,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	qtx := s.q.WithTx(tx)
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('T')
+		routeID, err := store.NewRouteID('T')
 		if err != nil {
 			return store.Workspace{}, err
 		}
@@ -594,7 +594,7 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 	}
 	inserted := false
 	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
-		routeID, err := newRouteID('C')
+		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return store.Channel{}, store.Event{}, err
 		}


### PR DESCRIPTION
## What Problem This Solves

SQLite and PostgreSQL maintain identical handwritten encoders for the same public route ID format. This behavior-neutral refactor gives that format one owner.

## Why This Change Was Made

Both stores now call `store.NewRouteID`, backed by Go's standard base32 encoder with the existing Crockford alphabet and no padding. It keeps ten crypto-random bytes and the original byte prefix, producing the same sixteen uppercase payload characters. All creation, backfill, collision retry, transaction, and permission logic stays with its existing store owner.

## User Impact

No user-visible behavior change. The production diff removes 48 lines; one shared format test adds 24 lines to enforce the alphabet contract beyond the existing prefix and length assertions.

## Evidence

The existing SQLite route/default-workspace and HTTP route tests pass, covering lazy assignment, resolution, immutable IDs, migration backfill, and permission checks. The existing concurrent-assignment tests also pass under the race detector in SQLite and PostgreSQL, alongside the shared format test.

Independent live API checks passed on SQLite and PostgreSQL before and after restarting the candidate binary against the same persisted databases: existing channel, DM, channel-thread, and DM-thread links resolve unchanged; nonparticipants cannot resolve private DM or thread routes; newly created workspace/channel routes retain the format and resolve.

Validation: focused Go tests, concurrent route tests with `-race`, gofmt, `git diff --check`, and isolated Codex autoreview (no accepted/actionable P0 findings).


## Inspectable live restart proof

Addressing the ClawSweeper proof request and rank-up move: this trace was captured from real local HTTP servers backed by persistent SQLite and PostgreSQL, using synthetic fixtures only. The baseline binary was built from `9639ea80b24c540c0c97eacc9771ead654e6d622`; it created the route IDs below. That process was stopped, and a binary built from this PR candidate reopened the same data directories/database. These GET results compare the saved pre-restart IDs with the returned post-restart targets. No mock API/store was used.

```json
[
  {
    "backend": "sqlite",
    "persisted_route_id_before_restart": "C6CZJD1FX0X9V0V4K",
    "http_status": 200,
    "after_restart_target_id": "chn_01m1c74zdzpsyqxwwz9pjyzyh4",
    "same_target": true,
    "canonical_path": "/app/TKAYTAY1YFAFCCHEY/C6CZJD1FX0X9V0V4K"
  },
  {
    "backend": "sqlite",
    "persisted_route_id_before_restart": "D5S2Y6MDNGC2C2P3R",
    "http_status": 200,
    "after_restart_target_id": "dm_01m1c74zkmje6q8b3e4hvc80tg",
    "same_target": true,
    "canonical_path": "/app/TKAYTAY1YFAFCCHEY/D5S2Y6MDNGC2C2P3R"
  },
  {
    "backend": "sqlite",
    "persisted_route_id_before_restart": "MCNVEJ0MZ9TZ9KVZ4",
    "http_status": 200,
    "after_restart_target_id": "msg_01m1c74zkx9vq0570bvzakms9h",
    "same_target": true,
    "canonical_path": "/app/TKAYTAY1YFAFCCHEY/MCNVEJ0MZ9TZ9KVZ4"
  },
  {
    "backend": "sqlite",
    "persisted_route_id_before_restart": "M2TGFYC8CMEQYP1KQ",
    "http_status": 200,
    "after_restart_target_id": "msg_01m1c74zmmvqaxxct6arphw8k6",
    "same_target": true,
    "canonical_path": "/app/TKAYTAY1YFAFCCHEY/M2TGFYC8CMEQYP1KQ"
  },
  {
    "backend": "sqlite",
    "nonparticipant": "dm",
    "http_status": 404
  },
  {
    "backend": "sqlite",
    "nonparticipant": "dmroot",
    "http_status": 404
  },
  {
    "backend": "postgres",
    "persisted_route_id_before_restart": "CSQWCGRWQ8RRKECA6",
    "http_status": 200,
    "after_restart_target_id": "chn_01m1c74zvk9p9xna9209svwqp7",
    "same_target": true,
    "canonical_path": "/app/TYZKT9HNY03J1DXNE/CSQWCGRWQ8RRKECA6"
  },
  {
    "backend": "postgres",
    "persisted_route_id_before_restart": "DW75RGPX0T152ZANE",
    "http_status": 200,
    "after_restart_target_id": "dm_01m1c75006tjmydncr63rkb7mn",
    "same_target": true,
    "canonical_path": "/app/TYZKT9HNY03J1DXNE/DW75RGPX0T152ZANE"
  },
  {
    "backend": "postgres",
    "persisted_route_id_before_restart": "MRV4ZMKRWYH6P51V8",
    "http_status": 200,
    "after_restart_target_id": "msg_01m1c7503eywq3gg40dn6847qy",
    "same_target": true,
    "canonical_path": "/app/TYZKT9HNY03J1DXNE/MRV4ZMKRWYH6P51V8"
  },
  {
    "backend": "postgres",
    "persisted_route_id_before_restart": "MB12F0R48B6EHVJYC",
    "http_status": 200,
    "after_restart_target_id": "msg_01m1c75084ghjsbhgs9w40ta40",
    "same_target": true,
    "canonical_path": "/app/TYZKT9HNY03J1DXNE/MB12F0R48B6EHVJYC"
  },
  {
    "backend": "postgres",
    "nonparticipant": "dm",
    "http_status": 404
  },
  {
    "backend": "postgres",
    "nonparticipant": "dmroot",
    "http_status": 404
  }
]
```

The same live script also created new workspace/channel routes with the candidate, checked the uppercase 17-character format, and resolved them successfully on both stores. Focused route tests cover backfill and default creation; race tests exercised concurrent allocation on real PostgreSQL and SQLite. All exact-head CI checks passed, including full browser E2E and desktop builds.
