### PR TITLE
fix(desktop): keep Settings dismissal with its saving window

### DIFF
--- a/apps/desktop/scripts/main.test.mjs
+++ b/apps/desktop/scripts/main.test.mjs
@@ -312,3 +312,33 @@ test("current OAuth verifies the session before navigating and consumes the atte
   assert.equal(d.requests.length, 2);
   assert.equal(JSON.parse(await readFile(d.destination, "utf8")).serverUrl, A);
 });
+
+for (const replacementStage of ["after-save", "during-probe"]) {
+  test(`saving Settings never closes a replacement opened ${replacementStage}`, async (t) => {
+    const d = await desktop(t);
+    const originalSettings = d.windows[1];
+    let save;
+    let probe;
+    if (replacementStage === "during-probe") {
+      probe = deferred();
+      d.controls.probe = () => probe.promise;
+      save = d.save(B);
+      await settle();
+    } else {
+      await d.save(B);
+    }
+    originalSettings.destroy();
+    d.send(d.main, "desktop:open-settings");
+    const replacement = d.windows.at(-1);
+    assert.notEqual(replacement, originalSettings);
+    assert.equal(replacement.destroyed, false);
+    let unexpectedCloses = 0;
+    replacement.on("close", () => unexpectedCloses++);
+    if (probe) {
+      probe.resolve(new Response(""));
+      await save;
+    }
+    await d.flushTimers();
+    assert.equal(unexpectedCloses, 0, "An old save must not close a newly opened Settings window");
+  });
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -422,7 +422,6 @@ function registerIPC() {
       rememberWindowState();
       mainWindow?.destroy();
       createMainWindow();
-      setTimeout(() => settingsWindow?.close(), 350);
       return settingsInfo();
     });
   });

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -70,6 +70,7 @@ async function save() {
       startAtLogin: startAtLoginInput.checked,
     });
     setStatus("Connected. Returning to ClickClack…", "success");
+    setTimeout(() => window.close(), 350);
   } catch (error) {
     setStatus(errorMessage(error), "error");
     setBusy(false);

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -72,6 +72,8 @@ Saving a server takes effect after the settings file is written successfully.
 Until then, the current server, window, and desktop controls stay active. A
 failed save leaves that selection intact and can be retried. Concurrent saves
 are applied in order, including window-state updates made while saving.
+A successful save dismisses its original Settings window; reopening Settings
+during a save leaves the new window open.
 
 GitHub sign-in opens in the system browser, where existing GitHub sessions,
 passkeys, password managers, and two-factor authentication already work. After


### PR DESCRIPTION
A delayed successful Settings save could close a different Settings window opened in the meantime, losing its edits without explanation. The main process timer read the mutable global window after asynchronous probing and persistence. Move the existing 350 ms dismissal into the saving renderer, whose document owns its timer and can only close itself. No new IPC or alternate persistence path; production LOC is neutral (+1/−1).

The table-driven regression fails on main for replacements opened after save and while the capability probe is paused; both pass with this change. The full desktop suite passes 45 tests, and desktop TypeScript checking passes. Three existing harness tests initially hit their 2-second I/O deadline on a heavily loaded host; the focused rerun and subsequent full run both passed without changing deadlines or assertions. Independent Codex review found no actionable P0–P2 findings.

Live proof used a Foundation-signed macOS Electron 43.4.1 app and disposable loopback servers. Successful save switches A → B and closes the initiating Settings window. An injected filesystem write failure keeps Settings open, shows the error, and re-enables Save; removing the fault and retrying succeeds and closes Settings. Reopening Settings displays saved server B. The native UI driver cannot reliably fit close/reopen into the 350 ms window (or the 3-second capability probe), so the precise replacement interleavings are proved by the real-main-entry harness, not claimed as a native race capture. Electron permits sandboxed renderers to close their own window; its macOS native destruction detaches child windows, which is why the old global-window timer was unsafe.

Terminal regression evidence:

```text
Before: saving Settings never closes a replacement opened after-save — FAIL (unexpected close: 1)
Before: saving Settings never closes a replacement opened during-probe — FAIL (unexpected close: 1)
After: both replacement scenarios PASS
Full desktop suite: tests 45, pass 45, fail 0
Signed bundle: chat.clickclack.desktop, FWJYW4S8P8, hardened runtime, sealed resources
```

The screenshots show the synthetic baseline after a save and the candidate's reopened Settings with saved server B. They document the native flow, not the subsecond race.

Baseline after save:

![Baseline synthetic server B](https://github.com/user-attachments/assets/588cc05c-e71c-451f-8189-a7e7b05adf7e)

Candidate Settings reopened after successful save:

![Candidate Settings on synthetic server B](https://github.com/user-attachments/assets/f7efe89c-7638-4896-a5ee-bb887fcb7906)
