### PR TITLE
fix(test): resolve fakeco-aws fixture paths on checkouts containing spaces

### DIFF
--- a/deploy/fakeco/aws/owner.test.mjs
+++ b/deploy/fakeco/aws/owner.test.mjs
@@ -4,8 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-const directory = path.dirname(new URL(import.meta.url).pathname);
+const directory = path.dirname(fileURLToPath(import.meta.url));
 const repositoryRoot = path.resolve(directory, "../../..");
 const ownerPath = path.join(directory, "owner.mjs");
 const profilePath = path.join(directory, "profile.json");
@@ -1430,6 +1431,36 @@ test("bootstrap proves seed equality, health, readiness, metadata metrics, and b
   assert.match(runbook, /wait_ready \|\| "\$\{compose\[@\]\}" stop app/u);
 });
 
+test("sibling fixtures resolve from module directories containing spaces", async (t) => {
+  const temporary = await temporaryDirectory(t, "clickclack fakeco spaces ");
+  assert.ok(temporary.includes(" "));
+  const probePath = path.join(temporary, "probe.mjs");
+  await writeFile(path.join(temporary, "template.json"), JSON.stringify({ ok: true }));
+  await writeFile(
+    probePath,
+    [
+      'import { readFile } from "node:fs/promises";',
+      'import path from "node:path";',
+      'import { fileURLToPath } from "node:url";',
+      "",
+      "const directory = path.dirname(fileURLToPath(import.meta.url));",
+      "const legacy = path.dirname(new URL(import.meta.url).pathname);",
+      "const template = await readFile(path.join(directory, `template.json`), `utf8`);",
+      "process.stdout.write(",
+      "  JSON.stringify({ template: JSON.parse(template), legacyEncoded: legacy.includes(`%20`) }),",
+      ");",
+      "",
+    ].join("\n"),
+  );
+
+  const result = spawnSync(process.execPath, [probePath], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(JSON.parse(result.stdout), {
+    template: { ok: true },
+    legacyEncoded: true,
+  });
+});
+
 function fakecoEnvironment() {
   return {
     FAKECO_AWS_ACCOUNT_ID: "123456789012",
@@ -1727,8 +1758,8 @@ function runOwner(args, environment = {}) {
   });
 }
 
-async function temporaryDirectory(t) {
-  const temporary = await mkdtemp(path.join(os.tmpdir(), "clickclack-fakeco-owner-"));
+async function temporaryDirectory(t, prefix = "clickclack-fakeco-owner-") {
+  const temporary = await mkdtemp(path.join(os.tmpdir(), prefix));
   t.after(() => rm(temporary, { recursive: true, force: true }));
   return temporary;
 }

--- a/deploy/fakeco/aws/owner.test.mjs
+++ b/deploy/fakeco/aws/owner.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { cp, mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -1433,32 +1433,21 @@ test("bootstrap proves seed equality, health, readiness, metadata metrics, and b
 
 test("sibling fixtures resolve from module directories containing spaces", async (t) => {
   const temporary = await temporaryDirectory(t, "clickclack fakeco spaces ");
-  assert.ok(temporary.includes(" "));
-  const probePath = path.join(temporary, "probe.mjs");
-  await writeFile(path.join(temporary, "template.json"), JSON.stringify({ ok: true }));
-  await writeFile(
-    probePath,
+  const copiedDirectory = path.join(temporary, "deploy/fakeco/aws");
+  await cp(directory, copiedDirectory, { recursive: true });
+  const result = spawnSync(
+    process.execPath,
     [
-      'import { readFile } from "node:fs/promises";',
-      'import path from "node:path";',
-      'import { fileURLToPath } from "node:url";',
-      "",
-      "const directory = path.dirname(fileURLToPath(import.meta.url));",
-      "const legacy = path.dirname(new URL(import.meta.url).pathname);",
-      "const template = await readFile(path.join(directory, `template.json`), `utf8`);",
-      "process.stdout.write(",
-      "  JSON.stringify({ template: JSON.parse(template), legacyEncoded: legacy.includes(`%20`) }),",
-      ");",
-      "",
-    ].join("\n"),
+      "--test",
+      "--test-reporter=tap",
+      "--test-name-pattern=^profile and template lock the private ARM64 single-VM contract$",
+      path.join(copiedDirectory, "owner.test.mjs"),
+    ],
+    // A nested test runner otherwise skips its files inside a node:test child.
+    { encoding: "utf8", env: { ...process.env, NODE_TEST_CONTEXT: undefined } },
   );
-
-  const result = spawnSync(process.execPath, [probePath], { encoding: "utf8" });
-  assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(JSON.parse(result.stdout), {
-    template: { ok: true },
-    legacyEncoded: true,
-  });
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /# pass 1\b/u);
 });
 
 function fakecoEnvironment() {


### PR DESCRIPTION
Fixes #205.

The FakeCo AWS test suite aborted before its tests could run when the checkout path contained spaces: `URL.pathname` left `%20` in the filesystem path. Decode the module URL with `fileURLToPath`, matching the adjacent production owner.

The regression now copies the actual owner/test fixtures to a temporary checkout containing spaces and runs the existing profile/template contract there. It clears Node's inherited test-child context so the nested runner really executes, and checks that its selected test passed. This replaces the copied URL-conversion probe with proof of ClickClack's fixture loader.

Validation: the old main suite fails at module load with ENOENT from a space-containing path; the candidate passes all 31 tests from a real space-containing worktree. Restoring the old lookup in a normal-path scratch copy makes the new regression fail inside its relocated child. Node syntax, shell syntax, formatting, lint, diff checks, and independent Codex autoreview pass. Production code is unchanged; the PR adds only the fixture-path repair and regression coverage.

Original contribution by @isaiahknight-va, authored by Tater with Russet. Maintainer refinement preserves their fix and replaces the regression probe with execution of the actual owner test. No changelog changes; this is developer tooling release-note context.
