### PR TITLE
refactor(sdk): reuse canonical API resource types

### DIFF
--- a/docs/features/dms.md
+++ b/docs/features/dms.md
@@ -76,10 +76,14 @@ DM root messages support the same one-level thread model as channel messages.
 Thread replies carry `direct_conversation_id`, use `thread_seq`, and do not
 appear in the root DM timeline or unread root-message sequence.
 
+## Search
+
+[Search](search.md) supports one direct conversation through
+`direct_conversation_id`. The caller must be a conversation member; workspace
+and channel searches continue to exclude direct messages.
+
 ## What is intentionally missing
 
 - DM-only auth tokens.
 - One-on-one vs group distinctions in the API surface — the client decides
   based on member count.
-- DM-only search. Workspace/channel search excludes DMs; DM search needs a
-  separate endpoint so private messages never leak into channel results.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -167,9 +167,11 @@ targets to publish workspace-wide.
 export type { components, paths } from "./generated/openapi";
 ```
 
-Use the friendly hand-written types (`User`, `Workspace`, `Message`, etc.)
-for app code; reach into `components["schemas"]` only when you need the
-exact OpenAPI shape.
+Use the friendly exported types (`User`, `Workspace`, `Message`, etc.)
+for app code. Resource types reuse the generated OpenAPI schemas, so the
+protocol owns their fields and optionality. Client input helpers retain richer
+constraints, such as mutually exclusive message and event targets. Reach into
+`components["schemas"]` for other wire shapes.
 
 ## Bot accounts
 

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -6,225 +6,54 @@ export type HomeLink = components["schemas"]["HomeLink"];
 
 export type User = components["schemas"]["User"];
 
-export type DeletedBot = {
-  id: string;
-  display_name: string;
-  former_handle: string;
-  deleted_at: string;
-};
+export type DeletedBot = components["schemas"]["DeletedBot"];
 
-export type BotToken = {
-  id: string;
-  bot_user_id: string;
-  workspace_id: string;
-  owner_user_id?: string;
-  name: string;
-  scopes: string[];
-  created_by?: string;
-  created_at: string;
-  last_used_at?: string;
-  revoked_at?: string;
-  token?: string;
-};
+export type BotToken = components["schemas"]["BotToken"];
 
-export type BotWithTokens = {
-  bot: User;
-  tokens: BotToken[];
-};
+export type BotWithTokens = components["schemas"]["BotWithTokens"];
 
-export type BotSetupCode = {
-  id: string;
-  bot_user_id: string;
-  workspace_id: string;
-  token_name: string;
-  scopes: string[];
-  defaults: BotSetupCodeDefaults;
-  created_by?: string;
-  created_at: string;
-  expires_at: string;
-  /** One-time plaintext setup code. Present only in the mint response. */
-  code?: string;
-  /** Version 1 treats claim_url as the exact endpoint. */
-  contract_version?: 1;
-  claim_url?: string;
-  api_base_url?: string;
-};
+export type BotSetupCode = components["schemas"]["BotSetupCode"];
 
-export type BotSetupCodeDefaults = {
-  defaultTo?: string;
-  allowFrom?: string[];
-  agentActivity?: boolean;
-};
+export type BotSetupCodeDefaults = components["schemas"]["BotSetupCodeClaimDefaults"];
 
-export type BotSetupCodeClaim = {
-  token: string;
-  bot: {
-    id: string;
-    handle: string;
-    display_name: string;
-  };
-  workspace: {
-    id: string;
-    route_id: string;
-    slug: string;
-    name: string;
-  };
-  defaults: BotSetupCodeDefaults;
-  contract_version?: 1;
-  api_base_url?: string;
-};
+export type BotSetupCodeClaim = components["schemas"]["BotSetupCodeClaimResponse"];
 
-export type BotCommandInput = {
-  command: string;
-  description: string;
-  args_hint?: string;
-};
+export type BotCommandInput = components["schemas"]["BotCommandInput"];
 
-export type BotCommand = {
-  id: string;
-  workspace_id: string;
-  bot_user_id: string;
-  command: string;
-  description: string;
-  args_hint: string;
-  created_at: string;
-  updated_at: string;
-};
+export type BotCommand = components["schemas"]["BotCommand"];
 
-export type BotCommandBot = {
-  id: string;
-  handle: string;
-  display_name: string;
-  avatar_url: string;
-};
+export type BotCommandBot = components["schemas"]["BotCommandBot"];
 
-export type WorkspaceBotCommand = {
-  id: string;
-  command: string;
-  description: string;
-  args_hint: string;
-  bot: BotCommandBot;
-  created_at: string;
-  updated_at: string;
-};
+export type WorkspaceBotCommand = components["schemas"]["WorkspaceBotCommand"];
 
-export type OwnedBotWorkspace = {
-  id: string;
-  route_id: string;
-  name: string;
-};
+export type OwnedBotWorkspace = components["schemas"]["OwnedBotWorkspace"];
 
-export type OwnedBotEntry = {
-  bot: User;
-  workspace: OwnedBotWorkspace;
-  active_token_count: number;
-};
+export type OwnedBotEntry = components["schemas"]["OwnedBotEntry"];
 
-export type AppInstallation = {
-  id: string;
-  workspace_id: string;
-  app_slug: string;
-  display_name: string;
-  bot_user_id: string;
-  config: Record<string, unknown>;
-  created_by?: string;
-  created_at: string;
-  revoked_at?: string;
-};
+export type AppInstallation = components["schemas"]["AppInstallation"];
 
-export type RevokeAppInstallationOptions = {
-  revoke_slash_commands?: boolean;
-  revoke_event_subscriptions?: boolean;
-  revoke_bot_tokens?: boolean;
-  delete_bot?: boolean;
-};
+export type RevokeAppInstallationOptions = components["schemas"]["RevokeAppInstallationRequest"];
 
-export type AppInstallationRevokedCounts = {
-  slash_commands: number;
-  event_subscriptions: number;
-  bot_tokens: number;
-};
+export type AppInstallationRevokedCounts = components["schemas"]["AppInstallationRevokedCounts"];
 
-export type RevokeAppInstallationResult = {
-  installation: AppInstallation;
-  revoked: AppInstallationRevokedCounts;
-  deleted_bot?: DeletedBot;
-};
+export type RevokeAppInstallationResult = components["schemas"]["RevokeAppInstallationResponse"];
 
-export type SlashCommand = {
-  id: string;
-  workspace_id: string;
-  app_installation_id?: string;
-  command: string;
-  description: string;
-  callback_url: string;
-  signing_secret?: string;
-  bot_user_id: string;
-  created_by?: string;
-  created_at: string;
-  revoked_at?: string;
-};
+export type SlashCommand = components["schemas"]["SlashCommand"];
 
-export type EventSubscription = {
-  id: string;
-  workspace_id: string;
-  app_installation_id?: string;
-  event_types: string[];
-  callback_url: string;
-  signing_secret?: string;
-  created_by?: string;
-  created_at: string;
-  revoked_at?: string;
-};
+export type EventSubscription = components["schemas"]["EventSubscription"];
 
-export type EventDeliveryAttempt = {
-  id: string;
-  subscription_id: string;
-  event_id: string;
-  workspace_id: string;
-  event_type: string;
-  attempt: number;
-  request_json?: string;
-  response_status: number;
-  response_body?: string;
-  error?: string;
-  created_at: string;
-  completed_at: string;
-};
+export type EventDeliveryAttempt = components["schemas"]["EventDeliveryAttempt"];
 
 export type EventDeliveryAttemptsOptions = {
   limit?: number;
   before?: string;
 };
 
-export type EventDeliveryAttemptsPage = {
-  deliveries: EventDeliveryAttempt[];
-  next_cursor: string | null;
-};
+export type EventDeliveryAttemptsPage = components["schemas"]["EventDeliveryAttemptsResponse"];
 
-export type AuditLogEntry = {
-  id: string;
-  workspace_id: string;
-  actor_user_id: string;
-  action: string;
-  target_type: string;
-  target_id: string;
-  metadata: Record<string, unknown>;
-  created_at: string;
-};
+export type AuditLogEntry = components["schemas"]["AuditLogEntry"];
 
-export type ConnectedAccount = {
-  id: string;
-  workspace_id: string;
-  user_id: string;
-  provider: string;
-  provider_account_id: string;
-  display_name: string;
-  scopes: string[];
-  metadata: Record<string, unknown>;
-  created_at: string;
-  revoked_at?: string;
-};
+export type ConnectedAccount = components["schemas"]["ConnectedAccount"];
 
 export type BotEventHandler = (
   event: RealtimeEvent,
@@ -238,43 +67,11 @@ export type ClickClackBotOptions = ClickClackClientOptions & {
   onClose?: () => void;
 };
 
-export type Workspace = {
-  id: string;
-  route_id: string;
-  name: string;
-  slug: string;
-  icon_url: string;
-  created_at: string;
-  role?: "owner" | "moderator" | "member" | "guest" | "bot";
-};
+export type Workspace = components["schemas"]["Workspace"];
 
-export type Channel = {
-  id: string;
-  route_id: string;
-  workspace_id: string;
-  name: string;
-  display_title?: string;
-  kind: string;
-  created_at: string;
-  archived_at?: string;
-  external_managed: boolean;
-  external_ref?: string;
-  external_url?: string;
-  sidebar_section?: string;
-  last_seq?: number;
-  last_read_seq?: number;
-  unread_count?: number;
-};
+export type Channel = components["schemas"]["Channel"];
 
-export type Topic = {
-  id: string;
-  workspace_id: string;
-  channel_id?: string;
-  name: string;
-  created_by?: string;
-  created_at: string;
-  archived_at?: string;
-};
+export type Topic = components["schemas"]["Topic"];
 
 export type MessageKind = "message" | "agent_commentary" | "agent_tool";
 
@@ -308,67 +105,19 @@ export type MessagePageOptions = {
   topic_id?: string;
 };
 
-export type SearchHighlight = {
-  start: number;
-  end: number;
-};
+export type SearchHighlight = components["schemas"]["SearchHighlight"];
 
-export type SearchResult = {
-  id: string;
-  workspace_id: string;
-  channel_id?: string;
-  channel_name?: string;
-  direct_conversation_id?: string;
-  author: User;
-  parent_message_id?: string;
-  thread_root_id: string;
-  channel_seq?: number;
-  thread_seq?: number;
-  created_at: string;
-  edited_at?: string;
-  reply_count: number;
-  last_reply_at?: string;
-  snippet: string;
-  highlights: SearchHighlight[];
-};
+export type SearchResult = components["schemas"]["SearchResult"];
 
-export type SearchResponse = {
-  results: SearchResult[];
-  next_cursor: string | null;
-};
+export type SearchResponse = components["schemas"]["SearchResponse"];
 
 export type Upload = components["schemas"]["Upload"];
 
-export type DirectConversation = {
-  id: string;
-  route_id: string;
-  workspace_id: string;
-  created_at: string;
-  members: User[];
-  can_send: boolean;
-  last_seq?: number;
-  last_read_seq?: number;
-  unread_count?: number;
-};
+export type DirectConversation = components["schemas"]["DirectConversation"];
 
-export type ReadReceipt = {
-  scope_id: string;
-  user_id: string;
-  last_read_seq: number;
-  last_read_at: string;
-};
+export type ReadReceipt = components["schemas"]["ReadReceipt"];
 
-export type RouteTarget = {
-  workspace_id: string;
-  workspace_route_id: string;
-  target_type: "channel" | "direct" | "thread";
-  target_id: string;
-  target_route_id: string;
-  parent_type?: "channel" | "direct";
-  parent_id?: string;
-  parent_route_id?: string;
-  canonical_path: string;
-};
+export type RouteTarget = components["schemas"]["RouteTarget"];
 
 export type RealtimeEventPayload = {
   correlation_id?: string;


### PR DESCRIPTION
The SDK maintained 31 resource types separately from identical generated OpenAPI definitions. Replace those copies with aliases to the protocol-owned schemas, removing 251 handwritten production lines while preserving every exported name, nested field, optional property, and literal union. Client-only constraints, realtime projections, and the legacy three-field Thread type remain intact.

Correct the SDK documentation's type-ownership guidance and the stale statement that DM search is unavailable. Scoped DM search already exists and continues to exclude private messages from workspace/channel results.

Validation:
- Compiler comparison: all 31 old/new exports are assignable both ways and have identical recursive shapes, including optionality, readonly properties, unions, arrays, and index signatures. A negative control changing Workspace.role correctly fails.
- SDK build and all workspace typechecks pass, including the existing public type contracts and bot example.
- Emitted runtime JavaScript is byte-for-byte identical to the baseline.
- Built SDK live-tested against a local Go server with synthetic SQLite data: workspace/channel operations, topics, read receipts, routing, bot lifecycle, setup-code mint/claim, command menus, DMs, channel/DM search isolation, app installation/revocation, connected accounts, and audit log. No token values were logged.
- Formatting, lint, diff checks, and independent Codex autoreview pass.

Production: +31/-282 (-251). Tests: unchanged. Documentation: +11/-5 (+6). No generated files, runtime behavior, dependencies, or changelog edits.

## Captured validation

After-fix head: `b5a72ce1cae4b394de0627249dc5d5321f41d662`. The following command executed the built SDK against the loopback Go server with synthetic SQLite data; exit status was 0. The runtime bundle was also compared byte-for-byte with the baseline via `cmp`, which exited 0.

```sh
node /tmp/clickclack-pass4-20260831/sdk-live.mjs
```

```json
{
  "result": "passed",
  "flows": [
    "workspace CRUD",
    "channel CRUD",
    "topics",
    "read receipts",
    "route resolution",
    "bot lifecycle",
    "setup-code mint and claim",
    "bot command menu",
    "DM history and reads",
    "channel/DM search isolation",
    "app install/revoke",
    "connected account lifecycle",
    "audit log"
  ],
  "secretsLogged": false
}
```

<details>
<summary>Executed SDK smoke source (synthetic data only)</summary>

```js
import assert from 'node:assert/strict';
import { ClickClackClient } from './sdk-dist/index.js';
const run = crypto.randomUUID().slice(0,8);
const baseUrl = 'http://127.0.0.1:19830';
const client = new ClickClackClient({ baseUrl });
const me = await client.me();
const workspace = await client.workspaces.create({ name: 'Synthetic SDK proof', slug: `sdk-proof-${run}` });
assert.equal(workspace.role, 'owner');
assert((await client.workspaces.list()).some(({id}) => id === workspace.id));
assert.equal((await client.workspaces.get(workspace.id)).route_id, workspace.route_id);
assert.equal((await client.workspaces.update(workspace.id, {name:'Synthetic SDK contract'})).name, 'Synthetic SDK contract');
const channel = await client.channels.create(workspace.id, {name:'schema-proof', display_title:'Schema proof'});
assert.equal((await client.channels.update(channel.id,{display_title:'API schema proof'})).display_title,'API schema proof');
assert((await client.channels.list(workspace.id)).some(({id})=>id===channel.id));
const topic = await client.topics.create(workspace.id,{name:'Compatibility',channel_id:channel.id});
assert((await client.topics.list(workspace.id)).some(({id})=>id===topic.id));
const message = await client.channels.sendMessage(channel.id,{body:'schema compatibility channel',topic_id:topic.id});
assert.equal((await client.channels.markRead(channel.id,message.channel_seq)).last_read_seq,message.channel_seq);
assert.equal((await client.routes.resolve(workspace.route_id,channel.route_id)).target_id,channel.id);
const created = await client.bots.create(workspace.id,{display_name:'Synthetic SDK bot',owner_user_id:me.id,handle:`sdkproof${run}`,initial_token:false});
assert.equal(created.bot_token,undefined);
const setup = await client.bots.createSetupCode(workspace.id,created.bot.id,{name:'synthetic',scopes:['bot:write'],defaults:{defaultTo:`channel:${channel.id}`}});
assert(setup.code);
assert.equal(setup.contract_version,1);
assert.equal(setup.claim_url,baseUrl+'/api/bot-setup-codes/claim');
const claim = await client.bots.claimSetupCode(setup.code);
assert(claim.token);
assert.equal(claim.workspace.id,workspace.id);
assert.equal(claim.bot.id,created.bot.id);
assert.equal(claim.defaults.defaultTo,`channel:${channel.id}`);
assert.equal(claim.contract_version,1);
const botClient = new ClickClackClient({baseUrl,token:claim.token});
const commands = await botClient.bots.setCommands([{command:'status',description:'Synthetic status'}]);
assert.equal(commands[0].command,'/status');
assert((await client.bots.listCommands(workspace.id)).some(c=>c.bot.id===created.bot.id));
assert((await client.bots.listMine()).some(b=>b.bot.id===created.bot.id));
assert((await client.bots.list(workspace.id)).some(b=>b.bot.id===created.bot.id));
const tokens=await client.bots.listWorkspaceTokens(workspace.id,created.bot.id);
assert.equal(tokens.length,1);assert.equal(tokens[0].token,undefined);
const conversation = await client.dms.create(workspace.id,[created.bot.id]);
assert(conversation.members.some(u=>u.id===me.id));assert.equal(conversation.can_send,true);
assert.equal((await client.dms.get(conversation.id)).route_id,conversation.route_id);
assert((await client.dms.list(workspace.id)).some(c=>c.id===conversation.id));
const direct=await client.dms.sendMessage(conversation.id,{body:'schema compatibility private'});
assert.equal((await client.dms.markRead(conversation.id,direct.channel_seq)).last_read_seq,direct.channel_seq);
const channelSearch=await client.search(workspace.id,'schema',{channelId:channel.id});
assert.equal(channelSearch.results[0].id,message.id);assert.equal(channelSearch.next_cursor,null);
const dmSearch=await client.search(workspace.id,'schema',{directConversationId:conversation.id});
assert.equal(dmSearch.results[0].id,direct.id);assert.equal(dmSearch.results[0].direct_conversation_id,conversation.id);
assert.equal(dmSearch.next_cursor,null);
assert(!(await client.search(workspace.id,'schema')).results.some(r=>r.id===direct.id));
const installation=await client.apps.install(workspace.id,{app_slug:'synthetic-proof',bot_user_id:created.bot.id,config:{synthetic:true}});
assert.equal(installation.config.synthetic,true);
assert((await client.apps.list(workspace.id)).some(a=>a.id===installation.id));
const account=await client.connectedAccounts.create(workspace.id,{user_id:me.id,provider:'synthetic',provider_account_id:'proof',scopes:[],metadata:{synthetic:true}});
assert((await client.connectedAccounts.list(workspace.id)).some(a=>a.id===account.id));
assert((await client.connectedAccounts.revoke(account.id)).revoked_at);
assert.deepEqual(await client.slashCommands.list(workspace.id),[]);
assert.deepEqual(await client.eventSubscriptions.list(workspace.id),[]);
assert((await client.auditLog.list(workspace.id)).length>0);
const revoked=await client.apps.revoke(installation.id,{revoke_bot_tokens:true});
assert.equal(revoked.revoked.bot_tokens,1);
const deleted=await client.bots.delete(created.bot.id);assert.equal(deleted.id,created.bot.id);assert(deleted.deleted_at);
console.log(JSON.stringify({result:'passed',flows:['workspace CRUD','channel CRUD','topics','read receipts','route resolution','bot lifecycle','setup-code mint and claim','bot command menu','DM history and reads','channel/DM search isolation','app install/revoke','connected account lifecycle','audit log'],secretsLogged:false},null,2));
```

</details>

This captured execution addresses all three proof-related Before merge items in the ClawSweeper review: the entrypoint, assertions, and observed completion are now available. There were no code findings or rank-up moves. No source changed after the reviewed head.
