### PR TITLE
refactor: consolidate account settings writes

### DIFF
--- a/apps/api/internal/httpapi/mutations_test.go
+++ b/apps/api/internal/httpapi/mutations_test.go
@@ -54,10 +54,12 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	if err := st.AddWorkspaceMember(ctx, workspaces[0].ID, second.ID, "member"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          second.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "u12345678901234567890123456789",
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: second.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "u12345678901234567890123456789",
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -262,9 +264,9 @@ func TestMutationAndEphemeralEndpoints(t *testing.T) {
 	}
 
 	secondBoard := "iris"
-	if _, err := st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
-		UserID: second.ID,
-		Patch:  store.AppearancePreferencesPatch{BoardTheme: &secondBoard},
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID:                second.ID,
+		AppearancePreferences: &store.AppearancePreferencesPatch{BoardTheme: &secondBoard},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -730,10 +732,12 @@ func TestPushNotificationsRespectModerationVisibility(t *testing.T) {
 	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, guest.ID, store.WorkspaceRoleGuest); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          guest.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "g12345678901234567890123456789",
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: guest.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "g12345678901234567890123456789",
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -779,10 +783,12 @@ func TestPushNotificationsRespectModerationVisibility(t *testing.T) {
 	if _, err := st.EnsureDefaultGuestWorkspaceMember(ctx, member.ID, store.WorkspaceRoleMember); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          member.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "m12345678901234567890123456789",
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: member.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "m12345678901234567890123456789",
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -1356,10 +1356,12 @@ func TestHTTPErrorPathsAndSPA(t *testing.T) {
 	if auth.User.DisplayName != "Auth User" || auth.Session.Token == "" {
 		t.Fatalf("unexpected auth payload: %#v", auth)
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          auth.User.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "abcdefghijklmnopqrstuvwxyz1234",
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: auth.User.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "abcdefghijklmnopqrstuvwxyz1234",
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/postgres/appearance.go
+++ b/apps/api/internal/store/postgres/appearance.go
@@ -26,28 +26,6 @@ func (s *Store) GetAppearancePreferences(ctx context.Context, userID string) (*s
 	return &preferences, nil
 }
 
-func (s *Store) UpdateAppearancePreferences(ctx context.Context, input store.UpdateAppearancePreferencesInput) (*store.AppearancePreferences, error) {
-	patch, err := store.NormalizeAppearancePreferencesPatch(input.Patch)
-	if err != nil {
-		return nil, err
-	}
-	if store.AppearancePreferencesPatchEmpty(patch) {
-		return s.GetAppearancePreferences(ctx, input.UserID)
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-	if err := updateAppearancePreferences(ctx, s.q.WithTx(tx), input.UserID, patch); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return s.GetAppearancePreferences(ctx, input.UserID)
-}
-
 func updateAppearancePreferences(ctx context.Context, q *storedb.Queries, userID string, patch store.AppearancePreferencesPatch) error {
 	if err := q.EnsureAppearancePreferences(ctx, userID); err != nil {
 		return err

--- a/apps/api/internal/store/postgres/appearance_test.go
+++ b/apps/api/internal/store/postgres/appearance_test.go
@@ -44,9 +44,9 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 	dark := "dark"
 	iris := "iris"
 	comfortable := "comfortable"
-	preferences, err = st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
+	account, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID: user.ID,
-		Patch: store.AppearancePreferencesPatch{
+		AppearancePreferences: &store.AppearancePreferencesPatch{
 			ColorMode:  &dark,
 			BoardTheme: &iris,
 			Density:    &comfortable,
@@ -55,15 +55,16 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	preferences = account.AppearancePreferences
 	if preferences == nil || preferences.ColorMode != "dark" || preferences.BoardTheme != "iris" || preferences.MessageLayout != "" || preferences.Density != "" {
 		t.Fatalf("unexpected initial preferences: %#v", preferences)
 	}
 
 	standard := "standard"
 	ember := "ember"
-	preferences, err = st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
+	account, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID: user.ID,
-		Patch: store.AppearancePreferencesPatch{
+		AppearancePreferences: &store.AppearancePreferencesPatch{
 			BoardTheme:    &ember,
 			MessageLayout: &standard,
 		},
@@ -71,14 +72,15 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	preferences = account.AppearancePreferences
 	if preferences == nil || preferences.ColorMode != "dark" || preferences.BoardTheme != "ember" || preferences.MessageLayout != "" || preferences.Density != "" {
 		t.Fatalf("partial update replaced unrelated preferences: %#v", preferences)
 	}
 
 	invalid := "roomy"
-	if _, err := st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
-		UserID: user.ID,
-		Patch:  store.AppearancePreferencesPatch{Density: &invalid},
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID:                user.ID,
+		AppearancePreferences: &store.AppearancePreferencesPatch{Density: &invalid},
 	}); err == nil {
 		t.Fatal("expected invalid density to fail")
 	}
@@ -112,7 +114,7 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 
 	newHandle := "@appearance-postgres"
 	compact := "compact"
-	account, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+	account, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID:                user.ID,
 		Handle:                &newHandle,
 		AppearancePreferences: &store.AppearancePreferencesPatch{Density: &compact},

--- a/apps/api/internal/store/postgres/notifications.go
+++ b/apps/api/internal/store/postgres/notifications.go
@@ -13,21 +13,6 @@ import (
 
 var pushoverUserKeyRE = regexp.MustCompile(`^[A-Za-z0-9]{30}$`)
 
-func (s *Store) UpdateNotificationSettings(ctx context.Context, input store.UpdateNotificationSettingsInput) (store.NotificationSettings, error) {
-	settings, enabled, err := normalizeNotificationSettings(input)
-	if err != nil {
-		return store.NotificationSettings{}, err
-	}
-	if err := s.q.UpsertNotificationSettings(ctx, storedb.UpsertNotificationSettingsParams{
-		UserID:          input.UserID,
-		PushoverEnabled: enabled,
-		PushoverUserKey: settings.PushoverUserKey,
-	}); err != nil {
-		return store.NotificationSettings{}, err
-	}
-	return settings, nil
-}
-
 func normalizeNotificationSettings(input store.UpdateNotificationSettingsInput) (store.NotificationSettings, int64, error) {
 	userKey := strings.TrimSpace(input.PushoverUserKey)
 	if input.PushoverEnabled && userKey == "" {

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -258,20 +258,6 @@ func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserPro
 	return s.GetUser(ctx, input.UserID)
 }
 
-func (s *Store) UpdateUserProfileAndNotificationSettings(ctx context.Context, input store.UpdateUserProfileAndNotificationSettingsInput) (store.User, error) {
-	result, err := s.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
-		UserID:               input.UserID,
-		DisplayName:          &input.DisplayName,
-		Handle:               &input.Handle,
-		AvatarURL:            &input.AvatarURL,
-		NotificationSettings: input.NotificationSettings,
-	})
-	if err != nil {
-		return store.User{}, err
-	}
-	return result.User, nil
-}
-
 func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrentUserInput) (store.CurrentUserState, error) {
 	displayName, handle, avatarURL, err := normalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {

--- a/apps/api/internal/store/sqlite/appearance.go
+++ b/apps/api/internal/store/sqlite/appearance.go
@@ -26,28 +26,6 @@ func (s *Store) GetAppearancePreferences(ctx context.Context, userID string) (*s
 	return &preferences, nil
 }
 
-func (s *Store) UpdateAppearancePreferences(ctx context.Context, input store.UpdateAppearancePreferencesInput) (*store.AppearancePreferences, error) {
-	patch, err := store.NormalizeAppearancePreferencesPatch(input.Patch)
-	if err != nil {
-		return nil, err
-	}
-	if store.AppearancePreferencesPatchEmpty(patch) {
-		return s.GetAppearancePreferences(ctx, input.UserID)
-	}
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-	if err := updateAppearancePreferences(ctx, s.q.WithTx(tx), input.UserID, patch); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-	return s.GetAppearancePreferences(ctx, input.UserID)
-}
-
 func updateAppearancePreferences(ctx context.Context, q *storedb.Queries, userID string, patch store.AppearancePreferencesPatch) error {
 	if err := q.EnsureAppearancePreferences(ctx, userID); err != nil {
 		return err

--- a/apps/api/internal/store/sqlite/appearance_test.go
+++ b/apps/api/internal/store/sqlite/appearance_test.go
@@ -28,20 +28,22 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 		t.Fatalf("expected missing preferences, got %#v", preferences)
 	}
 
-	if preferences, err = st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
-		UserID: user.ID,
-	}); err != nil {
+	account, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID:                user.ID,
+		AppearancePreferences: &store.AppearancePreferencesPatch{},
+	})
+	if err != nil {
 		t.Fatal(err)
-	} else if preferences != nil {
-		t.Fatalf("empty patch created a row: %#v", preferences)
+	} else if account.AppearancePreferences != nil {
+		t.Fatalf("empty patch created a row: %#v", account.AppearancePreferences)
 	}
 
 	system := "system"
 	moss := "moss"
 	compact := "compact"
-	preferences, err = st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
+	account, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID: user.ID,
-		Patch: store.AppearancePreferencesPatch{
+		AppearancePreferences: &store.AppearancePreferencesPatch{
 			ColorMode:  &system,
 			BoardTheme: &moss,
 			Density:    &compact,
@@ -50,15 +52,16 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	preferences = account.AppearancePreferences
 	if preferences == nil || preferences.ColorMode != "" || preferences.BoardTheme != "moss" || preferences.MessageLayout != "" || preferences.Density != "compact" {
 		t.Fatalf("unexpected initial preferences: %#v", preferences)
 	}
 
 	signal := "signal"
 	outlined := "outlined"
-	preferences, err = st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
+	account, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID: user.ID,
-		Patch: store.AppearancePreferencesPatch{
+		AppearancePreferences: &store.AppearancePreferencesPatch{
 			BoardTheme:    &signal,
 			MessageLayout: &outlined,
 		},
@@ -66,14 +69,15 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	preferences = account.AppearancePreferences
 	if preferences == nil || preferences.ColorMode != "" || preferences.BoardTheme != "" || preferences.MessageLayout != "outlined" || preferences.Density != "compact" {
 		t.Fatalf("partial update replaced unrelated preferences: %#v", preferences)
 	}
 
 	invalid := "sepia"
-	if _, err := st.UpdateAppearancePreferences(ctx, store.UpdateAppearancePreferencesInput{
-		UserID: user.ID,
-		Patch:  store.AppearancePreferencesPatch{ColorMode: &invalid},
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID:                user.ID,
+		AppearancePreferences: &store.AppearancePreferencesPatch{ColorMode: &invalid},
 	}); err == nil {
 		t.Fatal("expected invalid color mode to fail")
 	}
@@ -107,7 +111,7 @@ func TestAppearancePreferencesLifecycle(t *testing.T) {
 
 	newHandle := "@appearance-user"
 	dark := "dark"
-	account, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+	account, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID:                user.ID,
 		Handle:                &newHandle,
 		AppearancePreferences: &store.AppearancePreferencesPatch{ColorMode: &dark},

--- a/apps/api/internal/store/sqlite/mentions_notifications_test.go
+++ b/apps/api/internal/store/sqlite/mentions_notifications_test.go
@@ -591,10 +591,12 @@ func TestPushNotificationRecipientsRespectChannelMute(t *testing.T) {
 	}
 
 	// Enable push notifications for the member.
-	_, err = st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          member.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "m12345678901234567890123456789",
+	_, err = st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: member.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "m12345678901234567890123456789",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/apps/api/internal/store/sqlite/misc_test.go
+++ b/apps/api/internal/store/sqlite/misc_test.go
@@ -49,16 +49,17 @@ func TestStoreMiscBranches(t *testing.T) {
 	if updatedOwner.Handle != "steipete" || updatedOwner.AvatarURL != "https://example.com/avatar.png" {
 		t.Fatalf("unexpected profile update: %#v", updatedOwner)
 	}
-	clearedOwner, err := st.UpdateUserProfileAndNotificationSettings(ctx, store.UpdateUserProfileAndNotificationSettingsInput{
+	empty := ""
+	clearedOwner, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID:      owner.ID,
-		DisplayName: updatedOwner.DisplayName,
-		Handle:      updatedOwner.Handle,
-		AvatarURL:   "",
+		DisplayName: &updatedOwner.DisplayName,
+		Handle:      &updatedOwner.Handle,
+		AvatarURL:   &empty,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if clearedOwner.AvatarURL != ownerGravatar {
+	if clearedOwner.User.AvatarURL != ownerGravatar {
 		t.Fatalf("expected cleared avatar to restore Gravatar %q, got %#v", ownerGravatar, clearedOwner)
 	}
 	if _, err := st.UpdateUserProfile(ctx, store.UpdateUserProfileInput{UserID: unnamed.ID, DisplayName: "Other", Handle: "STEIPETE"}); err == nil {
@@ -79,18 +80,24 @@ func TestStoreMiscBranches(t *testing.T) {
 	if _, err := st.UpdateUserProfile(ctx, store.UpdateUserProfileInput{UserID: "usr_missing", DisplayName: "Missing"}); err == nil {
 		t.Fatal("expected missing profile user error")
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{UserID: owner.ID, PushoverEnabled: true}); err == nil {
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID:               owner.ID,
+		NotificationSettings: &store.NotificationSettings{PushoverEnabled: true},
+	}); err == nil {
 		t.Fatal("expected missing pushover key error")
 	}
-	settings, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          owner.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "u12345678901234567890123456789",
+	account, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: owner.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "u12345678901234567890123456789",
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !settings.PushoverEnabled || settings.PushoverUserKey == "" {
+	settings := account.User.NotificationSettings
+	if settings == nil || !settings.PushoverEnabled || settings.PushoverUserKey == "" {
 		t.Fatalf("unexpected notification settings: %#v", settings)
 	}
 	ownerWithSettings, err := st.GetUser(ctx, owner.ID)
@@ -166,16 +173,17 @@ func TestStoreMiscBranches(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	fallbackIdentity, err = st.UpdateUserProfileAndNotificationSettings(ctx, store.UpdateUserProfileAndNotificationSettingsInput{
+	clearedIdentity, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 		UserID:      fallbackIdentity.ID,
-		DisplayName: fallbackIdentity.DisplayName,
-		AvatarURL:   "",
+		DisplayName: &fallbackIdentity.DisplayName,
+		Handle:      &empty,
+		AvatarURL:   &empty,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fallbackIdentity.AvatarURL != fallbackGravatar {
-		t.Fatalf("expected late identity email to restore Gravatar %q, got %#v", fallbackGravatar, fallbackIdentity)
+	if clearedIdentity.User.AvatarURL != fallbackGravatar {
+		t.Fatalf("expected late identity email to restore Gravatar %q, got %#v", fallbackGravatar, clearedIdentity)
 	}
 	emailIdentity, err := st.UpsertIdentityUser(ctx, store.UpsertIdentityUserInput{Provider: "github", ProviderSubject: "email", Email: "email@example.com"})
 	if err != nil {
@@ -469,10 +477,12 @@ func TestConcurrentProfileClearRestoresLateEmailFallback(t *testing.T) {
 	go func() {
 		defer group.Done()
 		<-start
-		_, err := st.UpdateUserProfileAndNotificationSettings(ctx, store.UpdateUserProfileAndNotificationSettingsInput{
+		empty := ""
+		_, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
 			UserID:      user.ID,
-			DisplayName: user.DisplayName,
-			AvatarURL:   "",
+			DisplayName: &user.DisplayName,
+			Handle:      &empty,
+			AvatarURL:   &empty,
 		})
 		errors <- err
 	}()

--- a/apps/api/internal/store/sqlite/notifications.go
+++ b/apps/api/internal/store/sqlite/notifications.go
@@ -14,21 +14,6 @@ import (
 
 var pushoverUserKeyRE = regexp.MustCompile(`^[A-Za-z0-9]{30}$`)
 
-func (s *Store) UpdateNotificationSettings(ctx context.Context, input store.UpdateNotificationSettingsInput) (store.NotificationSettings, error) {
-	settings, enabled, err := normalizeNotificationSettings(input)
-	if err != nil {
-		return store.NotificationSettings{}, err
-	}
-	if err := s.q.UpsertNotificationSettings(ctx, storedb.UpsertNotificationSettingsParams{
-		UserID:          input.UserID,
-		PushoverEnabled: enabled,
-		PushoverUserKey: settings.PushoverUserKey,
-	}); err != nil {
-		return store.NotificationSettings{}, err
-	}
-	return settings, nil
-}
-
 func normalizeNotificationSettings(input store.UpdateNotificationSettingsInput) (store.NotificationSettings, int64, error) {
 	userKey := strings.TrimSpace(input.PushoverUserKey)
 	if input.PushoverEnabled && userKey == "" {

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -272,20 +272,6 @@ func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserPro
 	return s.GetUser(ctx, input.UserID)
 }
 
-func (s *Store) UpdateUserProfileAndNotificationSettings(ctx context.Context, input store.UpdateUserProfileAndNotificationSettingsInput) (store.User, error) {
-	result, err := s.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
-		UserID:               input.UserID,
-		DisplayName:          &input.DisplayName,
-		Handle:               &input.Handle,
-		AvatarURL:            &input.AvatarURL,
-		NotificationSettings: input.NotificationSettings,
-	})
-	if err != nil {
-		return store.User{}, err
-	}
-	return result.User, nil
-}
-
 func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrentUserInput) (store.CurrentUserState, error) {
 	displayName, handle, avatarURL, err := normalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {

--- a/apps/api/internal/store/sqlite/sqlite_test.go
+++ b/apps/api/internal/store/sqlite/sqlite_test.go
@@ -33,10 +33,12 @@ func TestStoreValidationAndAdminHelpers(t *testing.T) {
 	}
 	workspace := workspaces[0]
 	pushoverUserKey := "abcdefghijklmnopqrstuvwxyz1234"
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          owner.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: pushoverUserKey,
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: owner.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: pushoverUserKey,
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -98,10 +100,12 @@ func TestStoreValidationAndAdminHelpers(t *testing.T) {
 	if want := store.ResolveAvatarURL("", "magic@example.com"); magicUser.AvatarURL != want {
 		t.Fatalf("expected magic-link Gravatar %q, got %#v", want, magicUser)
 	}
-	if _, err := st.UpdateNotificationSettings(ctx, store.UpdateNotificationSettingsInput{
-		UserID:          magicUser.ID,
-		PushoverEnabled: true,
-		PushoverUserKey: "abcdefghijklmnopqrstuvwxyz1234",
+	if _, err := st.UpdateCurrentUser(ctx, store.UpdateCurrentUserInput{
+		UserID: magicUser.ID,
+		NotificationSettings: &store.NotificationSettings{
+			PushoverEnabled: true,
+			PushoverUserKey: "abcdefghijklmnopqrstuvwxyz1234",
+		},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -215,11 +215,6 @@ type AppearancePreferencesPatch struct {
 	Density       *string `json:"density,omitempty"`
 }
 
-type UpdateAppearancePreferencesInput struct {
-	UserID string
-	Patch  AppearancePreferencesPatch
-}
-
 type ChannelNotificationInput struct {
 	ChannelID  string
 	UserID     string
@@ -814,14 +809,6 @@ type UpdateUserProfileInput struct {
 	AvatarURL   string
 }
 
-type UpdateUserProfileAndNotificationSettingsInput struct {
-	UserID               string
-	DisplayName          string
-	Handle               string
-	AvatarURL            string
-	NotificationSettings *NotificationSettings
-}
-
 type UpdateCurrentUserInput struct {
 	UserID                string
 	DisplayName           *string
@@ -1213,11 +1200,8 @@ type Store interface {
 	RevokeConnectedAccount(ctx context.Context, accountID, requesterID string) (ConnectedAccount, error)
 	UpsertIdentityUser(ctx context.Context, input UpsertIdentityUserInput) (User, error)
 	UpdateUserProfile(ctx context.Context, input UpdateUserProfileInput) (User, error)
-	UpdateUserProfileAndNotificationSettings(ctx context.Context, input UpdateUserProfileAndNotificationSettingsInput) (User, error)
 	UpdateCurrentUser(ctx context.Context, input UpdateCurrentUserInput) (CurrentUserState, error)
-	UpdateNotificationSettings(ctx context.Context, input UpdateNotificationSettingsInput) (NotificationSettings, error)
 	GetAppearancePreferences(ctx context.Context, userID string) (*AppearancePreferences, error)
-	UpdateAppearancePreferences(ctx context.Context, input UpdateAppearancePreferencesInput) (*AppearancePreferences, error)
 	ListPushNotificationRecipients(ctx context.Context, messageID string, mentionedUserIDs []string) ([]PushNotificationRecipient, error)
 	UpsertChannelNotificationSettings(ctx context.Context, input ChannelNotificationInput) error
 	GetChannelNotificationPreference(ctx context.Context, channelID, userID string) (string, error)


### PR DESCRIPTION
## What Problem This Solves

Account settings had three unused writer paths in each store while `PATCH /api/me` already used `UpdateCurrentUser`. Only tests still called those older methods, leaving duplicate transaction and validation code to maintain.

## Why This Change Was Made

Remove the six obsolete methods, three interface entries, and two dead input types. Existing lifecycle, notification, and avatar tests now call `UpdateCurrentUser` directly with the same explicit updates and assertions. The canonical writer, validators, reads, SQL, and production profile-seeding path stay unchanged.

## User Impact

No API behavior change. This internal refactor removes 118 production lines; adapting the existing tests adds 30 net lines, for 88 fewer lines overall.

## Evidence

All 20 focused top-level tests passed: 12 SQLite, 3 real PostgreSQL, and 5 HTTP tests. They retain empty/default/partial appearance updates, rollback and deletion cascade, notification visibility and session/export behavior, and concurrent avatar clearing. PostgreSQL ran in a disposable outer schema. gofmt, `git diff --check`, and isolated Codex autoreview passed (no accepted/actionable P0 findings).

Independent live API proof ran on SQLite and PostgreSQL before and after restarting the same persisted databases with the candidate binary. Each phase sent separate `PATCH /api/me` requests for notifications, appearance, and display name, then read the combined state with `GET /api/me`. A combined patch with display name `Must Not Persist` and invalid color mode returned HTTP 400; a subsequent GET matched the entire previous state. These are the actual synthetic proof records:

SQLite, before:

```json
{
  "backend": "sqlite",
  "phase": "before",
  "display_name": "Synthetic Settings before",
  "appearance_preferences": {
    "color_mode": "dark"
  },
  "notification_settings": {
    "pushover_enabled": false,
    "pushover_user_key": ""
  },
  "partial_sections_preserved": true,
  "invalid_combined_patch_status": 400,
  "invalid_combined_patch_atomic": true
}
```

SQLite, after:

```json
{
  "backend": "sqlite",
  "phase": "after",
  "display_name": "Synthetic Settings after",
  "appearance_preferences": {
    "color_mode": "light"
  },
  "notification_settings": {
    "pushover_enabled": false,
    "pushover_user_key": ""
  },
  "partial_sections_preserved": true,
  "invalid_combined_patch_status": 400,
  "invalid_combined_patch_atomic": true
}
```

Postgres, before:

```json
{
  "backend": "postgres",
  "phase": "before",
  "display_name": "Synthetic Settings before",
  "appearance_preferences": {
    "color_mode": "dark"
  },
  "notification_settings": {
    "pushover_enabled": false,
    "pushover_user_key": ""
  },
  "partial_sections_preserved": true,
  "invalid_combined_patch_status": 400,
  "invalid_combined_patch_atomic": true
}
```

Postgres, after:

```json
{
  "backend": "postgres",
  "phase": "after",
  "display_name": "Synthetic Settings after",
  "appearance_preferences": {
    "color_mode": "light"
  },
  "notification_settings": {
    "pushover_enabled": false,
    "pushover_user_key": ""
  },
  "partial_sections_preserved": true,
  "invalid_combined_patch_status": 400,
  "invalid_combined_patch_atomic": true
}
```
