### PR TITLE
feat(desktop): redesign settings window on the Switchboard design system

### DIFF
--- a/apps/desktop/resources/settings.css
+++ b/apps/desktop/resources/settings.css
@@ -1,14 +1,43 @@
+/* ClickClack desktop settings — shares the web app's "Switchboard" identity:
+   porcelain keycaps over an aluminum board by day, the same board anodized
+   navy-black by night, electric cyan signal accent. Tokens mirror
+   apps/web/src/styles/base.css; keep the two in sync when the board changes. */
 :root {
-  color-scheme: dark;
-  font-family: "Avenir Next", "Segoe UI Variable", "Noto Sans", sans-serif;
-  --aqua: #91e1dc;
-  --coral: #f05a47;
-  --coral-hot: #ff7967;
-  --cream: #fff5e8;
-  --ink: #17110f;
-  --muted: #b9a69c;
-  --panel: #231a17;
-  --rule: rgba(255, 245, 232, 0.13);
+  color-scheme: light dark;
+  font-family:
+    -apple-system,
+    BlinkMacSystemFont,
+    "SF Pro Text",
+    "Segoe UI Variable Text",
+    "Segoe UI",
+    "Noto Sans",
+    sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Consolas", "Menlo", monospace;
+  --bg: light-dark(#edeff2, #0e1219);
+  --panel: light-dark(#f8f9fb, #141926);
+  --panel-2: light-dark(#e8ebef, #1b2232);
+  --hover: light-dark(rgba(16, 21, 29, 0.05), rgba(214, 228, 255, 0.045));
+  --line: light-dark(rgba(16, 21, 29, 0.1), rgba(190, 210, 255, 0.09));
+  --line-strong: light-dark(rgba(16, 21, 29, 0.17), rgba(190, 210, 255, 0.16));
+  --text: light-dark(#232a35, #dbe2ec);
+  --text-strong: light-dark(#10151d, #f4f7fb);
+  --muted: light-dark(#5d6878, #8a95a8);
+  --muted-2: light-dark(#8b94a3, #5c6577);
+  --accent: light-dark(#0080c4, #41c6ff);
+  --accent-hover: light-dark(#006aa6, #6ad3ff);
+  --accent-contrast: light-dark(#ffffff, #061420);
+  --accent-soft: light-dark(rgba(0, 128, 196, 0.13), rgba(65, 198, 255, 0.15));
+  --success: light-dark(#14876a, #30c48d);
+  --warn: #e8a33e;
+  --danger: light-dark(#d13438, #ff6d68);
+  /* Keycap tactility: controls sit proud of the board on a hard 1px edge and
+     press flat on :active. */
+  --key-edge:
+    0 1px 0 var(--line-strong),
+    0 2px 0 light-dark(rgba(16, 21, 29, 0.1), rgba(0, 0, 0, 0.45));
+  --key-edge-pressed: 0 1px 0 var(--line-strong);
+  --radius: 6px;
+  --radius-lg: 10px;
 }
 
 * {
@@ -22,19 +51,11 @@ body {
 
 body {
   margin: 0;
-  color: var(--cream);
-  background:
-    radial-gradient(circle at 78% 4%, rgba(240, 90, 71, 0.22), transparent 32rem),
-    linear-gradient(140deg, #120e0d 0%, #1b1412 58%, #0f0c0b 100%);
-}
-
-body::before {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  content: "";
-  opacity: 0.16;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='72' height='72' viewBox='0 0 72 72'%3E%3Cpath d='M0 71.5h72M71.5 0v72' stroke='%23fff5e8' stroke-opacity='.18'/%3E%3C/svg%3E");
+  color: var(--text);
+  background: var(--bg);
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
 }
 
 button,
@@ -42,235 +63,272 @@ input {
   font: inherit;
 }
 
-button {
-  cursor: pointer;
-}
-
 .settings-shell {
-  position: relative;
-  width: min(100%, 780px);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  width: min(100%, 620px);
   min-height: 100vh;
-  padding: 46px clamp(28px, 7vw, 64px) 34px;
+  padding: 22px 28px 18px;
   margin: 0 auto;
 }
 
-.signal-header,
-.brand-lockup,
-.platform-chip,
-.url-row,
-.status-rail,
-.switch-row,
-footer {
+#settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.shell-header {
   display: flex;
   align-items: center;
-}
-
-.signal-header {
   justify-content: space-between;
-  gap: 24px;
-  margin-bottom: 36px;
+  gap: 16px;
+  padding: 2px 2px 0;
 }
 
-.brand-lockup {
-  gap: 18px;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
-.brand-lockup img {
-  border-radius: 18px;
-  box-shadow: 0 18px 48px rgba(240, 90, 71, 0.28);
+.brand img {
+  border-radius: 7px;
 }
 
-.eyebrow {
-  margin: 0 0 5px;
-  color: var(--aqua);
-  font-family: "DIN Alternate", "Bahnschrift", "Arial Narrow", sans-serif;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+.brand-name {
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
 }
 
-h1,
-h2,
-p {
-  margin-top: 0;
+.brand-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--line-strong);
 }
 
-h1 {
-  margin-bottom: 0;
-  font-family: "Iowan Old Style", "Palatino Linotype", serif;
-  font-size: 38px;
-  font-weight: 600;
-  letter-spacing: -0.045em;
-  line-height: 1;
+.brand-context {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .platform-chip {
   flex: 0 0 auto;
-  gap: 9px;
-  padding: 8px 12px;
+  padding: 3px 10px;
   color: var(--muted);
-  border: 1px solid var(--rule);
+  background: var(--panel);
+  border: 1px solid var(--line);
   border-radius: 999px;
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
-.live-dot,
-.status-light {
-  width: 8px;
-  height: 8px;
-  background: var(--aqua);
-  border-radius: 50%;
-  box-shadow: 0 0 0 4px rgba(145, 225, 220, 0.11), 0 0 16px rgba(145, 225, 220, 0.5);
+/* ---------- Groups: porcelain panels on the board ---------- */
+
+.group {
+  padding: 18px 20px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 1px 0 light-dark(rgba(16, 21, 29, 0.04), rgba(0, 0, 0, 0.3));
 }
 
-.connection-card {
-  position: relative;
-  padding: clamp(28px, 6vw, 46px);
-  overflow: hidden;
-  background: linear-gradient(145deg, rgba(43, 31, 27, 0.98), rgba(29, 21, 19, 0.98));
-  border: 1px solid var(--rule);
-  border-radius: 30px 8px 30px 8px;
-  box-shadow: 0 34px 90px rgba(0, 0, 0, 0.34);
+.group-head {
+  margin-bottom: 14px;
 }
 
-.connection-card::after {
-  position: absolute;
-  top: -80px;
-  right: -76px;
-  width: 180px;
-  height: 180px;
-  content: "";
-  border: 28px solid rgba(240, 90, 71, 0.08);
-  border-radius: 50%;
+.group-head:only-child,
+.group-head:has(+ .switch-stack) {
+  margin-bottom: 8px;
 }
 
-.card-number {
-  position: absolute;
-  top: 28px;
-  right: 34px;
-  color: rgba(255, 245, 232, 0.12);
-  font-family: "DIN Alternate", "Bahnschrift", sans-serif;
-  font-size: 64px;
-  font-weight: 800;
-  letter-spacing: -0.08em;
+.group-head h2 {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 650;
+  letter-spacing: 0.01em;
 }
 
-.card-copy {
-  position: relative;
-  max-width: 490px;
-  margin-bottom: 30px;
-}
-
-.card-copy h2 {
-  max-width: 420px;
-  margin-bottom: 12px;
-  font-family: "Iowan Old Style", "Palatino Linotype", serif;
-  font-size: clamp(28px, 6vw, 43px);
-  font-weight: 500;
-  letter-spacing: -0.04em;
-  line-height: 1.02;
-}
-
-.card-copy > p:last-child {
-  max-width: 500px;
-  margin-bottom: 0;
+.group-head p {
+  max-width: 46em;
+  margin: 4px 0 0;
   color: var(--muted);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.server-field {
-  display: block;
-}
-
-.server-field > span {
-  display: block;
-  margin-bottom: 9px;
-  color: var(--cream);
   font-size: 12px;
-  font-weight: 700;
-  letter-spacing: 0.02em;
+}
+
+.field-label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 600;
 }
 
 .url-row {
-  gap: 10px;
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
 }
 
 input[type="url"] {
-  width: 100%;
-  height: 50px;
-  padding: 0 16px;
-  color: var(--cream);
+  flex: 1;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  color: var(--text-strong);
   outline: none;
-  background: rgba(12, 9, 8, 0.64);
-  border: 1px solid rgba(255, 245, 232, 0.17);
-  border-radius: 10px 3px 10px 3px;
-  transition: border-color 150ms ease, box-shadow 150ms ease;
+  background: light-dark(#ffffff, rgba(4, 8, 14, 0.55));
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-input[type="url"]:focus {
-  border-color: var(--aqua);
-  box-shadow: 0 0 0 3px rgba(145, 225, 220, 0.12);
+input[type="url"]::placeholder {
+  color: var(--muted-2);
 }
 
-.secondary-button {
-  height: 50px;
-  padding: 0 20px;
-  color: var(--cream);
-  background: transparent;
-  border: 1px solid rgba(255, 245, 232, 0.22);
-  border-radius: 3px 10px 3px 10px;
+input[type="url"]:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
-.secondary-button:hover:not(:disabled) {
-  border-color: var(--coral-hot);
+/* ---------- Keycap buttons ---------- */
+
+.key-button {
+  height: 34px;
+  padding: 0 14px;
+  color: var(--text-strong);
+  cursor: pointer;
+  background: var(--panel-2);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--key-edge);
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 120ms ease, box-shadow 80ms ease, transform 80ms ease;
 }
+
+.key-button:hover:not(:disabled) {
+  background: light-dark(#dde1e7, #232c3f);
+}
+
+.key-button:active:not(:disabled) {
+  box-shadow: var(--key-edge-pressed);
+  transform: translateY(1px);
+}
+
+.key-button:focus-visible {
+  outline: none;
+  box-shadow: var(--key-edge), 0 0 0 3px var(--accent-soft);
+}
+
+.key-button.primary {
+  color: var(--accent-contrast);
+  background: var(--accent);
+  border-color: light-dark(rgba(0, 90, 140, 0.55), rgba(120, 220, 255, 0.4));
+}
+
+.key-button.primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+/* ---------- Status rail: the signal LED ---------- */
 
 .status-rail {
-  gap: 10px;
-  min-height: 38px;
-  padding: 9px 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 18px;
+  margin-top: 10px;
   color: var(--muted);
-  font-size: 12px;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
-.status-rail:has([data-state="error"]) .status-light {
-  background: var(--coral-hot);
-  box-shadow: 0 0 0 4px rgba(255, 121, 103, 0.1);
+.status-light {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  background: var(--muted-2);
+  border-radius: 50%;
+  transition: background 150ms ease, box-shadow 150ms ease;
+}
+
+.status-rail:has([data-state="idle"]) .status-light {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .status-rail:has([data-state="working"]) .status-light {
+  background: var(--warn);
+  box-shadow: 0 0 0 3px rgba(232, 163, 62, 0.2);
   animation: signal-pulse 1.1s ease-in-out infinite;
 }
 
+.status-rail:has([data-state="success"]) .status-light {
+  background: var(--success);
+  box-shadow: 0 0 0 3px light-dark(rgba(20, 135, 106, 0.16), rgba(48, 196, 141, 0.18));
+}
+
+.status-rail:has([data-state="success"]) {
+  color: var(--success);
+}
+
+.status-rail:has([data-state="error"]) .status-light {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px light-dark(rgba(209, 52, 56, 0.14), rgba(255, 109, 104, 0.16));
+}
+
+.status-rail:has([data-state="error"]) {
+  color: var(--danger);
+}
+
+/* ---------- Toggle rows ---------- */
+
 .switch-stack {
-  margin: 9px 0 26px;
-  border-top: 1px solid var(--rule);
+  display: flex;
+  flex-direction: column;
 }
 
 .switch-row {
   position: relative;
+  display: flex;
+  align-items: center;
   justify-content: space-between;
   gap: 18px;
-  min-height: 78px;
-  border-bottom: 1px solid var(--rule);
+  padding: 12px 0;
   cursor: pointer;
+}
+
+.switch-row + .switch-row {
+  border-top: 1px solid var(--line);
 }
 
 .switch-row > span:first-child {
   display: grid;
-  gap: 4px;
+  gap: 2px;
 }
 
 .switch-row strong {
-  font-size: 14px;
+  color: var(--text-strong);
+  font-size: 13px;
+  font-weight: 600;
 }
 
 .switch-row small {
   color: var(--muted);
-  font-size: 11px;
-  line-height: 1.35;
+  font-size: 12px;
+  line-height: 1.4;
 }
 
 .switch-row input {
@@ -282,120 +340,111 @@ input[type="url"]:focus {
 .switch {
   position: relative;
   flex: 0 0 auto;
-  width: 44px;
-  height: 24px;
-  background: #0e0b0a;
-  border: 1px solid rgba(255, 245, 232, 0.22);
+  width: 40px;
+  height: 22px;
+  background: var(--panel-2);
+  border: 1px solid var(--line-strong);
   border-radius: 999px;
-  transition: background 160ms ease, border-color 160ms ease;
+  box-shadow: inset 0 1px 2px light-dark(rgba(16, 21, 29, 0.08), rgba(0, 0, 0, 0.4));
+  transition: background 150ms ease, border-color 150ms ease;
 }
 
 .switch::after {
   position: absolute;
-  top: 3px;
-  left: 3px;
+  top: 2px;
+  left: 2px;
   width: 16px;
   height: 16px;
   content: "";
-  background: var(--muted);
+  background: light-dark(#ffffff, #dbe2ec);
   border-radius: 50%;
-  transition: transform 160ms ease, background 160ms ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 150ms ease, background 150ms ease;
 }
 
 .switch-row input:checked + .switch {
-  background: rgba(240, 90, 71, 0.24);
-  border-color: var(--coral-hot);
+  background: var(--accent);
+  border-color: transparent;
 }
 
 .switch-row input:checked + .switch::after {
-  background: var(--coral-hot);
-  transform: translateX(20px);
+  background: light-dark(#ffffff, #061420);
+  transform: translateX(18px);
 }
 
 .switch-row input:focus-visible + .switch {
-  box-shadow: 0 0 0 3px rgba(145, 225, 220, 0.2);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .switch-row input:disabled + .switch {
-  opacity: 0.38;
+  opacity: 0.4;
 }
 
-.primary-button {
+.switch-row:has(input:disabled) {
+  cursor: default;
+}
+
+.switch-row:has(input:disabled) strong,
+.switch-row:has(input:disabled) small {
+  opacity: 0.55;
+}
+
+/* ---------- Action bar & footer ---------- */
+
+.action-bar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
-  height: 54px;
-  padding: 0 20px;
-  color: #160f0c;
-  background: linear-gradient(100deg, var(--coral-hot), #ff9b6a);
-  border: 0;
-  border-radius: 12px 4px 12px 4px;
-  box-shadow: 0 13px 34px rgba(240, 90, 71, 0.24);
-  font-weight: 800;
-  transition: transform 150ms ease, box-shadow 150ms ease;
+  gap: 16px;
+  padding: 0 2px;
 }
 
-.primary-button:hover:not(:disabled) {
-  box-shadow: 0 16px 42px rgba(240, 90, 71, 0.34);
-  transform: translateY(-1px);
+.action-hint {
+  color: var(--muted-2);
+  font-size: 12px;
 }
 
 button:disabled,
-input:disabled {
+input[type="url"]:disabled {
   cursor: wait;
   opacity: 0.55;
 }
 
-footer {
-  justify-content: space-between;
-  gap: 20px;
-  padding: 22px 4px 0;
-  color: rgba(255, 245, 232, 0.42);
+.version-line {
+  margin: auto 0 0;
+  padding-top: 10px;
+  color: var(--muted-2);
+  font-family: var(--font-mono);
   font-size: 10px;
-  letter-spacing: 0.03em;
-}
-
-footer span:last-child {
-  text-align: right;
+  text-align: center;
 }
 
 @keyframes signal-pulse {
   50% {
-    opacity: 0.45;
-    transform: scale(0.72);
+    opacity: 0.4;
   }
 }
 
-@media (max-width: 620px) {
+@media (max-width: 520px) {
   .settings-shell {
-    padding: 28px 20px 24px;
+    padding: 16px 16px 14px;
   }
 
-  .platform-chip {
+  .brand-context {
     display: none;
   }
 
-  .connection-card {
-    padding: 28px 22px;
-  }
-
-  .card-number {
-    font-size: 48px;
-  }
-
   .url-row {
+    flex-direction: column;
+  }
+
+  .action-bar {
     align-items: stretch;
-    flex-direction: column;
+    flex-direction: column-reverse;
   }
 
-  footer {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  footer span:last-child {
-    text-align: left;
+  .action-hint {
+    text-align: center;
   }
 }
 
@@ -403,7 +452,6 @@ footer span:last-child {
   *,
   *::before,
   *::after {
-    scroll-behavior: auto !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;

--- a/apps/desktop/resources/settings.html
+++ b/apps/desktop/resources/settings.html
@@ -12,57 +12,56 @@
   </head>
   <body>
     <main class="settings-shell">
-      <header class="signal-header">
-        <div class="brand-lockup">
-          <img src="../assets/icon.png" alt="" width="74" height="74" />
-          <div>
-            <p class="eyebrow">Native signal desk</p>
-            <h1>ClickClack</h1>
-          </div>
+      <header class="shell-header">
+        <div class="brand">
+          <img src="../assets/icon.png" alt="" width="30" height="30" />
+          <span class="brand-name">ClickClack</span>
+          <span class="brand-sep" aria-hidden="true"></span>
+          <span class="brand-context">Desktop settings</span>
         </div>
-        <div class="platform-chip">
-          <span class="live-dot"></span>
-          <span id="platform-name">Desktop</span>
-        </div>
+        <span class="platform-chip" id="platform-name">Desktop</span>
       </header>
 
-      <section class="connection-card">
-        <div class="card-number">01</div>
-        <div class="card-copy">
-          <p class="eyebrow">Connection</p>
-          <h2>Your server, in a real window.</h2>
-          <p>
-            Hosted ClickClack works out of the box. Self-hosted servers need HTTPS; local development
-            may use loopback HTTP.
-          </p>
-        </div>
+      <form id="settings-form">
+        <section class="group" aria-labelledby="server-group-title">
+          <div class="group-head">
+            <h2 id="server-group-title">Server</h2>
+            <p>
+              Hosted ClickClack works out of the box. Self-hosted servers need HTTPS; loopback
+              HTTP is fine for local development.
+            </p>
+          </div>
 
-        <form id="settings-form">
-          <label class="server-field" for="server-url">
-            <span>ClickClack server</span>
-            <div class="url-row">
-              <input
-                id="server-url"
-                name="server-url"
-                type="url"
-                autocomplete="url"
-                placeholder="https://app.clickclack.chat"
-                required
-              />
-              <button id="test-server" type="button" class="secondary-button">Test</button>
-            </div>
-          </label>
+          <label class="field-label" for="server-url">Server address</label>
+          <div class="url-row">
+            <input
+              id="server-url"
+              name="server-url"
+              type="url"
+              autocomplete="url"
+              spellcheck="false"
+              placeholder="https://app.clickclack.chat"
+              required
+            />
+            <button id="test-server" type="button" class="key-button">Test</button>
+          </div>
 
-          <div class="status-rail">
-            <span class="status-light"></span>
+          <div class="status-rail" role="status">
+            <span class="status-light" aria-hidden="true"></span>
             <span id="connection-status" data-state="idle">Loading settings…</span>
+          </div>
+        </section>
+
+        <section class="group" aria-labelledby="behavior-group-title">
+          <div class="group-head">
+            <h2 id="behavior-group-title">Desktop behavior</h2>
           </div>
 
           <div class="switch-stack">
             <label class="switch-row">
               <span>
-                <strong>Keep the signal alive</strong>
-                <small>Close hides the window; tray notifications and realtime continue.</small>
+                <strong>Keep running in the tray</strong>
+                <small>Closing the window hides it; notifications and realtime stay live.</small>
               </span>
               <input id="close-to-tray" type="checkbox" />
               <span class="switch" aria-hidden="true"></span>
@@ -71,24 +70,23 @@
             <label class="switch-row">
               <span>
                 <strong>Launch at login</strong>
-                <small>Supported by the native macOS and Windows installers.</small>
+                <small>Available with the native macOS and Windows installers.</small>
               </span>
               <input id="start-at-login" type="checkbox" />
               <span class="switch" aria-hidden="true"></span>
             </label>
           </div>
+        </section>
 
-          <button id="save-settings" type="submit" class="primary-button">
-            <span>Save &amp; reconnect</span>
-            <span aria-hidden="true">↗</span>
+        <footer class="action-bar">
+          <span class="action-hint">Changes apply after reconnecting.</span>
+          <button id="save-settings" type="submit" class="key-button primary">
+            Save &amp; reconnect
           </button>
-        </form>
-      </section>
+        </footer>
+      </form>
 
-      <footer>
-        <span id="app-version">Desktop</span>
-        <span>Native notifications · deep links · unread badges · quick compose</span>
-      </footer>
+      <p class="version-line" id="app-version">Desktop</p>
     </main>
     <script src="../dist/settings.js"></script>
   </body>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -321,12 +321,12 @@ function createSettingsWindow() {
     return;
   }
   const window = new BrowserWindow({
-    backgroundColor: "#17110f",
-    height: 720,
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#0e1219" : "#edeff2",
+    height: 580,
     icon: assetPath("icon.png"),
     maximizable: false,
-    minHeight: 640,
-    minWidth: 620,
+    minHeight: 560,
+    minWidth: 600,
     parent: mainWindow ?? undefined,
     resizable: true,
     show: false,

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -48,7 +48,7 @@ form.addEventListener("submit", (event) => {
 
 async function testConnection() {
   setBusy(true);
-  setStatus("Knocking on the server…", "working");
+  setStatus("Testing connection…", "working");
   try {
     const result = await window.clickclackSettings.testServer(serverInput.value);
     showProbe(result);


### PR DESCRIPTION
The desktop settings window had its own private art direction — warm espresso browns, a serif display headline ("Your server, in a real window."), a decorative "01" numeral, asymmetric corner radii, and a glowing coral CTA. None of it exists anywhere else in the product: the web app runs the "Switchboard" identity (porcelain keycaps over an aluminum board by day, the board anodized navy-black by night, electric cyan signal accent). The settings window read as a landing page squeezed into a dialog, and its content didn't even fit the default 680×720 window — the save button clipped below the fold.

This PR rebuilds the screen as what it is: a small native instrument panel on the product's own design system.

## What changed

- **Tokens lifted from `apps/web/src/styles/base.css`** — same board surfaces, hairlines, ink, cyan accent, and status colors, expressed as `light-dark()` pairs. The window now follows the OS appearance (the old screen was dark-only).
- **Keycap tactility** — buttons sit proud of the board with the web app's `--key-edge` hard-edge shadow and press flat on `:active`, so the controls feel like the same hardware as the web app's keys.
- **Native settings anatomy** — compact header (icon, wordmark, platform chip), a "Server" group with a monospace URL field + Test key and a status LED rail, a "Desktop behavior" group with the two toggles, and a footer action bar. No marketing copy, no display serif, no decorative numerals.
- **A real status LED** — idle cyan, working amber (pulsing), success green, error red, with the status line in mono. The old screen showed every state with the same aqua dot.
- **Window shell** — `main.ts` background color now matches the board per appearance (`#0e1219` dark / `#edeff2` light) instead of hardcoded brown, and the default window shrinks to 680×580 (min 600×560) since the content now fits with room to spare.
- **Bug fix**: the generic `input:disabled { opacity: 0.55 }` rule used to override the visually-hidden toggle checkboxes' `opacity: 0` while saving/testing, flashing raw checkbox squares over the switch labels. The rule is now scoped to the URL field.
- Copy tightened: "Keep the signal alive" → "Keep running in the tray"; "Knocking on the server…" → "Testing connection…".

The renderer contract is untouched — same element IDs, same `clickclackSettings` bridge, same status `data-state` values — so `settings.ts` logic is unchanged apart from one status string.

## Before / after

| Before (dark only, full page) | After (dark) |
| --- | --- |
| ![before, dark, full page](https://github.com/user-attachments/assets/6aea90bd-6ce4-4204-ab0a-1ca77daaae4f) | ![after, dark, ready](https://github.com/user-attachments/assets/b472149c-427d-433d-9376-417c834dbb0c) |

| After (light) | Before error state | 
| --- | --- |
| ![after, light, ready](https://github.com/user-attachments/assets/fc4b9925-0373-4ec0-ad7a-568190150e10) | ![before, error state](https://github.com/user-attachments/assets/aaf38e06-8e2a-4c22-9e72-ebbecbfd020c) |

## Related screens (states)

| Testing | Success (dark) |
| --- | --- |
| ![after, dark, testing](https://github.com/user-attachments/assets/8e7c87c8-a6ea-4a0e-a2fc-e27ad0c4edae) | ![after, dark, success](https://github.com/user-attachments/assets/785607b6-a9b4-4ff0-8ae5-145751fcce8d) |

| Error (dark) | Error (light) |
| --- | --- |
| ![after, dark, error](https://github.com/user-attachments/assets/6a701234-00f8-4ff7-82b6-8bd4a5f7615d) | ![after, light, error](https://github.com/user-attachments/assets/1de5a70f-29d2-4889-a8e7-73601a8d0a34) |

Screenshots are rendered from the real `settings.html`/`settings.css` and the built `settings.js` with only the IPC bridge stubbed, at the window's content size (2× scale).

### Native Electron validation

The integrated candidate `800417adfac10235ea21661cac9d7b09c1855765` was packaged and Developer-ID signed, then tested in actual Electron 43.4.1 with the real main process, preload bridge, IPC handlers, and Go server. Its tree is identical to merged commit `3c2ab244d66e2d1a229c3d671f2241f8551be49b`; it also preserves #209's delayed-close fix.

The native run passed default and minimum window geometry, light/dark appearance, keyboard toggles and tab order, invalid URL feedback, a delayed real connection test, 125% zoom, and Save followed by reopening to read persisted settings. Hidden checkbox inputs stayed hidden during the busy state. The test used a separate temporary profile and did not change the operator's saved settings.

```text
packaged Electron: 43.4.1; Developer ID signature verified
window: 680x580 outer, 680x548 content; Save bottom 514.16
minimum: 600x560 outer, 600x528 content; Save bottom 514.16
light appearance: no horizontal overflow; Save visible
keyboard toggles and tab order: passed
real server connection test: passed
125% zoom: Save reachable
real Save + reopen: closeToTray=true, startAtLogin=false persisted
overall: passed
```

This completes the native-runtime proof requested in the review. The following native screenshots were checked for synthetic-only content. The original before/after render captures above remain available.

![Native settings in dark appearance](https://github.com/user-attachments/assets/116c8f5d-a432-44ff-b2f4-d8d239d1779f)

![Native delayed connection test](https://github.com/user-attachments/assets/df105684-c23c-415d-ab63-90b1ec886805)

![Native settings reopened after Save](https://github.com/user-attachments/assets/03ec5c6f-14d4-441f-b9dc-108910962e54)
