### PR TITLE
test(cli): avoid pipe backpressure in stdout capture

### DIFF
--- a/apps/api/cmd/clickclack/reactions_test.go
+++ b/apps/api/cmd/clickclack/reactions_test.go
@@ -280,28 +280,37 @@ func TestReactionCommandsUseCurrentClientErrors(t *testing.T) {
 func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 	oldStdout := os.Stdout
-	read, write, err := os.Pipe()
+	outputFile, err := os.CreateTemp(t.TempDir(), "stdout")
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = write
-	t.Cleanup(func() { os.Stdout = oldStdout })
+	os.Stdout = outputFile
+	defer func() {
+		os.Stdout = oldStdout
+		_ = outputFile.Close()
+	}()
 	if err := fn(); err != nil {
-		_ = write.Close()
 		t.Fatal(err)
 	}
-	if err := write.Close(); err != nil {
+	if _, err := outputFile.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
-	os.Stdout = oldStdout
-	output, err := io.ReadAll(read)
+	output, err := io.ReadAll(outputFile)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := read.Close(); err != nil {
 		t.Fatal(err)
 	}
 	return string(output)
+}
+
+func TestCaptureStdoutHandlesLargeOutput(t *testing.T) {
+	want := strings.Repeat("large output\n", 1<<16)
+	got := captureStdout(t, func() error {
+		_, err := io.WriteString(os.Stdout, want)
+		return err
+	})
+	if got != want {
+		t.Fatalf("captured %d bytes, want %d", len(got), len(want))
+	}
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)


### PR DESCRIPTION
CLI tests captured stdout in an OS pipe but did not read the pipe until the command returned. Once JSON output filled the pipe, the command could not return. On macOS the existing status-selection test stalled for minutes inside `json.Encoder.Encode`; the full check could not finish.

Capture output in a private test-owned temporary file, rewind it after the callback, and restore stdout and close the file with a defer. This removes the bounded pipe buffer and restores stdout even when the callback exits through a fatal test failure. A regression captures 851,968 bytes; the old helper times out and the new helper returns every byte.

Validation: the complete CLI package passes in 3.7 seconds; the old-helper regression times out under a three-second limit; a real built CLI successfully runs `status --json` against a live local server. Independent P0–P2 review is clean. Production code and dependencies are unchanged. This is independent of the runtime dependency PR and should merge before its local-check verification.
