### PR TITLE
fix(realtime): retire revoked bot credentials on open sockets

### DIFF
--- a/apps/api/internal/httpapi/realtime_token_test.go
+++ b/apps/api/internal/httpapi/realtime_token_test.go
@@ -1,0 +1,164 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/openclaw/clickclack/apps/api/internal/realtime"
+	"github.com/openclaw/clickclack/apps/api/internal/store"
+)
+
+func createRealtimeBot(t *testing.T, fixture realtimeWorkspaceFixture) (store.BotToken, store.CreateBotInput) {
+	t.Helper()
+	input := store.CreateBotInput{
+		WorkspaceID: fixture.workspace.ID, DisplayName: "Realtime bot",
+		CreatedBy: fixture.owner.ID, Scopes: []string{"bot:read"}, SetupNonce: "realtime-token-proof",
+	}
+	_, token, err := fixture.store.CreateBot(fixture.ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token, input
+}
+
+func expectRealtimeTokenClose(t *testing.T, conn *websocket.Conn, code websocket.StatusCode) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, err := conn.Read(ctx)
+	if got := websocket.CloseStatus(err); got != code {
+		t.Fatalf("credential check returned %v, want close %v: %v", got, code, err)
+	}
+}
+
+func TestRealtimeBotTokenRevocation(t *testing.T) {
+	for _, scenario := range []string{"durable", "ephemeral", "idle", "replacement"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Parallel()
+			fixture := newRealtimeWorkspaceFixture(t, scenario+"-token@example.com")
+			token, input := createRealtimeBot(t, fixture)
+			hub := realtime.NewHub()
+			server := New(fixture.store, hub, Options{})
+			if scenario == "idle" {
+				server.realtimeSessionCheck = 20 * time.Millisecond
+			}
+			httpServer := httptest.NewServer(server.Handler())
+			defer httpServer.Close()
+			conn := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, token.Token)
+			defer conn.CloseNow()
+			hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+			if _, ok := readEventTypeWithin(t, conn, "presence.changed", 5*time.Second); !ok {
+				t.Fatal("bot did not receive the positive control")
+			}
+
+			var replacement store.BotToken
+			if scenario == "replacement" {
+				_, rotated, err := fixture.store.CreateBot(fixture.ctx, input)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if rotated.ID != token.ID || rotated.Token == token.Token {
+					t.Fatal("setup replay must replace the credential in the same token row")
+				}
+				replacement = rotated
+			} else if _, err := fixture.store.RevokeBotToken(fixture.ctx, token.ID, fixture.owner.ID); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := fixture.store.GetBotTokenAuth(fixture.ctx, token.Token); err == nil {
+				t.Fatal("old credential still authenticates")
+			}
+			switch scenario {
+			case "durable":
+				_, event, err := fixture.store.CreateMessage(fixture.ctx, store.CreateMessageInput{
+					ChannelID: fixture.channel.ID, AuthorID: fixture.owner.ID, Body: "After revocation",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				hub.Publish(event)
+			case "ephemeral", "replacement":
+				hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+			}
+			expectRealtimeTokenClose(t, conn, websocket.StatusPolicyViolation)
+			if replacement.Token != "" {
+				current := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, replacement.Token)
+				defer current.CloseNow()
+				hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+				if _, ok := readEventTypeWithin(t, current, "presence.changed", 5*time.Second); !ok {
+					t.Fatal("replacement credential could not receive events")
+				}
+			}
+		})
+	}
+}
+
+func TestRealtimeReplayRechecksBotTokenAfterVisibilityLookup(t *testing.T) {
+	fixture := newRealtimeWorkspaceFixture(t, "replay-token@example.com")
+	token, _ := createRealtimeBot(t, fixture)
+	if _, _, err := fixture.store.CreateMessage(fixture.ctx, store.CreateMessageInput{
+		ChannelID: fixture.channel.ID, AuthorID: fixture.owner.ID, Body: "Before connection",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	unblock := sync.OnceFunc(func() { close(release) })
+	defer unblock()
+	blocked := &blockingChannelStore{Store: fixture.store, entered: make(chan struct{}), release: release, tailCaptured: make(chan struct{})}
+	httpServer := httptest.NewServer(New(blocked, realtime.NewHub(), Options{}).Handler())
+	defer httpServer.Close()
+	conn := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, token.Token)
+	defer conn.CloseNow()
+	select {
+	case <-blocked.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("replay did not reach visibility lookup")
+	}
+	if _, err := fixture.store.RevokeBotToken(fixture.ctx, token.ID, fixture.owner.ID); err != nil {
+		t.Fatal(err)
+	}
+	unblock()
+	expectRealtimeTokenClose(t, conn, websocket.StatusPolicyViolation)
+}
+
+type unavailableBotTokenStore struct {
+	store.Store
+	unavailable atomic.Bool
+}
+
+func (s *unavailableBotTokenStore) GetBotTokenAuth(ctx context.Context, token string) (store.BotTokenAuth, error) {
+	if s.unavailable.Load() {
+		return store.BotTokenAuth{}, errors.New("temporary database failure")
+	}
+	return s.Store.GetBotTokenAuth(ctx, token)
+}
+
+func TestRealtimeBotTokenLookupFailureRemainsRetryable(t *testing.T) {
+	fixture := newRealtimeWorkspaceFixture(t, "retry-token@example.com")
+	token, _ := createRealtimeBot(t, fixture)
+	wrapped := &unavailableBotTokenStore{Store: fixture.store}
+	hub := realtime.NewHub()
+	httpServer := httptest.NewServer(New(wrapped, hub, Options{}).Handler())
+	defer httpServer.Close()
+	conn := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, token.Token)
+	defer conn.CloseNow()
+	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+	if _, ok := readEventTypeWithin(t, conn, "presence.changed", 5*time.Second); !ok {
+		t.Fatal("bot did not receive the positive control")
+	}
+	wrapped.unavailable.Store(true)
+	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+	expectRealtimeTokenClose(t, conn, websocket.StatusTryAgainLater)
+	wrapped.unavailable.Store(false)
+	current := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, token.Token)
+	defer current.CloseNow()
+	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+	if _, ok := readEventTypeWithin(t, current, "presence.changed", 5*time.Second); !ok {
+		t.Fatal("credential could not recover after the store recovered")
+	}
+}

--- a/apps/api/internal/httpapi/realtime_token_test.go
+++ b/apps/api/internal/httpapi/realtime_token_test.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"sync"
 	"sync/atomic"
@@ -160,5 +161,58 @@ func TestRealtimeBotTokenLookupFailureRemainsRetryable(t *testing.T) {
 	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
 	if _, ok := readEventTypeWithin(t, current, "presence.changed", 5*time.Second); !ok {
 		t.Fatal("credential could not recover after the store recovered")
+	}
+}
+
+func TestRealtimeCredentialChecksDoNotRecordNewTokenUsage(t *testing.T) {
+	fixture := newRealtimeWorkspaceFixture(t, "usage-token@example.com")
+	token, _ := createRealtimeBot(t, fixture)
+	hub := realtime.NewHub()
+	httpServer := httptest.NewServer(New(fixture.store, hub, Options{}).Handler())
+	defer httpServer.Close()
+	lastUsed := func() string {
+		t.Helper()
+		bots, err := fixture.store.ListBots(fixture.ctx, fixture.workspace.ID, fixture.owner.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, bot := range bots {
+			for _, candidate := range bot.Tokens {
+				if candidate.ID == token.ID && candidate.LastUsedAt != nil {
+					return *candidate.LastUsedAt
+				}
+			}
+		}
+		return ""
+	}
+	conn := dialRealtimeWithSession(t, httpServer.URL, fixture.workspace.ID, token.Token)
+	defer conn.CloseNow()
+	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+	if _, ok := readEventTypeWithin(t, conn, "presence.changed", 5*time.Second); !ok {
+		t.Fatal("bot did not receive the positive control")
+	}
+	connectedAt := lastUsed()
+	if connectedAt == "" {
+		t.Fatal("WebSocket authentication did not record credential usage")
+	}
+	hub.Publish(store.Event{WorkspaceID: fixture.workspace.ID, Type: "presence.changed"})
+	if _, ok := readEventTypeWithin(t, conn, "presence.changed", 5*time.Second); !ok {
+		t.Fatal("bot did not receive the next event")
+	}
+	if lastUsed() != connectedAt {
+		t.Fatal("delivery revalidation recorded another token use")
+	}
+	req, err := http.NewRequest(http.MethodGet, httpServer.URL+"/api/me", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token.Token)
+	response, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK || lastUsed() == connectedAt {
+		t.Fatal("fresh HTTP authentication did not advance credential usage")
 	}
 }

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1677,6 +1677,8 @@ func (s *Server) currentActor(r *http.Request) (actor, error) {
 	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
 		token := strings.TrimSpace(strings.TrimPrefix(auth, "Bearer "))
 		if botAuth, err := s.store.GetBotTokenAuth(r.Context(), token); err == nil {
+			// Record ingress use once; realtime revalidation stays read-only.
+			_ = s.store.RecordBotTokenUse(r.Context(), botAuth.TokenID)
 			return actor{
 				user:        botAuth.User,
 				botTokenID:  botAuth.TokenID,

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -70,9 +70,9 @@ const (
 	realtimeReplayCloseReason         = "realtime replay interrupted; reconnect with after_cursor"
 	realtimeResyncRequiredCloseReason = "realtime replay limit exceeded; resync required"
 	realtimeSessionRevokedCloseReason = "session revoked; sign in again"
-	// realtimeSessionRecheckInterval bounds how long a connection whose session
+	// realtimeSessionRecheckInterval bounds how long a connection whose credential
 	// was revoked can sit open while its workspace is quiet. Delivery revalidates
-	// the session regardless, so this only shortens the idle case.
+	// the credential regardless, so this only shortens the idle case.
 	realtimeSessionRecheckInterval = 30 * time.Second
 	// setupCodeClaimLimit/Window bound unauthenticated bot setup code
 	// claim attempts per client IP.
@@ -1393,31 +1393,37 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 	defer conn.CloseNow()
 	ctx := conn.CloseRead(r.Context())
 	replayCursor := r.URL.Query().Get("after_cursor")
-	// Read shared session state so revocation on another replica reaches this socket.
-	// Bot tokens and trusted-proxy identities have no session to revalidate.
-	sessionAuthorityLive := func() bool {
-		if act.sessionToken == "" {
-			return true
+	// Revalidate the exact credential in the shared store: setup replay can replace
+	// a bot secret without changing its token ID, including on another replica.
+	bearerToken := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	credentialAuthorityLive := func() bool {
+		var err error
+		revokedReason := realtimeSessionRevokedCloseReason
+		if act.botTokenID != "" {
+			_, err = s.store.GetBotTokenAuth(ctx, bearerToken)
+			revokedReason = "bot token revoked; reconnect with a valid token"
+		} else if act.sessionToken != "" {
+			_, err = s.sessionUser(ctx, act.sessionToken)
 		}
-		if _, err := s.sessionUser(ctx, act.sessionToken); err != nil {
-			if errors.Is(err, errSessionLookupUnavailable) {
-				_ = conn.Close(websocket.StatusTryAgainLater, "session verification unavailable; retry")
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) || errors.Is(err, store.ErrSessionExpired) {
+				_ = conn.Close(websocket.StatusPolicyViolation, revokedReason)
 			} else {
-				_ = conn.Close(websocket.StatusPolicyViolation, realtimeSessionRevokedCloseReason)
+				_ = conn.Close(websocket.StatusTryAgainLater, "credential verification unavailable; retry")
 			}
 			return false
 		}
 		return true
 	}
 	writeEvent := func(event store.Event) bool {
-		return sessionAuthorityLive() && writeWS(ctx, conn, event) == nil
+		return credentialAuthorityLive() && writeWS(ctx, conn, event) == nil
 	}
 	sessionRecheck := time.NewTicker(s.realtimeSessionCheck)
 	defer sessionRecheck.Stop()
 	// Startup and live delivery share one ordered, authorized durable-log drain.
 	// Capture a finite tail each time; a wake received during this drain stays queued.
 	drain := func() bool {
-		if !sessionAuthorityLive() {
+		if !credentialAuthorityLive() {
 			return false
 		}
 		replayTail, err := s.store.LatestEventCursor(ctx, workspaceID, act.user.ID)
@@ -1516,7 +1522,7 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 		case <-sessionRecheck.C:
 			// An idle socket delivers nothing to revalidate against, so revocation
 			// reaches it here instead of waiting for the workspace's next event.
-			if !sessionAuthorityLive() {
+			if !credentialAuthorityLive() {
 				return
 			}
 		case _, ok := <-subscription.Wake:

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -347,8 +347,11 @@ func (s *Store) GetBotTokenAuth(ctx context.Context, token string) (store.BotTok
 	if err := s.requireMembership(ctx, auth.WorkspaceID, auth.User.ID); err != nil {
 		return store.BotTokenAuth{}, err
 	}
-	_ = s.q.TouchBotToken(ctx, storedb.TouchBotTokenParams{LastUsedAt: sqlText(now()), ID: auth.TokenID})
 	return auth, nil
+}
+
+func (s *Store) RecordBotTokenUse(ctx context.Context, tokenID string) error {
+	return s.q.TouchBotToken(ctx, storedb.TouchBotTokenParams{LastUsedAt: sqlText(now()), ID: tokenID})
 }
 
 func (s *Store) ListBots(ctx context.Context, workspaceID, requesterID string) ([]store.BotWithTokens, error) {

--- a/apps/api/internal/store/sqlite/bots.go
+++ b/apps/api/internal/store/sqlite/bots.go
@@ -301,8 +301,11 @@ func (s *Store) GetBotTokenAuth(ctx context.Context, token string) (store.BotTok
 	if err := s.requireMembership(ctx, auth.WorkspaceID, auth.User.ID); err != nil {
 		return store.BotTokenAuth{}, err
 	}
-	_ = s.q.TouchBotToken(ctx, storedb.TouchBotTokenParams{LastUsedAt: sqlText(now()), ID: auth.TokenID})
 	return auth, nil
+}
+
+func (s *Store) RecordBotTokenUse(ctx context.Context, tokenID string) error {
+	return s.q.TouchBotToken(ctx, storedb.TouchBotTokenParams{LastUsedAt: sqlText(now()), ID: tokenID})
 }
 
 func (s *Store) ListBots(ctx context.Context, workspaceID, requesterID string) ([]store.BotWithTokens, error) {

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -1332,4 +1332,5 @@ type Store interface {
 	CreateDesktopOAuthGrant(ctx context.Context, grant DesktopOAuthGrant) error
 	ConsumeDesktopOAuthGrant(ctx context.Context, grantHash, desktopChallenge string, now time.Time) (Session, error)
 	GetBotTokenAuth(ctx context.Context, token string) (BotTokenAuth, error)
+	RecordBotTokenUse(ctx context.Context, tokenID string) error
 }

--- a/docs/features/bots.md
+++ b/docs/features/bots.md
@@ -125,7 +125,8 @@ Rules:
   changes are not applied retroactively; rotate or mint a token to gain a newly
   added scope such as `commands:write`.
 - Revoked tokens fail auth.
-- Tokens update `last_used_at` after successful auth.
+- Tokens update `last_used_at` after successful request authentication, including
+  a WebSocket handshake. Rechecking an established socket does not update it.
 - Tokens are workspace-scoped. A token cannot access another workspace even if
   the bot user is later added there.
 - A bot may have multiple tokens for different runtimes.

--- a/docs/features/realtime.md
+++ b/docs/features/realtime.md
@@ -43,9 +43,13 @@ POST /api/realtime/ephemeral
   authenticated with: a password change or a sign-out that revokes it closes
   the socket with `1008` rather than letting an already-open connection keep
   receiving. That check reads the store, so it holds across replicas, and an
-  idle connection repeats it on a timer. A temporary session-store failure closes
-  with retryable code `1013`; HTTP session checks return `503`, preserving the
-  session so clients can reconnect after recovery. The output-only socket handles ping,
+  idle connection repeats it on a timer. Bot connections revalidate their exact
+  bearer credential through the same delivery and idle checks. Revoking a token
+  or replacing its secret during setup closes the old socket with `1008`; the
+  replacement credential can reconnect normally, even when its token ID is unchanged.
+  Temporary credential-store failures close the socket with retryable code `1013`;
+  HTTP session checks return `503`, preserving the session so clients can reconnect
+  after recovery. The output-only socket handles ping,
   pong, and close frames and releases its subscription on peer disconnect;
   clients send ephemeral input through HTTP.
 - `GET /events` exposes durable replay in pull form. User-private durable


### PR DESCRIPTION
Revoking a bot token now ends its existing realtime connection, and replaying bot setup with the same nonce also retires connections using the replaced secret. Previously HTTP authentication rejected the old credential while its already-open socket could continue receiving events.

The WebSocket delivery owner now runs the existing bot credential lookup alongside its session check before replay, before each event, and on the idle timer. It validates the exact bearer credential because setup replay can rotate the secret without changing the token row ID. This replaces the bot-token exemption in the existing lifecycle; it adds no schema, configuration, protocol, or separate revocation registry. Temporary lookup failures close with retryable code 1013, while revoked/replaced credentials close with 1008. Credential lookup is now read-only; successful ingress authentication records last-use metadata once through the existing SQLC update. This avoids one metadata write per replayed event or idle recheck while preserving HTTP and WebSocket-handshake usage recording.

Validation:
- Six regression scenarios fail against the prior code: durable delivery, ephemeral delivery, idle revocation, same-row secret replacement, revocation during replay visibility lookup, and temporary credential-store failure.
- The realtime test suite covers the fix alongside session revocation, replay ordering, visibility, resync, overflow, and connection control behavior.
- Real Go server plus native WebSocket probes reproduced continued delivery before the fix; after the fix, both explicit revocation and secret replacement return HTTP 401 and close the original socket with 1008 without delivering the subsequent event.
- A regression test verifies that event delivery leaves last-use metadata unchanged while a fresh authenticated HTTP request advances it; it fails before separating usage recording from validation.
- Independent Codex review and formatting/diff checks.

Production delta: +15 lines, extending the existing authorization check to a previously exempt credential type. Tests: +218 lines. The SQLite and PostgreSQL credential implementations remain the authority, including membership and current-secret checks. The live proof used SQLite; PostgreSQL uses the same HTTP owner and its existing credential contract.

The review's no-touch validation finding is addressed in `78c4b986`: the existing SQLC authentication query is reused unchanged in both backends, while `RecordBotTokenUse` runs only at request admission. No second validation query or authentication policy was added.

<details>
<summary>Real-server runtime observations on 78c4b986</summary>

Built the Go server from this head, started it on loopback with synthetic SQLite data and development bootstrap, and connected using Node's native WebSocket implementation. Each case created a bot through the real API, verified a positive-control message, invalidated the credential through the real API, checked HTTP authentication, then sent another real channel message. No mocked WebSocket or store was involved. Credential values and synthetic identifiers are omitted.

Explicit token revocation:

```json
{
  "head": "78c4b9864833a574cf9cbf580888abd0e651955c",
  "deliveredBefore": true,
  "revokedPersisted": true,
  "revokedHttpStatus": 401,
  "deliveredAfterRevocation": false,
  "closed": {
    "code": 1008,
    "reason": "bot token revoked; reconnect with a valid token"
  }
}
```

Setup replay replaces the secret in the same row:

```json
{
  "head": "78c4b9864833a574cf9cbf580888abd0e651955c",
  "deliveredBefore": true,
  "sameTokenRow": true,
  "replacedCredential": true,
  "revokedHttpStatus": 401,
  "deliveredAfterRevocation": false,
  "closed": {
    "code": 1008,
    "reason": "bot token revoked; reconnect with a valid token"
  },
  "replacementDelivered": true
}
```

Both corresponding runs on main `381863ea` returned HTTP 401 but recorded `deliveredAfterRevocation: true` and no socket close. The replacement run above also opened a fresh socket with the new credential and received a subsequent message.

Local realtime suite: PASS (287.474s). After splitting usage recording, focused HTTP and SQLite bot tests: PASS; PostgreSQL package compiled and its environment-gated integration cases are left to CI. The new usage test fails on the initial candidate and passes after the split.

</details>
