### PR TITLE
fix: preserve thread pages across CLI and SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed CLI thread output dropping paging metadata, added latest and cursor windows, and aligned SDK message types with API thread summaries and attachments.
+
 - Fixed reaction viewer state when realtime events arrive before history pages, and refreshed root and reply reactions after authoritative reconnects in chat and embeds.
 
 - Fixed delayed channel and DM history loads replacing newer search, quote, unread, or latest-message selections, ignored topic filter changes during loading, and target scrolling within long same-author message groups.

--- a/apps/api/cmd/clickclack/client_commands.go
+++ b/apps/api/cmd/clickclack/client_commands.go
@@ -258,17 +258,24 @@ func (c apiClient) threadOpen(messageID string, args []string) error {
 	opts := c.opts
 	flags := flag.NewFlagSet("threads open", flag.ExitOnError)
 	addClientFlags(flags, &opts)
-	limit := flags.Int("limit", 100, "reply limit")
+	values := url.Values{"limit": {"100"}}
+	flags.Int("limit", 100, "reply limit (1–200)")
+	flags.Bool("latest", false, "show the latest reply window")
+	flags.Int64("before-seq", 0, "show replies before this thread sequence")
+	flags.Int64("after-seq", 0, "show replies after this thread sequence")
+	flags.Int64("around-seq", 0, "show replies around this thread sequence")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
 	c = c.withOptions(opts, true)
-	var result struct {
-		Root        store.Message     `json:"root"`
-		Replies     []store.Message   `json:"replies"`
-		ThreadState store.ThreadState `json:"thread_state"`
-	}
-	path := fmt.Sprintf("/api/messages/%s/thread?limit=%d", url.PathEscape(messageID), *limit)
+	flags.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "limit", "latest", "before-seq", "after-seq", "around-seq":
+			values.Set(strings.ReplaceAll(f.Name, "-", "_"), f.Value.String())
+		}
+	})
+	var result store.ThreadPage
+	path := fmt.Sprintf("/api/messages/%s/thread?%s", url.PathEscape(messageID), values.Encode())
 	if err := c.get(path, &result); err != nil {
 		return err
 	}

--- a/apps/api/cmd/clickclack/thread_test.go
+++ b/apps/api/cmd/clickclack/thread_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http/httptest"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openclaw/clickclack/apps/api/internal/httpapi"
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+	sqlitestore "github.com/openclaw/clickclack/apps/api/internal/store/sqlite"
+)
+
+func TestThreadOpenPreservesAPIPages(t *testing.T) {
+	ctx := context.Background()
+	st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(ctx); err != nil {
+		t.Fatal(err)
+	}
+	owner, err := st.EnsureBootstrap(ctx, "Thread Reader", "reader@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaces, err := st.ListWorkspaces(ctx, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channels, err := st.ListChannels(ctx, workspaces[0].ID, owner.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root, _, err := st.CreateMessage(ctx, store.CreateMessageInput{ChannelID: channels[0].ID, AuthorID: owner.ID, Body: "root"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 201; i++ {
+		if _, _, _, err := st.CreateThreadReply(ctx, store.CreateThreadReplyInput{RootMessageID: root.ID, AuthorID: owner.ID, Body: fmt.Sprintf("reply-%d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := httptest.NewServer(httpapi.New(st, realtime.NewHub(), httpapi.Options{}).Handler())
+	t.Cleanup(server.Close)
+	c := apiClient{opts: clientOptions{Server: server.URL, UserID: owner.ID, JSON: true}, http: server.Client()}
+	for _, tc := range []struct {
+		name, query string
+		args        []string
+		first, last int64
+	}{
+		{"earliest", "limit=2", nil, 1, 2},
+		{"latest", "limit=2&latest=true", []string{"--latest"}, 200, 201},
+		{"before", "limit=2&before_seq=200", []string{"--before-seq", "200"}, 198, 199},
+		{"after", "limit=2&after_seq=200", []string{"--after-seq", "200"}, 201, 201},
+		{"around", "limit=2&around_seq=200", []string{"--around-seq", "200"}, 200, 201},
+		{"zero cursor", "limit=2&before_seq=0", []string{"--before-seq", "0"}, 0, 0},
+		{"latest false", "limit=2&latest=false", []string{"--latest=false"}, 1, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var want map[string]any
+			if err := c.get("/api/messages/"+root.ID+"/thread?"+tc.query, &want); err != nil {
+				t.Fatal(err)
+			}
+			output := captureStdout(t, func() error { return c.threads(append([]string{"open", root.ID, "--limit", "2"}, tc.args...)) })
+			var got map[string]any
+			if err := json.Unmarshal([]byte(output), &got); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("CLI output differs from API:\n%s\nwant %#v", output, want)
+			}
+			if got["oldest_seq"] != float64(tc.first) || got["newest_seq"] != float64(tc.last) {
+				t.Fatalf("wrong reply window: %v..%v", got["oldest_seq"], got["newest_seq"])
+			}
+		})
+	}
+	t.Run("invalid cursors", func(t *testing.T) {
+		for _, args := range [][]string{{"--latest", "--after-seq", "1"}, {"--before-seq", "2", "--after-seq", "1"}, {"--after-seq", "-1"}} {
+			if err := c.threadOpen(root.ID, args); err == nil || !strings.Contains(err.Error(), "400") {
+				t.Fatalf("args %v: want API validation error, got %v", args, err)
+			}
+		}
+	})
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,6 +259,19 @@ clickclack --server http://localhost:8080 --token sst_... messages list --channe
 clickclack --server http://localhost:8080 --token sst_... threads open msg_... --json
 ```
 
+`threads open` preserves the API's complete thread page in `--json` output,
+including `oldest_seq`, `newest_seq`, `has_older`, and `has_newer`. Its default
+is the earliest 100 replies. Use `--limit 1..200` and either `--latest`,
+`--before-seq S`, `--after-seq S`, or `--around-seq S` to select another window:
+
+```sh
+clickclack threads open msg_... --latest --limit 50 --json
+clickclack threads open msg_... --before-seq 151 --limit 50 --json
+```
+
+Cursors use thread sequences, including zero, and cannot be combined with one
+another or with `--latest`. See [thread pagination](features/threads.md#ordering-and-pagination).
+
 `workspaces list` prints `id slug name` in human mode. `channels list` prints
 `id name kind`. `messages list` prints `seq id author body`.
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -85,6 +85,10 @@ See [features/auth.md](features/auth.md).
 
 ## Thread history
 
+`Message` uses the generated API schema across channel history, DM history,
+and thread replies. Root messages expose optional `thread_state`; messages
+retain optional `attachments` typed as `Upload[]`.
+
 `threads.get` preserves the earliest-first default and supports bounded latest,
 before, after, and around windows. Sequences are local to the thread:
 

--- a/packages/protocol/openapi.yaml
+++ b/packages/protocol/openapi.yaml
@@ -3259,6 +3259,10 @@ components:
           description: Correlates durable agent activity rows from one agent turn.
         author:
           $ref: "#/components/schemas/User"
+        attachments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Upload"
         quoted_message_id:
           type: string
         quoted_body_snapshot:

--- a/packages/sdk-ts/src/generated/openapi.d.ts
+++ b/packages/sdk-ts/src/generated/openapi.d.ts
@@ -2003,6 +2003,7 @@ export interface components {
       /** @description Correlates durable agent activity rows from one agent turn. */
       turn_id?: string;
       author?: components["schemas"]["User"];
+      attachments?: components["schemas"]["Upload"][];
       quoted_message_id?: string;
       quoted_body_snapshot?: string;
       quoted_author_id?: string;

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -295,42 +295,9 @@ export type ReactionMutationResponse = components["schemas"]["ReactionMutationRe
 export type PinnedMessage = components["schemas"]["PinnedMessage"];
 export type PinMessageResponse = components["schemas"]["PinMessageResponse"];
 
-export type Message = {
-  id: string;
-  route_id?: string;
-  workspace_id: string;
-  channel_id?: string;
-  direct_conversation_id?: string;
-  author_id: string;
-  parent_message_id?: string;
-  thread_root_id: string;
-  topic_id?: string;
-  channel_seq?: number;
-  thread_seq?: number;
-  body: string;
-  body_format: "markdown";
-  created_at: string;
-  edited_at?: string;
-  deleted_at?: string;
-  kind?: MessageKind;
-  turn_id?: string;
-  author?: User;
-  attachments?: Upload[];
-  quoted_message_id?: string;
-  quoted_body_snapshot?: string;
-  quoted_author_id?: string;
-  quoted_author?: User;
-  nonce?: string;
-  reactions?: ReactionSummary[];
-};
+export type Message = components["schemas"]["Message"];
 
-export type MessagePage = {
-  messages: Message[];
-  oldest_seq: number;
-  newest_seq: number;
-  has_older: boolean;
-  has_newer: boolean;
-};
+export type MessagePage = components["schemas"]["MessagePage"];
 
 export type MessagePageOptions = {
   mode?: "latest";
@@ -370,19 +337,7 @@ export type SearchResponse = {
   next_cursor: string | null;
 };
 
-export type Upload = {
-  id: string;
-  workspace_id: string;
-  owner_id: string;
-  nonce?: string;
-  filename: string;
-  content_type: string;
-  byte_size: number;
-  width?: number;
-  height?: number;
-  duration_ms?: number;
-  created_at: string;
-};
+export type Upload = components["schemas"]["Upload"];
 
 export type DirectConversation = {
   id: string;
@@ -486,12 +441,7 @@ export type RealtimeEventPage = {
   tailCursor?: string;
 };
 
-export type ThreadState = {
-  root_message_id: string;
-  reply_count: number;
-  last_reply_at?: string;
-  last_reply_author_ids: string[];
-};
+export type ThreadState = components["schemas"]["ThreadState"];
 
 export type Thread = {
   root: Message;
@@ -499,12 +449,7 @@ export type Thread = {
   thread_state: ThreadState;
 };
 
-export type ThreadPage = Thread & {
-  oldest_seq: number;
-  newest_seq: number;
-  has_older: boolean;
-  has_newer: boolean;
-};
+export type ThreadPage = components["schemas"]["ThreadPage"];
 
 export type ClickClackClientOptions = {
   baseUrl: string;

--- a/packages/sdk-ts/src/thread.type-tests.d.ts
+++ b/packages/sdk-ts/src/thread.type-tests.d.ts
@@ -24,3 +24,15 @@ type _GetResultIncludesRequiredPaging = Assert<
     }
   >
 >;
+
+type ChannelMessage = Awaited<ReturnType<ClickClackClient["channels"]["messages"]>>[number];
+type DirectMessage = Awaited<ReturnType<ClickClackClient["dms"]["messages"]>>[number];
+type _ChannelSummaryAvailable = Assert<
+  IsAssignable<ChannelMessage["thread_state"], ThreadState | undefined>
+>;
+type _DirectSummaryAvailable = Assert<
+  IsAssignable<DirectMessage["thread_state"], ThreadState | undefined>
+>;
+type _AttachmentsPreserved = Assert<
+  IsAssignable<NonNullable<Message["attachments"]>[number], import("./index").Upload>
+>;


### PR DESCRIPTION
`threads open --json` discarded the API's paging bounds and flags, and the CLI could not reach replies beyond its earliest bounded window. Preserve the canonical `store.ThreadPage` response and forward the existing latest/before/after/around query modes, including explicit zero cursors. The earliest-first default and server validation remain unchanged.

The SDK's handwritten Message type also omitted thread summaries. Describe the existing attachments field in OpenAPI and use generated Message, MessagePage, Upload, ThreadState, and ThreadPage types, preserving the existing exported Thread contract. This removes duplicate client projections: production −44 lines (including the OpenAPI addition), generated +1, tests +103.

Validation: the new CLI test fails on the original code because JSON fields disappear; the SDK compile test fails because thread_state is missing. Both pass with the repair. All CLI package tests and root/SDK type checks pass. A built CLI against a real local SQLite server matches SDK/HTTP responses for earliest, latest, before, after, and around windows over 201 replies; the SDK also retrieves a hydrated thread summary and attachment. Independent Codex autoreview returned scoped-clean at its configured P0 threshold. No runtime, schema, or dependency changes.
