### PR TITLE
test(authpolicy): cover cookie-name and public-URL validation branches

### DIFF
--- a/apps/api/internal/authpolicy/policy_test.go
+++ b/apps/api/internal/authpolicy/policy_test.go
@@ -28,6 +28,7 @@ func TestCanonicalPublicURL(t *testing.T) {
 		"http://localhost:8080/":         "http://localhost:8080",
 		"http://127.0.0.1:8080":          "http://127.0.0.1:8080",
 		"http://[::1]:8080":              "http://[::1]:8080",
+		"https://[::1]":                  "https://[::1]",
 	} {
 		got, err := CanonicalPublicURL(input)
 		if err != nil {
@@ -48,6 +49,7 @@ func TestCanonicalPublicURL(t *testing.T) {
 		"https://chat.example.com.",
 		"https://chat.example.com:0",
 		"https://chat.example.com:65536",
+		"https://chat.example.com/%",
 	} {
 		if _, err := CanonicalPublicURL(value); err == nil {
 			t.Fatalf("expected %q to be invalid", value)
@@ -118,7 +120,25 @@ func TestNewCookieNames(t *testing.T) {
 	if loopback.Session != "cc-dev-session" || loopback.OAuthBinding != "cc-dev-oauth-binding" || !loopback.Namespaced {
 		t.Fatalf("unexpected loopback names: %#v", loopback)
 	}
-	if _, err := NewCookieNames("prod", "", ""); err == nil {
-		t.Fatal("expected namespaced cookies without a public URL to fail")
+	fallback, err := NewCookieNames("prod", "https://chat.example.com", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fallback.Session != "__Host-cc-prod-session" || fallback.OAuthBinding != "__Host-cc-prod-oauth-binding" || !fallback.Namespaced {
+		t.Fatalf("unexpected fallback names: %#v", fallback)
+	}
+	for _, invalid := range []struct {
+		namespace    string
+		publicURL    string
+		publicAPIURL string
+	}{
+		{"prod", "", ""},
+		{"Prod", "https://chat.example.com", "https://api.example.com"},
+		{"prod", "ftp://chat.example.com", ""},
+		{"prod", "https://chat.example.com", "http://api.example.com"},
+	} {
+		if _, err := NewCookieNames(invalid.namespace, invalid.publicURL, invalid.publicAPIURL); err == nil {
+			t.Fatalf("expected %+v to be invalid", invalid)
+		}
 	}
 }


### PR DESCRIPTION
## What Problem This Solves

Cookie-namespace and public-URL validation had uncovered rejection and boundary cases, including an omitted API URL and bracketed IPv6 origins.

## User Impact

No runtime behavior change. The existing security rules now have focused regression coverage.

## Why This Change Was Made

Add cases to the existing tables and retain the original missing-public-URL assertion. The API URL fallback must keep secure cookie prefixes, and malformed origins and namespaces must fail.

## Evidence

- Isolated Codex review: scoped-clean at P0–P2.
- `go test ./apps/api/internal/authpolicy -cover`: passed, 99.0% statement coverage.
- Rebased onto the completed dependency/CI follow-up; the contributor's test file is byte-identical to the original PR head.
- Built and ran the actual server with an invalid cookie namespace: startup rejected it before listening, with the expected namespace validation error.
