### PR TITLE
fix: bind desktop transitions to their current owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 - Fixed delayed thread loads reopening closed panes or replacing newer selections, and preserved failed reply drafts and quotes with duplicate-safe retries.
 
+- Fixed failed desktop server saves changing the active selection, and prevented stale desktop OAuth completions and browser-open failures from affecting a replacement server, window, or sign-in attempt.
+
 - Added configurable workspace home destinations and labels, preserving desktop home navigation and keeping long labels within the badge. Thanks @sercada.
 
 - Fixed background message ingestion, live scrolling as same-author groups grow, and channel navigation during startup, including stale route failures after revisiting a channel.

--- a/apps/desktop/scripts/main-harness.mjs
+++ b/apps/desktop/scripts/main-harness.mjs
@@ -1,0 +1,266 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { setImmediate } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const require = createRequire(import.meta.url);
+const bundle = fileURLToPath(new URL("../.test/main.cjs", import.meta.url));
+export const A = "http://127.0.0.1:19720";
+export const B = "http://127.0.0.1:19721";
+export const C = "http://127.0.0.1:19722";
+
+export function deferred() {
+  return Promise.withResolvers();
+}
+
+export async function settle() {
+  for (let i = 0; i < 5; i++) await setImmediate();
+}
+
+export async function until(predicate) {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await setImmediate();
+  }
+  assert.fail("Desktop did not reach the expected observable state");
+}
+
+// Run the real main entry point; replace only Electron and controllable I/O.
+// Programmatic loadURL does not emit will-navigate (Electron's navigation contract).
+export async function desktop(t) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "clickclack-main-"));
+  let pendingIO = 0;
+  const trackIO = async (operation) => {
+    pendingIO++;
+    try {
+      return await operation();
+    } finally {
+      pendingIO--;
+    }
+  };
+  const idle = async () => {
+    await settle();
+    await until(() => pendingIO === 0);
+    await settle();
+  };
+  t.after(async () => {
+    await idle();
+    await fs.rm(directory, { recursive: true, force: true });
+  });
+  const destination = path.join(directory, "desktop.json");
+  await fs.writeFile(destination, JSON.stringify({ serverUrl: A, closeToTray: true }));
+  const windows = [];
+  const errors = [];
+  const logs = [];
+  const badges = [];
+  const browserURLs = [];
+  const requests = [];
+  const handlers = new Map();
+  const timers = new Map();
+  const ready = deferred();
+  const app = new EventEmitter();
+  Object.assign(app, {
+    requestSingleInstanceLock: () => true,
+    setAsDefaultProtocolClient() {},
+    whenReady: () => ready.promise,
+    setName() {},
+    setAppUserModelId() {},
+    getPath: () => directory,
+    getVersion: () => "0.0.0-test",
+    isPackaged: false,
+    isReady: () => true,
+    setBadgeCount: (count) => badges.push(count),
+  });
+  const ipcMain = new EventEmitter();
+  ipcMain.handle = (channel, handler) => handlers.set(channel, handler);
+  const controls = {
+    probe: async () => new Response("<html><head></head></html>"),
+    fetch: async () => new Response("{}"),
+    openExternal: async () => {},
+    writeFile: fs.writeFile,
+    rename: fs.rename,
+  };
+  class Window extends EventEmitter {
+    constructor(options) {
+      super();
+      this.options = options;
+      this.destroyed = false;
+      this.loads = [];
+      this.messages = [];
+      this.shows = 0;
+      this.bounds = { x: 30, y: 40, width: options.width, height: options.height };
+      this.webContents = new EventEmitter();
+      Object.assign(this.webContents, {
+        id: windows.length + 1,
+        setWindowOpenHandler() {},
+        getURL: () => this.url,
+        isLoading: () => false,
+        send: (...args) => this.messages.push(args),
+      });
+      windows.push(this);
+    }
+    async loadURL(url) {
+      assert.equal(this.destroyed, false, "Cannot navigate a destroyed window");
+      this.loads.push(url);
+      this.url = url;
+      this.webContents.emit("did-navigate", {}, url);
+      if (this.navigation) await this.navigation.promise;
+    }
+    async loadFile(file) {
+      this.url = `file://${file}`;
+    }
+    isDestroyed() {
+      return this.destroyed;
+    }
+    getNormalBounds() {
+      return this.bounds;
+    }
+    isMaximized() {
+      return false;
+    }
+    isMinimized() {
+      return false;
+    }
+    show() {
+      this.shows++;
+    }
+    focus() {}
+    hide() {}
+    destroy() {
+      this.destroyed = true;
+      this.emit("closed");
+    }
+    close() {
+      this.emit("close", { preventDefault() {} });
+    }
+    setOverlayIcon() {}
+  }
+  const session = Object.assign(new EventEmitter(), {
+    setPermissionRequestHandler() {},
+    setPermissionCheckHandler() {},
+    fetch: (url, options) => {
+      requests.push({ url, options });
+      return controls.fetch(url, options);
+    },
+  });
+  const nativeImage = {
+    setTemplateImage() {},
+    resize() {
+      return this;
+    },
+  };
+  class Tray extends EventEmitter {
+    setToolTip() {}
+    setContextMenu() {}
+    setTitle() {}
+  }
+  const electron = {
+    app,
+    BrowserWindow: Window,
+    ipcMain,
+    Tray,
+    nativeTheme: new EventEmitter(),
+    nativeImage: { createFromPath: () => nativeImage },
+    Menu: { buildFromTemplate: (value) => value, setApplicationMenu() {} },
+    screen: { getDisplayMatching: () => ({ workArea: { x: 0, y: 0, width: 3000, height: 2000 } }) },
+    net: { fetch: (...args) => controls.probe(...args) },
+    session: { defaultSession: session },
+    shell: {
+      openExternal: (url) => {
+        browserURLs.push(url);
+        return controls.openExternal(url);
+      },
+    },
+    dialog: {
+      showMessageBox: async (...args) => {
+        errors.push(args.at(-1).message);
+      },
+    },
+  };
+  const testProcess = Object.assign(new EventEmitter(), {
+    platform: process.platform,
+    argv: [],
+    execPath: process.execPath,
+  });
+  vm.runInNewContext(
+    await fs.readFile(bundle, "utf8"),
+    {
+      require: (name) =>
+        name === "electron"
+          ? electron
+          : name === "node:fs/promises"
+            ? {
+                ...fs,
+                writeFile: (...args) => trackIO(() => controls.writeFile(...args)),
+                rename: (...args) => trackIO(() => controls.rename(...args)),
+              }
+            : require(name),
+      __dirname: path.dirname(bundle),
+      process: testProcess,
+      console: { error: (...args) => logs.push(args) },
+      URL,
+      Response,
+      TextDecoder,
+      AbortSignal,
+      Error,
+      setTimeout: (callback, delay) => {
+        const id = {};
+        timers.set(id, { callback, delay });
+        return id;
+      },
+      clearTimeout: (id) => timers.delete(id),
+    },
+    { filename: bundle },
+  );
+  ready.resolve();
+  await until(() => windows.length > 0);
+  const event = (window) => ({ sender: window.webContents, senderFrame: { url: window.url } });
+  const invoke = (window, channel, input) => handlers.get(channel)(event(window), input);
+  const send = (window, channel, input) => ipcMain.emit(channel, event(window), input);
+  send(windows[0], "desktop:open-settings");
+  const settingsWindow = windows[1];
+  return {
+    app,
+    controls,
+    windows,
+    errors,
+    logs,
+    badges,
+    requests,
+    browserURLs,
+    destination,
+    idle,
+    get main() {
+      return windows.filter((window) => !window.options.parent && !window.destroyed).at(-1);
+    },
+    getSettings: () => invoke(settingsWindow, "settings:get"),
+    save: (serverUrl) =>
+      invoke(settingsWindow, "settings:save", {
+        serverUrl,
+        closeToTray: true,
+        startAtLogin: false,
+      }),
+    signIn: (window = windows[0]) => invoke(window, "desktop:sign-in-with-github"),
+    send,
+    callback: (code = "a".repeat(43)) =>
+      app.emit(
+        "open-url",
+        { preventDefault() {} },
+        `chat.clickclack.desktop:/auth/callback?code=${code}`,
+      ),
+    disk: async () => JSON.parse(await fs.readFile(destination, "utf8")),
+    flushTimers: async () => {
+      for (const [id, timer] of timers) {
+        timers.delete(id);
+        timer.callback();
+      }
+      await settle();
+    },
+  };
+}

--- a/apps/desktop/scripts/main.test.mjs
+++ b/apps/desktop/scripts/main.test.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import test from "node:test";
+import { A, B, C, deferred, desktop, settle, until } from "./main-harness.mjs";
+
+for (const failure of ["write", "rename"]) {
+  test(`failed settings ${failure} preserves server, route, window and sender authority`, async (t) => {
+    const d = await desktop(t);
+    const original = d.main;
+    d.send(original, "desktop:set-active-route", "/app/team/general");
+    const blockedPath = failure === "write" ? `${d.destination}.tmp` : d.destination;
+    if (failure === "rename") await rm(blockedPath);
+    await mkdir(blockedPath);
+    await assert.rejects(d.save(B));
+    assert.equal(d.getSettings().serverUrl, A);
+    assert.equal(d.main, original);
+    d.send(original, "desktop:set-unread", 7);
+    assert.equal(d.badges.at(-1), 7);
+    d.app.emit("second-instance", {}, []);
+    assert.deepEqual(original.messages.at(-1), ["desktop:navigate", "/app/team/general"]);
+    await rm(blockedPath, { recursive: true });
+    original.bounds.width = 1440;
+    original.emit("resize");
+    await d.flushTimers();
+    await d.idle();
+    assert.equal((await d.disk()).serverUrl, A);
+    assert.equal((await d.disk()).window.width, 1440);
+    assert.equal((await d.save(B)).serverUrl, B);
+    assert.equal(d.main.url, `${B}/app`);
+  });
+}
+
+test("settings saves and window writes stay ordered while persistence and capability probing wait", async (t) => {
+  const d = await desktop(t);
+  const original = d.main;
+  const probe = deferred();
+  const write = deferred();
+  const reachedWrite = deferred();
+  d.controls.probe = (url) =>
+    url.startsWith(B) ? probe.promise : Promise.resolve(new Response(""));
+  let held = false;
+  d.controls.writeFile = async (...args) => {
+    if (!held) {
+      held = true;
+      reachedWrite.resolve();
+      await write.promise;
+    }
+    return writeFile(...args);
+  };
+  const saveB = d.save(B);
+  const saveC = d.save(C);
+  await settle();
+  const duringSave = { server: d.getSettings().serverUrl, window: d.main };
+  probe.resolve(new Response('<head><meta name="clickclack-desktop-titlebar" content="1"></head>'));
+  await reachedWrite.promise;
+  original.bounds.width = 1500;
+  original.emit("resize");
+  await d.flushTimers();
+  write.resolve();
+  const results = await Promise.all([saveB, saveC]);
+  await d.idle();
+  assert.equal(duringSave.server, A);
+  assert.equal(duringSave.window, original);
+  assert.deepEqual(
+    results.map((result) => result.serverUrl),
+    [B, C],
+  );
+  assert.equal(d.getSettings().serverUrl, C);
+  assert.equal((await d.disk()).serverUrl, C);
+  assert.equal((await d.disk()).window.width, 1500);
+  assert.equal(d.main.options.width, 1500);
+  assert.equal(d.main.options.titleBarStyle, undefined);
+  assert.equal(d.main.url, `${C}/app`);
+});
+
+test("a failed queued server change cannot roll back a later successful save", async (t) => {
+  const d = await desktop(t);
+  const failedWrite = deferred();
+  const reachedWrite = deferred();
+  const oauth = deferred();
+  d.controls.fetch = (url) =>
+    url.endsWith("/consume") ? oauth.promise : Promise.resolve(new Response("{}"));
+  await d.signIn();
+  d.callback();
+  let first = true;
+  d.controls.writeFile = async (...args) => {
+    if (first) {
+      first = false;
+      reachedWrite.resolve();
+      await failedWrite.promise;
+    }
+    return writeFile(...args);
+  };
+  const rejected = assert.rejects(d.save(B), /disk unavailable/);
+  await reachedWrite.promise;
+  const saveC = d.save(C);
+  failedWrite.reject(new Error("disk unavailable"));
+  await rejected;
+  assert.equal((await saveC).serverUrl, C);
+  oauth.resolve(new Response("{}"));
+  await d.idle();
+  assert.equal(d.getSettings().serverUrl, C);
+  assert.equal((await d.disk()).serverUrl, C);
+  assert.deepEqual(d.main.loads, [`${C}/app`]);
+  assert.deepEqual(d.errors, []);
+});
+
+test("failed persistence preserves the active OAuth attempt", async (t) => {
+  const d = await desktop(t);
+  await d.signIn();
+  await mkdir(`${d.destination}.tmp`);
+  await assert.rejects(d.save(B));
+  d.callback();
+  await settle();
+  assert.deepEqual(d.main.loads, [`${A}/app`, `${A}/app`]);
+  assert.deepEqual(d.errors, []);
+});
+
+for (const stage of ["consume", "me"]) {
+  for (const outcome of ["success", "http-error", "network-error"]) {
+    test(`server switch during ${stage}: stale ${outcome} cannot navigate or report an error`, async (t) => {
+      const d = await desktop(t);
+      const held = deferred();
+      d.controls.fetch = (url) =>
+        url.endsWith(stage === "consume" ? "/consume" : "/me")
+          ? held.promise
+          : Promise.resolve(new Response("{}"));
+      await d.signIn();
+      d.callback();
+      await until(() =>
+        d.requests.some(({ url }) => url.endsWith(stage === "consume" ? "/consume" : "/me")),
+      );
+      await d.save(B);
+      const replacement = d.main;
+      d.send(replacement, "desktop:set-active-route", "/app/team/new");
+      if (outcome === "network-error") held.reject(new Error("old request failed"));
+      else held.resolve(new Response("{}", { status: outcome === "success" ? 200 : 500 }));
+      await settle();
+      assert.deepEqual(replacement.loads, [`${B}/app`]);
+      assert.deepEqual(d.errors, []);
+      d.app.emit("second-instance", {}, []);
+      assert.deepEqual(replacement.messages.at(-1), ["desktop:navigate", "/app/team/new"]);
+      d.send(replacement, "desktop:set-unread", 9);
+      assert.equal(d.badges.at(-1), 9);
+      assert.equal(d.getSettings().serverUrl, B);
+    });
+  }
+}
+
+for (const stage of ["consume", "me"]) {
+  test(`server switch while reading the ${stage} response body stays on the selected server`, async (t) => {
+    const d = await desktop(t);
+    let body;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          body = controller;
+        },
+      }),
+    );
+    d.controls.fetch = (url) =>
+      Promise.resolve(
+        url.endsWith(stage === "consume" ? "/consume" : "/me") ? response : new Response("{}"),
+      );
+    await d.signIn();
+    d.callback();
+    await until(() => response.bodyUsed);
+    await d.save(B);
+    body.close();
+    await settle();
+    assert.deepEqual(d.main.loads, [`${B}/app`]);
+    assert.deepEqual(d.errors, []);
+  });
+}
+
+for (const outcome of ["success", "http-error", "network-error"]) {
+  test(`a replaced OAuth attempt cannot finish or erase the next attempt after ${outcome}`, async (t) => {
+    const d = await desktop(t);
+    const held = deferred();
+    d.controls.fetch = (_url, options) =>
+      options.body?.includes("a".repeat(43)) ? held.promise : Promise.resolve(new Response("{}"));
+    await d.signIn();
+    d.callback();
+    await until(() => d.requests.length === 1);
+    await d.signIn();
+    if (outcome === "network-error") held.reject(new Error("old request failed"));
+    else held.resolve(new Response("{}", { status: outcome === "success" ? 200 : 500 }));
+    await settle();
+    assert.deepEqual(d.main.loads, [`${A}/app`]);
+    d.callback("b".repeat(43));
+    await settle();
+    assert.deepEqual(d.main.loads, [`${A}/app`, `${A}/app`]);
+    assert.deepEqual(d.errors, []);
+    const consumed = d.requests.filter(({ url }) => url.endsWith("/consume"));
+    assert.equal(consumed.length, 2);
+    assert.notEqual(
+      JSON.parse(consumed[0].options.body).code_verifier,
+      JSON.parse(consumed[1].options.body).code_verifier,
+    );
+  });
+}
+
+for (const replacement of ["attempt", "server"]) {
+  test(`late browser-open rejection neither rejects nor clears a replacement ${replacement}`, async (t) => {
+    const d = await desktop(t);
+    const held = deferred();
+    d.controls.openExternal = () => (d.browserURLs.length === 1 ? held.promise : Promise.resolve());
+    const first = d.signIn();
+    const firstResult = first.then(
+      () => "resolved",
+      () => "rejected",
+    );
+    if (replacement === "server") await d.save(B);
+    await d.signIn(d.main);
+    held.reject(new Error("old browser launch failed"));
+    assert.equal(await firstResult, "resolved");
+    d.callback();
+    await settle();
+    const server = replacement === "server" ? B : A;
+    assert.deepEqual(d.main.loads, [`${server}/app`, `${server}/app`]);
+    assert.deepEqual(d.errors, []);
+  });
+}
+
+test("current browser-open failure is still returned to the renderer", async (t) => {
+  const d = await desktop(t);
+  d.controls.openExternal = async () => {
+    throw new Error("browser unavailable");
+  };
+  await assert.rejects(d.signIn(), /browser unavailable/);
+});
+
+test("OAuth cannot use a recreated window even at the same origin", async (t) => {
+  const d = await desktop(t);
+  const held = deferred();
+  d.controls.fetch = (url) =>
+    url.endsWith("/consume") ? held.promise : Promise.resolve(new Response("{}"));
+  await d.signIn();
+  d.callback();
+  await until(() => d.requests.length === 1);
+  d.main.destroy();
+  d.app.emit("activate");
+  const replacement = d.main;
+  held.resolve(new Response("{}"));
+  await settle();
+  assert.deepEqual(replacement.loads, [`${A}/app`]);
+  assert.deepEqual(d.errors, []);
+});
+
+for (const navigationFails of [false, true]) {
+  test(`navigation ${navigationFails ? "failure" : "completion"} from an old attempt cannot affect its replacement`, async (t) => {
+    const d = await desktop(t);
+    const original = d.main;
+    const navigation = deferred();
+    original.navigation = navigation;
+    await d.signIn();
+    d.callback();
+    await until(() => original.loads.length === 2);
+    await d.save(B);
+    const replacement = d.main;
+    const shows = replacement.shows;
+    if (navigationFails) navigation.reject(new Error("navigation cancelled"));
+    else navigation.resolve();
+    await settle();
+    assert.equal(replacement.shows, shows);
+    assert.deepEqual(d.errors, []);
+  });
+}
+
+for (const stage of ["consume", "me", "navigation"]) {
+  test(`current ${stage} error stays visible`, async (t) => {
+    const d = await desktop(t);
+    d.controls.fetch = (url) =>
+      Promise.resolve(
+        new Response("{}", {
+          status:
+            url.endsWith(stage === "consume" ? "/consume" : "/me") && stage !== "navigation"
+              ? 503
+              : 200,
+        }),
+      );
+    if (stage === "navigation") {
+      d.main.navigation = deferred();
+      d.main.navigation.promise.catch(() => {});
+      d.main.navigation.reject(new Error("navigation unavailable"));
+    }
+    await d.signIn();
+    d.callback();
+    await until(() => d.errors.length > 0);
+    assert.match(d.errors[0], stage === "navigation" ? /navigation unavailable/ : /503/);
+  });
+}
+
+test("current OAuth verifies the session before navigating and consumes the attempt once", async (t) => {
+  const d = await desktop(t);
+  const me = deferred();
+  d.controls.fetch = (url) =>
+    url.endsWith("/me") ? me.promise : Promise.resolve(new Response("{}"));
+  await d.signIn();
+  d.callback();
+  await until(() => d.requests.length === 2);
+  assert.deepEqual(d.main.loads, [`${A}/app`]);
+  assert.equal(d.requests[0].options.credentials, "include");
+  assert.equal(d.requests[1].url, `${A}/api/me`);
+  me.resolve(new Response("{}"));
+  await settle();
+  assert.deepEqual(d.main.loads, [`${A}/app`, `${A}/app`]);
+  assert.deepEqual(d.errors, []);
+  d.callback();
+  await until(() => d.errors.length > 0);
+  assert.match(d.errors[0], /expired/);
+  assert.equal(d.requests.length, 2);
+  assert.equal(JSON.parse(await readFile(d.destination, "utf8")).serverUrl, A);
+});

--- a/apps/desktop/scripts/test.mjs
+++ b/apps/desktop/scripts/test.mjs
@@ -19,9 +19,26 @@ await build({
   target: "node22",
 });
 
+await build({
+  absWorkingDir: root,
+  bundle: true,
+  entryPoints: ["src/main.ts"],
+  external: ["electron"],
+  format: "cjs",
+  outfile: path.join(root, ".test", "main.cjs"),
+  platform: "node",
+  target: "node22",
+});
+
 const result = spawnSync(
   process.execPath,
-  ["--test", outfile, releaseArtifactsTest, macosSigningTest],
+  [
+    "--test",
+    outfile,
+    path.join(root, "scripts", "main.test.mjs"),
+    releaseArtifactsTest,
+    macosSigningTest,
+  ],
   {
     stdio: "inherit",
   },

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -54,7 +54,8 @@ let quitting = false;
 let routesReady = false;
 let pendingRoute: string | null = null;
 let pendingProtocolURL: string | null = null;
-let pendingDesktopAuth: { serverUrl: string; verifier: string } | null = null;
+type DesktopAuthAttempt = Readonly<{ serverUrl: string; verifier: string; window: BrowserWindow }>;
+let pendingDesktopAuth: DesktopAuthAttempt | null = null;
 let windowSaveTimer: NodeJS.Timeout | undefined;
 let saveQueue = Promise.resolve();
 let integratedTitleBar = false;
@@ -406,29 +407,24 @@ function registerIPC() {
       };
     }
   });
-  ipcMain.handle("settings:save", async (event, input: PublicDesktopSettings) => {
+  ipcMain.handle("settings:save", (event, input: PublicDesktopSettings) => {
     requireSettingsSender(event.sender.id);
-    const next = mergeSettings({
-      ...settings,
-      ...input,
-      serverUrl: normalizeServerURL(input.serverUrl),
-    });
-    settings = next;
-    await persistSettings();
-    integratedTitleBar = await serverSupportsIntegratedTitleBar(settings.serverUrl);
-    applyLoginItemSetting();
-    currentRoute = "/app";
-    if (mainWindow && !mainWindow.isDestroyed()) {
+    const serverUrl = normalizeServerURL(input.serverUrl);
+    return queueSettingsSave(async () => {
+      const titleBar = await serverSupportsIntegratedTitleBar(serverUrl);
+      const next = mergeSettings({ ...settings, ...input, serverUrl });
+      await persistSettings(next);
+      settings = { ...next, window: settings.window };
+      integratedTitleBar = titleBar;
+      pendingDesktopAuth = null;
+      applyLoginItemSetting();
+      currentRoute = "/app";
       rememberWindowState();
-      const previousWindow = mainWindow;
-      mainWindow = null;
-      previousWindow.destroy();
+      mainWindow?.destroy();
       createMainWindow();
-    } else {
-      createMainWindow();
-    }
-    setTimeout(() => settingsWindow?.close(), 350);
-    return settingsInfo();
+      setTimeout(() => settingsWindow?.close(), 350);
+      return settingsInfo();
+    });
   });
 }
 
@@ -642,22 +638,38 @@ async function beginDesktopOAuth() {
   const verifier = randomBytes(32).toString("base64url");
   const challenge = createHash("sha256").update(verifier).digest("base64url");
   const serverUrl = normalizeServerURL(settings.serverUrl);
-  pendingDesktopAuth = { serverUrl, verifier };
+  const pending: DesktopAuthAttempt = {
+    serverUrl,
+    verifier,
+    window: mainWindow ?? createMainWindow(),
+  };
+  pendingDesktopAuth = pending;
   showMainWindow();
   try {
     await shell.openExternal(desktopOAuthStartURL(serverUrl, challenge));
   } catch (error) {
+    if (!isCurrentDesktopAuth(pending)) return;
     pendingDesktopAuth = null;
     throw error;
   }
 }
 
+function isCurrentDesktopAuth(pending: DesktopAuthAttempt): boolean {
+  return (
+    pendingDesktopAuth === pending &&
+    pending.serverUrl === settings.serverUrl &&
+    pending.window === mainWindow &&
+    !pending.window.isDestroyed()
+  );
+}
+
 async function completeDesktopOAuth(code: string) {
   const pending = pendingDesktopAuth;
-  if (!pending || pending.serverUrl !== normalizeServerURL(settings.serverUrl)) {
+  if (!pending) {
     await showDesktopAuthError("This sign-in request expired. Start again from ClickClack.");
     return;
   }
+  if (!isCurrentDesktopAuth(pending)) return;
   try {
     const response = await session.defaultSession.fetch(
       new URL("/api/auth/github/desktop/consume", pending.serverUrl).toString(),
@@ -675,6 +687,7 @@ async function completeDesktopOAuth(code: string) {
     );
     if (!response.ok) throw new Error(`Server returned HTTP ${response.status}`);
     await response.arrayBuffer();
+    if (!isCurrentDesktopAuth(pending)) return;
     const meResponse = await session.defaultSession.fetch(
       new URL("/api/me", pending.serverUrl).toString(),
       {
@@ -688,12 +701,14 @@ async function completeDesktopOAuth(code: string) {
       throw new Error(`Server did not establish a desktop session (HTTP ${meResponse.status})`);
     }
     await meResponse.arrayBuffer();
-    pendingDesktopAuth = null;
+    if (!isCurrentDesktopAuth(pending)) return;
     currentRoute = "/app";
-    const window = mainWindow ?? createMainWindow(currentRoute);
-    await window.loadURL(appURL(pending.serverUrl, currentRoute));
+    await pending.window.loadURL(appURL(pending.serverUrl, currentRoute));
+    if (!isCurrentDesktopAuth(pending)) return;
+    pendingDesktopAuth = null;
     showMainWindow();
   } catch (error) {
+    if (!isCurrentDesktopAuth(pending)) return;
     const detail = error instanceof Error ? error.message : "Unknown authentication error";
     await showDesktopAuthError(`GitHub sign-in could not be completed. ${detail}`);
   }
@@ -803,7 +818,8 @@ function rememberWindowState() {
       y: bounds.y,
     },
   };
-  void persistSettings();
+  // Resolve the active server when this write reaches the queue, after any server switch.
+  void queueSettingsSave(() => persistSettings(settings));
 }
 
 function applyLoginItemSetting() {
@@ -819,15 +835,17 @@ async function readSettings(): Promise<DesktopSettings> {
   }
 }
 
-function persistSettings(): Promise<void> {
-  const snapshot = JSON.stringify(settings, null, 2) + "\n";
+async function persistSettings(candidate: DesktopSettings): Promise<void> {
+  const snapshot = JSON.stringify(candidate, null, 2) + "\n";
   const destination = settingsPath();
   const temporary = `${destination}.tmp`;
-  const operation = saveQueue.then(async () => {
-    await writeFile(temporary, snapshot, { encoding: "utf8", mode: 0o600 });
-    await rename(temporary, destination);
-  });
-  saveQueue = operation.catch(logSettingsError);
+  await writeFile(temporary, snapshot, { encoding: "utf8", mode: 0o600 });
+  await rename(temporary, destination);
+}
+
+function queueSettingsSave<T>(save: () => Promise<T>): Promise<T> {
+  const operation = saveQueue.then(save);
+  saveQueue = operation.then(() => {}, logSettingsError);
   return operation;
 }
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -68,6 +68,11 @@ Remote servers must use HTTPS. Plain HTTP is accepted only for `localhost`,
 `127.0.0.1`, and `::1`. Authentication returns to Electron's persistent browser
 session and remains scoped to the selected origin.
 
+Saving a server takes effect after the settings file is written successfully.
+Until then, the current server, window, and desktop controls stay active. A
+failed save leaves that selection intact and can be retried. Concurrent saves
+are applied in order, including window-state updates made while saving.
+
 GitHub sign-in opens in the system browser, where existing GitHub sessions,
 passkeys, password managers, and two-factor authentication already work. After
 GitHub approves the login, `chat.clickclack.desktop:/auth/callback` returns a
@@ -75,6 +80,11 @@ one-time grant to the running app. The app redeems it against the exact server
 that initiated the flow, verifies the resulting session through `/api/me`, and
 then reloads itself as the signed-in workspace. The app also accepts the legacy
 `clickclack://auth/callback` format when connecting to an older server.
+
+Each sign-in belongs to its initiating server and window. Selecting another
+server, replacing that window, or starting another sign-in prevents the old
+in-flight attempt from navigating, showing a late error, or clearing the new
+attempt. Errors from the current attempt still appear normally.
 
 Servers using namespaced cookies require desktop OAuth protocol 2. They return
 an update-required page before sending an older desktop client to GitHub.


### PR DESCRIPTION
A failed Desktop Settings save published the new server before writing it to disk, leaving the old window's bridge unauthorized. Separately, a delayed OAuth completion could load server A into the newly selected server B's window, or erase a replacement sign-in attempt.

Serialize candidate persistence, publication, and window recreation through the existing settings queue. Window-state writes resolve the committed selection when they execute. Bind OAuth work to its exact attempt, origin, and initiating window across consumption, body reads, session verification, navigation, and browser-open errors. Remove duplicate window recreation and the redundant manual window reset.

The new main-process harness runs the actual entry point through Electron's IPC/protocol boundaries with real temporary filesystem writes. Twenty-one regressions fail on the original main; all 43 desktop tests pass after the repair, including current success/error controls. Typecheck, build, formatting, lint, and independent Codex autoreview pass. Production +18 lines implement the missing async ownership boundary; tests/support +597. No configuration, storage format, dependency, or wire protocol changes.

Native proof passed with Foundation Developer ID signed, hardened-runtime Electron builds and isolated user-data directories. A real filesystem write failure leaves server A's native actions working; after saving B and releasing A's held /api/me response, B remains selected and its real preload settings bridge works. The original build instead rejects A's actions after the failed write, and loads A into B's window after the delayed response. The synthetic server request trace and persisted selection agree with the visible result. No real account, deployment, or provider credentials were used.

| Scenario | Before | After |
| --- | --- | --- |
| Failed settings write | ![Before](https://github.com/user-attachments/assets/e5e82ac2-678a-4f34-96e8-4683b990f955) | ![After](https://github.com/user-attachments/assets/0b5e4e64-5e6a-4533-96ed-399298a7b41d) |
| Delayed sign-in after server switch | ![Before](https://github.com/user-attachments/assets/0abfaf3d-1bc1-4994-a871-423432ec8b33) | ![After](https://github.com/user-attachments/assets/39d7e25b-1334-4038-a7d4-5fa1eec22a02) |
