### PR TITLE
chore(cloudflare): roll prod container to prod-20260903-mobile-drawer

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -12,7 +12,7 @@
   ],
   "vars": {
     "CLICKCLACK_PUBLIC_URL": "https://app.clickclack.chat",
-    "CLICKCLACK_CONTAINER_NAME": "prod-20260901-keystroke",
+    "CLICKCLACK_CONTAINER_NAME": "prod-20260903-mobile-drawer",
     "CLICKCLACK_GITHUB_MODERATOR_ORG": "openclaw",
     "CLICKCLACK_UPLOADS": "r2://clickclack-uploads/prod",
     "CLICKCLACK_R2_ACCOUNT_ID": "91b59577e757131d68d55a471fe32aca"


### PR DESCRIPTION
Forces a fresh Cloudflare container instance on the image carrying the
mobile thread drawer fixes (#230) on top of v0.4.0. The running instance
is never replaced while it has traffic, so the container name is bumped
per the deploy runbook.
