### PR TITLE
fix(api): decode reaction removal paths exactly once

### DIFF
--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -1307,10 +1307,14 @@ func (s *Server) removeReaction(w http.ResponseWriter, r *http.Request) {
 	if _, ok := s.requireBotMessageResource(w, r, act, chi.URLParam(r, "message_id"), "dms:write"); !ok {
 		return
 	}
-	emoji, err := url.PathUnescape(chi.URLParam(r, "emoji"))
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err)
-		return
+	emoji := chi.URLParam(r, "emoji")
+	// Chi routes on RawPath when present; otherwise the parameter is already decoded.
+	if r.URL.RawPath != "" {
+		emoji, err = url.PathUnescape(emoji)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
 	}
 	event, err := s.store.RemoveReaction(r.Context(), store.CreateReactionInput{MessageID: chi.URLParam(r, "message_id"), UserID: act.user.ID, Emoji: emoji})
 	if err == nil && event.ID != "" {

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -285,6 +285,23 @@ func TestChatAPIVerticalSlice(t *testing.T) {
 	if removedSlashReaction.Event.Type != "reaction.removed" || len(removedSlashReaction.Reactions) != 0 {
 		t.Fatalf("slash reaction was not removed: %#v", removedSlashReaction)
 	}
+	for _, emoji := range []string{"%", "%2F", "%25", "100%", "%/", "👀", "eyes"} {
+		t.Run("reaction round trip "+emoji, func(t *testing.T) {
+			message := postJSON[struct {
+				Message store.Message `json:"message"`
+			}](t, server.URL+"/api/channels/"+channel.ID+"/messages", map[string]string{"body": "reaction path proof"})
+			endpoint := server.URL + "/api/messages/" + message.Message.ID + "/reactions"
+			postJSON[struct{}](t, endpoint, map[string]string{"emoji": emoji})
+			removed := deleteJSONAsUser[struct {
+				Event     store.Event             `json:"event"`
+				Reactions []store.ReactionSummary `json:"reactions"`
+			}](t, owner.ID, endpoint+"/"+url.PathEscape(emoji))
+			payload, ok := removed.Event.Payload.(map[string]any)
+			if removed.Event.Type != "reaction.removed" || !ok || payload["emoji"] != emoji || len(removed.Reactions) != 0 {
+				t.Fatalf("reaction %q was not removed exactly: %#v", emoji, removed)
+			}
+		})
+	}
 
 	dm := postJSON[struct {
 		Conversation store.DirectConversation `json:"conversation"`

--- a/docs/features/reactions.md
+++ b/docs/features/reactions.md
@@ -15,7 +15,7 @@ POST   /api/messages/{message_id}/reactions
 DELETE /api/messages/{message_id}/reactions/{emoji}
 ```
 
-`POST` body: `{emoji}`. Both endpoints require workspace membership for the
+`POST` body: `{"emoji":"👀"}`. Both endpoints require workspace membership for the
 message's workspace. Adding twice is a no-op that returns HTTP 200 without an
 event; removing a missing reaction is a no-op. Mutation responses include an
 event object and the message's complete aggregated reaction summaries. The
@@ -25,7 +25,7 @@ response shape.
 Message reads expose reactions as per-emoji summaries:
 
 ```json
-{"emoji":"lobster","count":3,"reacted_by_me":true}
+{"emoji":"🦞","count":3,"reacted_by_me":true}
 ```
 
 The API does not include the individual reacting users in message payloads.
@@ -48,7 +48,11 @@ fresh snapshot page; ordinary pages preserve newer realtime state.
 
 ## Storage
 
-Reactions are stored verbatim — there's no allowlist or canonical shortcode
-table. Pass any string the UI is willing to render. Crustacean reactions like
-`:lobster:` and `:claw:` are intended in the reaction pack but not enforced
-server-side.
+Reactions are stored and compared as exact strings; there is no allowlist or
+shortcode conversion. Bots should send the same Unicode glyph as the web picker
+(for example, `👀`, `👍`, or `🦞`) to share its reaction count. `eyes`, `:eyes:`, and
+`👀` are three separate reactions, and custom strings render literally.
+
+To remove a reaction, URL-encode its exact string once as a path segment. For
+example, `%` becomes `%25`, `/` becomes `%2F`, and the literal string `%2F`
+becomes `%252F`. The SDK handles this encoding in `removeReaction`.


### PR DESCRIPTION
Removing a literal `%` reaction returned HTTP 400, while strings such as `%2F` silently targeted a different key. Chi routes on Go's decoded `URL.Path` unless `RawPath` is present; the handler unconditionally decoded the parameter a second time. Decode only the raw-path case so removal preserves the exact stored key.

Also clarify the existing reaction contract: bots should send picker glyphs to share counts; custom strings remain distinct and render literally. This takes the compatibility-preserving documentation option offered in #229 and fixes its reproduced percent-path bug. Thanks @isaiahknight-va for the report.

Validation: four new round-trip cases fail on main; all seven new cases plus the existing slash case pass after the fix. The full HTTP API package passes. A built server passed eight real HTTP add/remove round trips (`%`, `%2F`, `%25`, `100%`, `%/`, `/`, `👀`, `eyes`), preserving the exact event key and leaving no reaction. Real Chrome showed the baseline error when removing `%`; the fixed binary removed the same user's reaction and decremented the count. Independent P0–P2 autoreview is clean.

Changelog entry is reserved for the final phase-three notes/dependencies PR to avoid sibling conflicts.

Fixes #229.
