### PR TITLE
fix(uploads): encode stored R2 object addresses

### DIFF
--- a/apps/api/internal/uploadstore/r2.go
+++ b/apps/api/internal/uploadstore/r2.go
@@ -212,7 +212,7 @@ func (s *R2) newRequest(ctx context.Context, method, key string, body io.Reader)
 }
 
 func (s *R2) objectPath(key string) string {
-	return "r2://" + s.bucket + "/" + strings.TrimLeft(key, "/")
+	return (&url.URL{Scheme: "r2", Host: s.bucket, Path: "/" + strings.TrimLeft(key, "/")}).String()
 }
 
 func (s *R2) keyFromPath(objectPath string) (string, error) {

--- a/apps/api/internal/uploadstore/r2_test.go
+++ b/apps/api/internal/uploadstore/r2_test.go
@@ -7,110 +7,149 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 )
 
 func TestR2SaveServeAndDelete(t *testing.T) {
 	t.Parallel()
-	var savedPath string
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
-			t.Fatalf("missing sigv4 authorization for %s", r.Method)
-		}
-		if r.Header.Get("X-Amz-Content-Sha256") == "" || r.Header.Get("X-Amz-Date") == "" {
-			t.Fatalf("missing signed r2 headers for %s", r.Method)
-		}
-		if !strings.HasPrefix(r.URL.Path, "/bucket/prefix/upload-") {
-			t.Fatalf("unexpected object path %q", r.URL.Path)
-		}
-		if strings.HasSuffix(r.URL.Path, "upload-missing") {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
-		switch r.Method {
-		case http.MethodPut:
-			if r.ContentLength != 8 {
-				t.Fatalf("unexpected put content length: %d", r.ContentLength)
+	for _, tc := range []struct {
+		name, prefix, storedPrefix, requestPrefix, legacyPath string
+	}{
+		{"plain", "prefix", "r2://bucket/prefix/", "/bucket/prefix/", "r2://bucket/prefix/upload-existing"},
+		{"space", "team files", "r2://bucket/team%20files/", "/bucket/team%2520files/", "r2://bucket/team files/upload-existing"},
+		{"percent", "100%", "r2://bucket/100%25/", "/bucket/100%2525/", ""},
+		{"escaped percent", "literal%20", "r2://bucket/literal%2520/", "/bucket/literal%252520/", ""},
+		{"fragment", "team#files", "r2://bucket/team%23files/", "/bucket/team%2523files/", ""},
+		{"query", "team?files", "r2://bucket/team%3Ffiles/", "/bucket/team%253Ffiles/", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var mu sync.Mutex
+			objects := make(map[string][]byte)
+			if tc.legacyPath != "" {
+				objects[tc.requestPrefix+"upload-existing"] = []byte("hello r2")
 			}
-			body, err := io.ReadAll(r.Body)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				defer mu.Unlock()
+				if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256 ") {
+					t.Errorf("missing sigv4 authorization for %s", r.Method)
+				}
+				if r.Header.Get("X-Amz-Content-Sha256") == "" || r.Header.Get("X-Amz-Date") == "" {
+					t.Errorf("missing signed r2 headers for %s", r.Method)
+				}
+				// Existing R2 objects use this wire encoding, including escaped prefixes.
+				if !strings.HasPrefix(r.RequestURI, tc.requestPrefix+"upload-") {
+					t.Errorf("unexpected object request URI %q", r.RequestURI)
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				switch r.Method {
+				case http.MethodPut:
+					if r.ContentLength != 8 {
+						t.Errorf("unexpected put content length: %d", r.ContentLength)
+					}
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Error(err)
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
+					if string(body) != "hello r2" || r.Header.Get("Content-Type") != "text/plain" {
+						t.Errorf("unexpected put body/header: %q %q", string(body), r.Header.Get("Content-Type"))
+					}
+					objects[r.RequestURI] = body
+					w.WriteHeader(http.StatusOK)
+				case http.MethodGet:
+					body, ok := objects[r.RequestURI]
+					if !ok {
+						w.WriteHeader(http.StatusNotFound)
+						return
+					}
+					if r.Header.Get("Range") == "bytes=99-100" {
+						w.Header().Set("Content-Range", "bytes */8")
+						w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+						return
+					}
+					if r.Header.Get("Range") != "bytes=0-4" {
+						t.Errorf("expected range passthrough, got %q", r.Header.Get("Range"))
+					}
+					w.Header().Set("Content-Range", "bytes 0-4/8")
+					w.Header().Set("Accept-Ranges", "bytes")
+					w.WriteHeader(http.StatusPartialContent)
+					_, _ = w.Write(body[:5])
+				case http.MethodDelete:
+					delete(objects, r.RequestURI)
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					t.Errorf("unexpected method %s", r.Method)
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			store, err := NewR2(R2Config{
+				AccountID:       "account",
+				AccessKeyID:     "access",
+				SecretAccessKey: "secret",
+				Bucket:          "bucket",
+				Prefix:          tc.prefix,
+				Endpoint:        server.URL,
+			})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if string(body) != "hello r2" || r.Header.Get("Content-Type") != "text/plain" {
-				t.Fatalf("unexpected put body/header: %q %q", string(body), r.Header.Get("Content-Type"))
+			saved, err := store.Save(context.Background(), strings.NewReader("hello r2"), SaveOptions{ContentType: "text/plain"})
+			if err != nil {
+				t.Fatal(err)
 			}
-			w.WriteHeader(http.StatusOK)
-		case http.MethodGet:
-			if r.Header.Get("Range") == "bytes=99-100" {
-				w.Header().Set("Content-Range", "bytes */8")
-				w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
-				return
+			if saved.ByteSize != 8 || !strings.HasPrefix(saved.Path, tc.storedPrefix+"upload-") {
+				t.Errorf("unexpected saved object: %#v", saved)
 			}
-			if r.Header.Get("Range") != "bytes=0-4" {
-				t.Fatalf("expected range passthrough, got %q", r.Header.Get("Range"))
+			paths := []string{saved.Path}
+			if tc.legacyPath != "" {
+				paths = append(paths, tc.legacyPath)
 			}
-			w.Header().Set("Content-Range", "bytes 0-4/8")
-			w.Header().Set("Accept-Ranges", "bytes")
-			w.WriteHeader(http.StatusPartialContent)
-			_, _ = w.Write([]byte("hello"))
-		case http.MethodDelete:
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			t.Fatalf("unexpected method %s", r.Method)
-		}
-	}))
-	t.Cleanup(server.Close)
+			for _, path := range paths {
+				recorder := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodGet, "/api/uploads/upl_1", nil)
+				req.Header.Set("Range", "bytes=0-4")
+				if err := store.ServeHTTP(recorder, req, Object{Path: path, ContentType: "text/plain", ByteSize: saved.ByteSize}); err != nil {
+					t.Fatalf("download saved upload %q: %v", path, err)
+				}
+				if recorder.Code != http.StatusPartialContent || recorder.Body.String() != "hello" {
+					t.Fatalf("unexpected serve response: %d %q", recorder.Code, recorder.Body.String())
+				}
+				if recorder.Header().Get("Content-Type") != "text/plain" || recorder.Header().Get("Content-Range") != "bytes 0-4/8" {
+					t.Fatalf("unexpected serve headers: %#v", recorder.Header())
+				}
 
-	store, err := NewR2(R2Config{
-		AccountID:       "account",
-		AccessKeyID:     "access",
-		SecretAccessKey: "secret",
-		Bucket:          "bucket",
-		Prefix:          "prefix",
-		Endpoint:        server.URL,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	saved, err := store.Save(context.Background(), strings.NewReader("hello r2"), SaveOptions{ContentType: "text/plain"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	savedPath = saved.Path
-	if saved.ByteSize != 8 || !strings.HasPrefix(saved.Path, "r2://bucket/prefix/upload-") {
-		t.Fatalf("unexpected saved object: %#v", saved)
-	}
-
-	recorder := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/uploads/upl_1", nil)
-	req.Header.Set("Range", "bytes=0-4")
-	if err := store.ServeHTTP(recorder, req, Object{Path: saved.Path, ContentType: "text/plain", ByteSize: saved.ByteSize}); err != nil {
-		t.Fatal(err)
-	}
-	if recorder.Code != http.StatusPartialContent || recorder.Body.String() != "hello" {
-		t.Fatalf("unexpected serve response: %d %q", recorder.Code, recorder.Body.String())
-	}
-	if recorder.Header().Get("Content-Type") != "text/plain" || recorder.Header().Get("Content-Range") != "bytes 0-4/8" {
-		t.Fatalf("unexpected serve headers: %#v", recorder.Header())
-	}
-	recorder = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/api/uploads/upl_1", nil)
-	req.Header.Set("Range", "bytes=99-100")
-	if err := store.ServeHTTP(recorder, req, Object{Path: saved.Path, ContentType: "text/plain", ByteSize: saved.ByteSize}); err != nil {
-		t.Fatal(err)
-	}
-	if recorder.Code != http.StatusRequestedRangeNotSatisfiable || recorder.Header().Get("Content-Range") != "bytes */8" {
-		t.Fatalf("unexpected unsatisfiable range response: %d %#v", recorder.Code, recorder.Header())
-	}
-	if err := store.Delete(context.Background(), savedPath); err != nil {
-		t.Fatal(err)
-	}
-	recorder = httptest.NewRecorder()
-	if err := store.ServeHTTP(recorder, req, Object{Path: "prefix/upload-missing"}); !errors.Is(err, ErrNotFound) || recorder.Body.Len() != 0 {
-		t.Fatalf("missing object must fail before writing file bytes: %v", err)
-	}
-	if err := store.Delete(context.Background(), "prefix/upload-missing"); err != nil {
-		t.Fatalf("deleting a missing object must succeed: %v", err)
+				recorder = httptest.NewRecorder()
+				req.Header.Set("Range", "bytes=99-100")
+				if err := store.ServeHTTP(recorder, req, Object{Path: path, ContentType: "text/plain", ByteSize: saved.ByteSize}); err != nil {
+					t.Fatal(err)
+				}
+				if recorder.Code != http.StatusRequestedRangeNotSatisfiable || recorder.Header().Get("Content-Range") != "bytes */8" {
+					t.Fatalf("unexpected unsatisfiable range response: %d %#v", recorder.Code, recorder.Header())
+				}
+				if err := store.Delete(context.Background(), path); err != nil {
+					t.Fatalf("delete saved upload %q: %v", path, err)
+				}
+				recorder = httptest.NewRecorder()
+				if err := store.ServeHTTP(recorder, req, Object{Path: path}); !errors.Is(err, ErrNotFound) || recorder.Body.Len() != 0 {
+					t.Fatalf("deleted object must fail before writing file bytes: %v", err)
+				}
+			}
+			if err := store.Delete(context.Background(), tc.prefix+"/upload-missing"); err != nil {
+				t.Fatalf("deleting a missing object must succeed: %v", err)
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if len(objects) != 0 {
+				t.Fatalf("uploads left in storage after deletion: %d", len(objects))
+			}
+		})
 	}
 }
 

--- a/docs/features/uploads.md
+++ b/docs/features/uploads.md
@@ -148,6 +148,10 @@ CLICKCLACK_R2_SECRET_ACCESS_KEY=...
 ```
 
 R2 keys are stored in the database as `r2://bucket/prefix/upload-...`.
+URL-encode reserved characters in the configured prefix, such as
+`r2://bucket/team%23files` for `team#files`. Newly stored upload addresses also
+escape these characters so downloads and cleanup retain the complete key.
+Existing stored addresses and physical object keys are not migrated.
 Download requests are still authenticated by ClickClack before the object is
 fetched from R2.
 


### PR DESCRIPTION
R2 uploads could save successfully but return an address that could not download or delete the object. The stored address concatenated the raw prefix into a URL, so percent signs, fragments, and query delimiters were reinterpreted when read back.

Serialize the stored address with `url.URL`. This keeps the existing object keys and signed request paths while making new addresses round-trip correctly. Extend the existing upload/download/delete test across six prefix forms, retaining range requests, missing-object behavior, and readable legacy plain/space addresses.

The regression fails before the change and the full upload-store race suite passes afterward. A separate live Cloudflare R2 run uploaded, downloaded byte-identical content, deleted each object, and verified it was absent for all six prefixes: ordinary text, spaces, `%`, a literal percent escape, `#`, and `?`. All synthetic cloud objects were removed. Independent Codex review found no actionable findings.

Production delta: 1 line replaced, net zero. Tests: +39 net lines; docs: +4. Existing physical keys and previously stored addresses are not migrated. Previously malformed stored addresses may still need an operator repair; this change prevents new broken metadata without guessing at historical object mappings.

### Live R2 evidence

The following is the actual successful terminal output for candidate `616fd0cabc9a6a373d8136f8844f4148742c1405`, using the configured Cloudflare R2 endpoint on September 1, 2026. Each line is emitted only after `Save`, an HTTP 200 download with exact byte comparison, `Delete`, and a subsequent read returning `ErrNotFound`. The harness imported the candidate's real `uploadstore` package; only the local HTTP response writer was a recorder. R2 transport and credentials were real. Account, bucket, credential values, and unique object keys are omitted.

```text
prefix="plain" bytes=41 upload=passed download=passed delete=passed
prefix="space prefix" bytes=48 upload=passed download=passed delete=passed
prefix="100%" bytes=40 upload=passed download=passed delete=passed
prefix="literal%20" bytes=46 upload=passed download=passed delete=passed
prefix="team#files" bytes=46 upload=passed download=passed delete=passed
prefix="team?files" bytes=46 upload=passed download=passed delete=passed
```

All six synthetic objects were deleted and the temporary credential copy removed. The existing full upload-store race suite also passed.

Review follow-through: this supplies the requested inspectable runtime trace. Historical malformed metadata is an existing limitation, not a newly rejected format: request construction and address parsing are unchanged. This PR deliberately prevents new corruption without rewriting persisted addresses or guessing which remote object an old malformed address meant. An operator-selected historical repair remains separate.
