### PR TITLE
fix(sdk): keep bot close callbacks scoped to their socket

### DIFF
--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -272,6 +272,10 @@ const bot = new ClickClackBot({
 bot.start();
 ```
 
+`start()` reuses a connecting or open socket. `stop()` disconnects without
+calling `onClose`. Other closes of the active socket still call `onClose`;
+delayed closes from stopped connections do not notify a replacement.
+
 Persist `event.cursor` after each handled event and reconnect with
 `afterCursor` for exactly-once-ish processing. Ignore events whose
 `payload.author_id` matches the bot's own user ID to avoid loops.

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -1079,13 +1079,13 @@ export class ClickClackBot {
     if (this.socket && isActiveSocket(this.socket)) {
       return this.socket;
     }
-    let socket: WebSocket;
-    socket = this.client.events.subscribe({
+    const socket = this.client.events.subscribe({
       workspaceId: this.workspaceId,
       afterCursor: this.afterCursor,
       onEvent: (event) => void this.onEvent(event, this.client),
       onClose: () => {
-        if (this.socket === socket) this.socket = undefined;
+        if (this.socket !== socket) return;
+        this.socket = undefined;
         this.onClose?.();
       },
     });

--- a/tests/e2e/realtime-snapshots.spec.ts
+++ b/tests/e2e/realtime-snapshots.spec.ts
@@ -1,8 +1,62 @@
 import { expect, test, type Page } from "@playwright/test";
 import { randomUUID } from "node:crypto";
+import { once } from "node:events";
+import { ClickClackBot, ClickClackClient } from "../../packages/sdk-ts/src";
 import type { Channel, User, Workspace } from "../../apps/web/src/lib/types";
 import { waitForAppReady } from "./app-ready";
 import { deferred } from "./thread-fixture";
+
+for (const action of ["remote close", "stop", "restart"] as const) {
+  test(`SDK bot only reports its current connection closing: ${action}`, async ({ baseURL }) => {
+    const client = new ClickClackClient({ baseUrl: baseURL! });
+    const workspace = await client.workspaces.create({ name: `SDK lifecycle ${randomUUID()}` });
+    const { bot, bot_token } = await client.bots.create(workspace.id, {
+      display_name: "Lifecycle bot",
+      scopes: ["bot:write"],
+    });
+    expect(Boolean(bot_token?.token)).toBe(true);
+    let closes = 0;
+    const runner = new ClickClackBot({
+      baseUrl: baseURL!,
+      workspaceId: workspace.id,
+      token: bot_token!.token,
+      onEvent() {},
+      onClose() {
+        closes++;
+      },
+    });
+    try {
+      const first = runner.start();
+      expect(runner.start() === first).toBe(true);
+      await once(first, "open");
+      const firstClosed = once(first, "close");
+      if (action === "remote close") {
+        await client.bots.removeMembership(workspace.id, bot.id);
+        await firstClosed;
+        expect(closes).toBe(1);
+      } else {
+        runner.stop();
+        if (action === "restart") {
+          const replacement = runner.start();
+          await Promise.all([firstClosed, once(replacement, "open")]);
+          expect(closes).toBe(0);
+          expect(runner.start() === replacement).toBe(true);
+          const replacementClosed = once(replacement, "close");
+          await client.bots.removeMembership(workspace.id, bot.id);
+          await replacementClosed;
+          expect(closes).toBe(1);
+        } else {
+          await firstClosed;
+          expect(closes).toBe(0);
+        }
+      }
+    } finally {
+      runner.stop();
+      await client.bots.delete(bot.id);
+      await client.workspaces.delete(workspace.id);
+    }
+  });
+}
 
 async function fixture(page: Page, open = true) {
   const created = await page.request.post("/api/workspaces", {


### PR DESCRIPTION
Stopping a `ClickClackBot` could still invoke its disconnect callback when the old WebSocket finished closing. During an immediate restart, that callback could also report a failure after the replacement had already become the active connection.

The bot now checks socket ownership before either close effect: only the current socket can clear the connection and notify `onClose`. Explicit stop and delayed closes from replaced sockets do not notify it. Unexpected remote closure of the current connection still does. The SDK guide documents this lifecycle contract.

Validation used Node's native WebSocket against the real Go server, with actual bot membership revocation to close remote connections. The remote-close control passed before; stop and stop/restart failed before and all three pass after. Root and SDK typechecks, lint, formatting, whitespace checks, and independent Codex autoreview pass.

Production: 3 lines added / 3 removed (net zero). Regression coverage: 54 added lines in the existing realtime suite. Documentation: 4 added lines. No new dependency, configuration, or storage surface.

Actual focused-run output for `a68d24bea592a9463fa8e18774f85b37ebe65e08`:

```text
SDK bot only reports its current connection closing: remote close (663ms) - passed
SDK bot only reports its current connection closing: stop (652ms) - passed
SDK bot only reports its current connection closing: restart (1.0s) - passed
3 passed (4.5s)
```

The test uses the real SDK, Node's native WebSocket implementation, and the real local server. It verifies idempotent start, intentional stop, delayed old-socket close, and membership-revocation closure of the replacement.

Maintainer compatibility decision: adopt the documented active-connection callback contract. An explicit `stop()` must leave the runner stopped; the runner callback reports an unrequested closure of its active connection. Callers needing intentional-shutdown cleanup should perform it when they call `stop()`. The lower-level `client.events.subscribe` WebSocket close behavior is unchanged.

The current and v0.3.1 SDK manifests both mark the package private at version 0.0.0; the tagged runner guide does not promise a callback after explicit stop. Source consumers could nevertheless have relied on the old incidental callback, so that observable change is intentionally documented rather than hidden behind a compatibility callback that can revive a stopped runner. This resolves the review's ownership decision.
