### PR TITLE
chore(cloudflare): roll prod container to prod-20260901-keystroke

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,7 +12,7 @@
   ],
   "vars": {
     "CLICKCLACK_PUBLIC_URL": "https://app.clickclack.chat",
-    "CLICKCLACK_CONTAINER_NAME": "prod-20260818-openclaw-id",
+    "CLICKCLACK_CONTAINER_NAME": "prod-20260901-keystroke",
     "CLICKCLACK_GITHUB_MODERATOR_ORG": "openclaw",
     "CLICKCLACK_UPLOADS": "r2://clickclack-uploads/prod",
     "CLICKCLACK_R2_ACCOUNT_ID": "91b59577e757131d68d55a471fe32aca"


### PR DESCRIPTION
Forces a fresh Cloudflare container instance on the image carrying the Keystroke logo, product site makeover (#221), and v0.4.0 (#228). The running instance is never replaced while it has traffic, so the container name is bumped per the deploy runbook.

Deployed 2026-09-02 from a clean origin/main checkout at e9bfe8ce: Worker version 1ae9d9e7, image sha256:90b5c645…, build entry/app.llo5J1Mx.js verified identical on clickclack.chat, www, app, and workers.dev; container health clean.