### PR TITLE
fix(api): drain active requests before shutdown

### DIFF
--- a/apps/api/cmd/clickclack/main.go
+++ b/apps/api/cmd/clickclack/main.go
@@ -14,6 +14,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/openclaw/clickclack/apps/api/internal/authpolicy"
@@ -121,7 +122,7 @@ func serve(args []string) error {
 		return err
 	}
 	defer st.Close()
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err := st.Migrate(ctx); err != nil {
 		return err

--- a/apps/api/internal/httpapi/authz_test.go
+++ b/apps/api/internal/httpapi/authz_test.go
@@ -1253,27 +1253,6 @@ func TestHTTPNotFoundPreservesAPIAndAssetBoundaries(t *testing.T) {
 	}
 }
 
-func TestListenAndServeStopsWithContext(t *testing.T) {
-	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() {
-		done <- ListenAndServe(ctx, "127.0.0.1:0", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNoContent)
-		}))
-	}()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("server did not stop")
-	}
-}
-
 func newEmptyHTTPStore(t *testing.T) *sqlitestore.Store {
 	t.Helper()
 	st, err := sqlitestore.Open("sqlite://" + filepath.Join(t.TempDir(), "clickclack.db"))

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -2045,15 +2045,19 @@ func writeMessagePage(w http.ResponseWriter, page store.MessagePage, err error) 
 
 func ListenAndServe(ctx context.Context, addr string, handler http.Handler) error {
 	server := newHTTPServer(addr, handler)
-	go func() {
-		<-ctx.Done()
+	defer server.Close()
+	shutdownDone := make(chan error, 1)
+	stopShutdown := context.AfterFunc(ctx, func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = server.Shutdown(shutdownCtx)
-	}()
+		shutdownDone <- server.Shutdown(shutdownCtx)
+	})
+	defer stopShutdown()
 	err := server.ListenAndServe()
 	if errors.Is(err, http.ErrServerClosed) {
-		return nil
+		// Closing the listener returns before active requests finish. Keep the
+		// caller and its store alive until draining completes or times out.
+		return <-shutdownDone
 	}
 	return fmt.Errorf("serve %s: %w", addr, err)
 }

--- a/apps/api/internal/httpapi/server_lifecycle_test.go
+++ b/apps/api/internal/httpapi/server_lifecycle_test.go
@@ -1,0 +1,123 @@
+package httpapi
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListenAndServeDrainsActiveRequest(t *testing.T) {
+	t.Parallel()
+	for _, finish := range []bool{true, false} {
+		name := "finished response"
+		if !finish {
+			name = "drain deadline"
+		}
+		t.Run(name, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := listener.Addr().String()
+			if err := listener.Close(); err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			started := make(chan struct{})
+			release := make(chan struct{})
+			defer close(release)
+			handlerDone := make(chan struct{})
+			done := make(chan error, 1)
+			go func() {
+				done <- ListenAndServe(ctx, addr, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					defer close(handlerDone)
+					close(started)
+					select {
+					case <-release:
+						_, _ = io.WriteString(w, "completed")
+					case <-r.Context().Done():
+					}
+				}))
+			}()
+			var conn net.Conn
+			deadline := time.Now().Add(5 * time.Second)
+			for {
+				conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+				if err == nil {
+					break
+				}
+				select {
+				case err := <-done:
+					t.Fatalf("server failed before request: %v", err)
+				default:
+				}
+				if time.Now().After(deadline) {
+					t.Fatalf("server never accepted connections: %v", err)
+				}
+				time.Sleep(time.Millisecond)
+			}
+			defer conn.Close()
+			_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+			if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-started:
+			case <-time.After(5 * time.Second):
+				t.Fatal("request handler never started")
+			}
+			cancel()
+			select {
+			case err := <-done:
+				t.Fatalf("server returned before its active request finished: %v", err)
+			case <-time.After(100 * time.Millisecond):
+			}
+			if finish {
+				release <- struct{}{}
+				response, err := http.ReadResponse(bufio.NewReader(conn), nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body, err := io.ReadAll(response.Body)
+				_ = response.Body.Close()
+				if err != nil || response.StatusCode != http.StatusOK || string(body) != "completed" {
+					t.Fatalf("active response was not preserved: status=%s body=%q err=%v", response.Status, body, err)
+				}
+			}
+			select {
+			case err := <-done:
+				if finish && err != nil || !finish && !errors.Is(err, context.DeadlineExceeded) {
+					t.Fatalf("unexpected drain result: %v", err)
+				}
+			case <-time.After(7 * time.Second):
+				t.Fatal("server did not finish draining")
+			}
+			select {
+			case <-handlerDone:
+			case <-time.After(time.Second):
+				t.Fatal("server left an active request after its drain deadline")
+			}
+		})
+	}
+}
+
+func TestListenAndServeReturnsBindError(t *testing.T) {
+	t.Parallel()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	addr := listener.Addr().String()
+	err = ListenAndServe(context.Background(), addr, http.NotFoundHandler())
+	if err == nil || !strings.Contains(err.Error(), addr) {
+		t.Fatalf("expected the listen error for %s, got %v", addr, err)
+	}
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,11 @@ ClickClack ships as one Go binary that embeds the Svelte SPA and the SQL
 migrations. The deployment story is "drop a binary on a box, point it at a
 data directory, run it behind a reverse proxy."
 
+On interrupt or `SIGTERM`, the server stops accepting new HTTP connections and
+keeps its database open while active requests finish. Requests have up to five
+seconds to drain before their connections close and the process exits. A drain
+timeout is reported as an error.
+
 Public surfaces:
 
 - `clickclack.chat` — product website.


### PR DESCRIPTION
ClickClack could exit during an active request: Go closes the listener before `Shutdown` finishes draining, but the serve wrapper returned immediately and the CLI closed the database. SIGTERM also bypassed the existing interrupt handler. A live multipart upload was interrupted under both signals.

Wait for shutdown completion before returning to the database owner, retain the existing five-second drain budget, and close remaining connections on expiry. The cancellation callback is removed when binding fails, and SIGTERM now uses the same shutdown path as an interrupt. Replace the idle cancellation test with real TCP coverage for a completed response, deadline expiry, and bind failure.

Validation: the active-request regression failed before the change and passes afterward. Real binary tests under both SIGINT and SIGTERM now preserve the full 33,792-byte upload, return HTTP 201, exit successfully, and serve identical bytes after restart. The HTTP API, CLI, and upload-store suites pass; independent Codex review found no actionable findings. One local live run stalled while creating its fixture during concurrent filesystem-heavy tests; the identical harness passed alone without changing timeouts or assertions.

Production delta: +5 lines, for the missing shutdown-completion boundary and SIGTERM handling. Tests: +102 net lines; documentation: +5. No configuration, schema, or dependency changes. WebSockets retain their existing reconnect-after-restart behavior; this change drains finite HTTP requests.
