### PR TITLE
refactor(store): share nonce and profile validation

### DIFF
--- a/apps/api/internal/httpapi/messages.go
+++ b/apps/api/internal/httpapi/messages.go
@@ -159,7 +159,7 @@ func (s *Server) getMessageByNonce(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("workspace_id is required"))
 		return
 	}
-	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
+	nonce, err := store.NormalizeClientNonce(r.URL.Query().Get("nonce"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return

--- a/apps/api/internal/httpapi/server_test.go
+++ b/apps/api/internal/httpapi/server_test.go
@@ -3119,16 +3119,16 @@ func TestNormalizeClientNonceCountsCharacters(t *testing.T) {
 	t.Parallel()
 
 	valid := strings.Repeat("é", 128)
-	if normalized, err := normalizeClientNonce(valid); err != nil || normalized != valid {
+	if normalized, err := store.NormalizeClientNonce(valid); err != nil || normalized != valid {
 		t.Fatalf("expected 128-character nonce to remain valid: normalized=%q err=%v", normalized, err)
 	}
-	if _, err := normalizeClientNonce(strings.Repeat("é", 129)); err == nil {
+	if _, err := store.NormalizeClientNonce(strings.Repeat("é", 129)); err == nil {
 		t.Fatal("expected 129-character nonce rejection")
 	}
-	if _, err := normalizeClientNonce(string([]byte{0xff})); err == nil {
+	if _, err := store.NormalizeClientNonce(string([]byte{0xff})); err == nil {
 		t.Fatal("expected invalid UTF-8 nonce rejection")
 	}
-	if _, err := normalizeClientNonce("invalid\x00nonce"); err == nil {
+	if _, err := store.NormalizeClientNonce("invalid\x00nonce"); err == nil {
 		t.Fatal("expected NUL nonce rejection")
 	}
 }

--- a/apps/api/internal/httpapi/uploads.go
+++ b/apps/api/internal/httpapi/uploads.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -47,7 +46,7 @@ func (s *Server) createUpload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusForbidden, err)
 		return
 	}
-	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
+	nonce, err := store.NormalizeClientNonce(r.URL.Query().Get("nonce"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return
@@ -307,20 +306,6 @@ func (s *Server) authorizeWorkspaceAccess(w http.ResponseWriter, r *http.Request
 	return true
 }
 
-func normalizeClientNonce(value string) (string, error) {
-	nonce := strings.TrimSpace(value)
-	if !utf8.ValidString(nonce) {
-		return "", errors.New("nonce must be valid UTF-8")
-	}
-	if strings.IndexByte(nonce, 0) >= 0 {
-		return "", errors.New("nonce must not contain NUL")
-	}
-	if utf8.RuneCountInString(nonce) > 128 {
-		return "", errors.New("nonce is too long")
-	}
-	return nonce, nil
-}
-
 func writeUploadBodyError(w http.ResponseWriter, err error, fallbackStatus int) {
 	if errors.Is(err, store.ErrUploadQuotaExceeded) {
 		writeStoreError(w, err)
@@ -350,7 +335,7 @@ func (s *Server) getUploadByNonce(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, errors.New("workspace_id is required"))
 		return
 	}
-	nonce, err := normalizeClientNonce(r.URL.Query().Get("nonce"))
+	nonce, err := store.NormalizeClientNonce(r.URL.Query().Get("nonce"))
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
 		return

--- a/apps/api/internal/store/input_validation.go
+++ b/apps/api/internal/store/input_validation.go
@@ -1,0 +1,102 @@
+package store
+
+import (
+	"errors"
+	"net/url"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+var handlePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{1,31}$`)
+
+func NormalizeClientNonce(value string) (string, error) {
+	nonce := strings.TrimSpace(value)
+	if !utf8.ValidString(nonce) {
+		return "", errors.New("nonce must be valid UTF-8")
+	}
+	if strings.IndexByte(nonce, 0) >= 0 {
+		return "", errors.New("nonce must not contain NUL")
+	}
+	if utf8.RuneCountInString(nonce) > 128 {
+		return "", errors.New("nonce is too long")
+	}
+	return nonce, nil
+}
+
+func NormalizeHandle(value string) (string, error) {
+	handle := strings.ToLower(strings.TrimSpace(value))
+	handle = strings.TrimPrefix(handle, "@")
+	if handle == "" {
+		return "", nil
+	}
+	if !handlePattern.MatchString(handle) {
+		return "", errors.New("handle must be 2-32 chars using letters, numbers, underscores, or dashes")
+	}
+	return handle, nil
+}
+
+func NormalizeAvatarURL(value string) (string, error) {
+	avatarURL := strings.TrimSpace(value)
+	if avatarURL == "" {
+		return "", nil
+	}
+	if len(avatarURL) > 500 {
+		return "", errors.New("avatar_url is too long")
+	}
+	parsed, err := url.Parse(avatarURL)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
+		return "", errors.New("avatar_url must be an http or https URL")
+	}
+	return avatarURL, nil
+}
+
+func NormalizeUserProfilePatch(displayNameInput, handleInput, avatarURLInput *string) (*string, *string, *string, error) {
+	var displayName *string
+	if displayNameInput != nil {
+		normalized := strings.TrimSpace(*displayNameInput)
+		if normalized == "" {
+			return nil, nil, nil, errors.New("display_name is required")
+		}
+		if len(normalized) > 80 {
+			return nil, nil, nil, errors.New("display_name is too long")
+		}
+		displayName = &normalized
+	}
+	var handle *string
+	if handleInput != nil {
+		normalized, err := NormalizeHandle(*handleInput)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		handle = &normalized
+	}
+	var avatarURL *string
+	if avatarURLInput != nil {
+		normalized, err := NormalizeAvatarURL(*avatarURLInput)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		avatarURL = &normalized
+	}
+	return displayName, handle, avatarURL, nil
+}
+
+func NormalizeUserProfile(displayNameInput, handleInput, avatarURLInput string) (string, string, string, error) {
+	displayName := strings.TrimSpace(displayNameInput)
+	if displayName == "" {
+		return "", "", "", errors.New("display_name is required")
+	}
+	if len(displayName) > 80 {
+		return "", "", "", errors.New("display_name is too long")
+	}
+	handle, err := NormalizeHandle(handleInput)
+	if err != nil {
+		return "", "", "", err
+	}
+	avatarURL, err := NormalizeAvatarURL(avatarURLInput)
+	if err != nil {
+		return "", "", "", err
+	}
+	return displayName, handle, avatarURL, nil
+}

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -133,11 +133,11 @@ func (s *Store) CreateBot(ctx context.Context, input store.CreateBotInput) (stor
 	if len(displayName) > 80 {
 		return store.User{}, store.BotToken{}, errors.New("display_name is too long")
 	}
-	handle, err := normalizeHandle(input.Handle)
+	handle, err := store.NormalizeHandle(input.Handle)
 	if err != nil {
 		return store.User{}, store.BotToken{}, err
 	}
-	avatarURL, err := normalizeAvatarURL(input.AvatarURL)
+	avatarURL, err := store.NormalizeAvatarURL(input.AvatarURL)
 	if err != nil {
 		return store.User{}, store.BotToken{}, err
 	}
@@ -1006,7 +1006,7 @@ func normalizeBotScopes(values []string) ([]string, error) {
 }
 
 func normalizeSetupNonce(value string) (string, error) {
-	nonce, err := normalizeClientNonce(value)
+	nonce, err := store.NormalizeClientNonce(value)
 	if err != nil {
 		return "", err
 	}

--- a/apps/api/internal/store/postgres/dms.go
+++ b/apps/api/internal/store/postgres/dms.go
@@ -247,7 +247,7 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	if body == "" {
 		return store.Message{}, store.Event{}, errors.New("message body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -6,13 +6,11 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"net/url"
 	"regexp"
 	"slices"
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
@@ -138,20 +136,6 @@ func scanMessage(row scanner) (store.Message, error) {
 	return m, nil
 }
 
-func normalizeClientNonce(value string) (string, error) {
-	nonce := strings.TrimSpace(value)
-	if !utf8.ValidString(nonce) {
-		return "", errors.New("nonce must be valid UTF-8")
-	}
-	if strings.IndexByte(nonce, 0) >= 0 {
-		return "", errors.New("nonce must not contain NUL")
-	}
-	if utf8.RuneCountInString(nonce) > 128 {
-		return "", errors.New("nonce is too long")
-	}
-	return nonce, nil
-}
-
 func getMessageByClientNonceTx(ctx context.Context, tx *sql.Tx, authorID, nonce string) (store.Message, error) {
 	if nonce == "" {
 		return store.Message{}, sql.ErrNoRows
@@ -164,35 +148,6 @@ func sameQuotedMessageID(message store.Message, quotedID string) bool {
 		return message.QuotedMessageID == nil || *message.QuotedMessageID == ""
 	}
 	return message.QuotedMessageID != nil && *message.QuotedMessageID == quotedID
-}
-
-var handlePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{1,31}$`)
-
-func normalizeHandle(value string) (string, error) {
-	handle := strings.ToLower(strings.TrimSpace(value))
-	handle = strings.TrimPrefix(handle, "@")
-	if handle == "" {
-		return "", nil
-	}
-	if !handlePattern.MatchString(handle) {
-		return "", errors.New("handle must be 2-32 chars using letters, numbers, underscores, or dashes")
-	}
-	return handle, nil
-}
-
-func normalizeAvatarURL(value string) (string, error) {
-	avatarURL := strings.TrimSpace(value)
-	if avatarURL == "" {
-		return "", nil
-	}
-	if len(avatarURL) > 500 {
-		return "", errors.New("avatar_url is too long")
-	}
-	parsed, err := url.Parse(avatarURL)
-	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
-		return "", errors.New("avatar_url must be an http or https URL")
-	}
-	return avatarURL, nil
 }
 
 func resolveProfileAvatarURL(ctx context.Context, q *storedb.Queries, userID, avatarURL string) (string, error) {

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -216,7 +216,7 @@ func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, e
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
-	displayName, handle, avatarURL, err := normalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
+	displayName, handle, avatarURL, err := store.NormalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {
 		return store.User{}, err
 	}
@@ -259,7 +259,7 @@ func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserPro
 }
 
 func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrentUserInput) (store.CurrentUserState, error) {
-	displayName, handle, avatarURL, err := normalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
+	displayName, handle, avatarURL, err := store.NormalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {
 		return store.CurrentUserState{}, err
 	}
@@ -365,56 +365,6 @@ func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrent
 		return store.CurrentUserState{}, err
 	}
 	return store.CurrentUserState{User: user, AppearancePreferences: preferences}, nil
-}
-
-func normalizeUserProfilePatch(displayNameInput, handleInput, avatarURLInput *string) (*string, *string, *string, error) {
-	var displayName *string
-	if displayNameInput != nil {
-		normalized := strings.TrimSpace(*displayNameInput)
-		if normalized == "" {
-			return nil, nil, nil, errors.New("display_name is required")
-		}
-		if len(normalized) > 80 {
-			return nil, nil, nil, errors.New("display_name is too long")
-		}
-		displayName = &normalized
-	}
-	var handle *string
-	if handleInput != nil {
-		normalized, err := normalizeHandle(*handleInput)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		handle = &normalized
-	}
-	var avatarURL *string
-	if avatarURLInput != nil {
-		normalized, err := normalizeAvatarURL(*avatarURLInput)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		avatarURL = &normalized
-	}
-	return displayName, handle, avatarURL, nil
-}
-
-func normalizeUserProfile(displayNameInput, handleInput, avatarURLInput string) (string, string, string, error) {
-	displayName := strings.TrimSpace(displayNameInput)
-	if displayName == "" {
-		return "", "", "", errors.New("display_name is required")
-	}
-	if len(displayName) > 80 {
-		return "", "", "", errors.New("display_name is too long")
-	}
-	handle, err := normalizeHandle(handleInput)
-	if err != nil {
-		return "", "", "", err
-	}
-	avatarURL, err := normalizeAvatarURL(avatarURLInput)
-	if err != nil {
-		return "", "", "", err
-	}
-	return displayName, handle, avatarURL, nil
 }
 
 func profileUpdateError(err error) error {
@@ -649,7 +599,7 @@ func (s *Store) GetMessage(ctx context.Context, messageID, userID string) (store
 }
 
 func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (store.Message, error) {
-	normalized, err := normalizeClientNonce(nonce)
+	normalized, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.Message{}, err
 	}
@@ -710,7 +660,7 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 	if body == "" {
 		return store.Message{}, store.Event{}, errors.New("message body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}
@@ -849,7 +799,7 @@ func (s *Store) CreateThreadReply(ctx context.Context, input store.CreateThreadR
 	if body == "" {
 		return store.Message{}, store.ThreadState{}, nil, errors.New("reply body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.ThreadState{}, nil, err
 	}

--- a/apps/api/internal/store/postgres/postgres_test.go
+++ b/apps/api/internal/store/postgres/postgres_test.go
@@ -392,7 +392,7 @@ func TestNormalizeClientNonceRejectsDatabaseInvalidText(t *testing.T) {
 	t.Parallel()
 
 	for _, nonce := range []string{string([]byte{0xff}), "invalid\x00nonce"} {
-		if _, err := normalizeClientNonce(nonce); err == nil {
+		if _, err := store.NormalizeClientNonce(nonce); err == nil {
 			t.Fatalf("expected database-invalid nonce rejection for %q", nonce)
 		}
 	}

--- a/apps/api/internal/store/postgres/uploads.go
+++ b/apps/api/internal/store/postgres/uploads.go
@@ -14,7 +14,7 @@ import (
 const uploadQuotaReservationTTL = 15 * time.Minute
 
 func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
-	normalizedNonce, err := normalizeClientNonce(nonce)
+	normalizedNonce, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
@@ -104,7 +104,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, non
 }
 
 func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, input store.CreateUploadInput) (store.Upload, error) {
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Upload{}, err
 	}
@@ -281,7 +281,7 @@ func (s *Store) GetUpload(ctx context.Context, uploadID, userID string) (store.U
 }
 
 func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (store.Upload, error) {
-	normalized, err := normalizeClientNonce(nonce)
+	normalized, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.Upload{}, err
 	}

--- a/apps/api/internal/store/sqlite/bots.go
+++ b/apps/api/internal/store/sqlite/bots.go
@@ -92,11 +92,11 @@ func (s *Store) CreateBot(ctx context.Context, input store.CreateBotInput) (stor
 	if len(displayName) > 80 {
 		return store.User{}, store.BotToken{}, errors.New("display_name is too long")
 	}
-	handle, err := normalizeHandle(input.Handle)
+	handle, err := store.NormalizeHandle(input.Handle)
 	if err != nil {
 		return store.User{}, store.BotToken{}, err
 	}
-	avatarURL, err := normalizeAvatarURL(input.AvatarURL)
+	avatarURL, err := store.NormalizeAvatarURL(input.AvatarURL)
 	if err != nil {
 		return store.User{}, store.BotToken{}, err
 	}
@@ -952,7 +952,7 @@ func normalizeBotScopes(values []string) ([]string, error) {
 }
 
 func normalizeSetupNonce(value string) (string, error) {
-	nonce, err := normalizeClientNonce(value)
+	nonce, err := store.NormalizeClientNonce(value)
 	if err != nil {
 		return "", err
 	}

--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -247,7 +247,7 @@ func (s *Store) CreateDirectMessage(ctx context.Context, input store.CreateDirec
 	if body == "" {
 		return store.Message{}, store.Event{}, errors.New("message body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -6,12 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"net/url"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
-	"unicode/utf8"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/openclaw/clickclack/apps/api/internal/requestmeta"
@@ -137,20 +135,6 @@ func scanMessage(row scanner) (store.Message, error) {
 	return m, nil
 }
 
-func normalizeClientNonce(value string) (string, error) {
-	nonce := strings.TrimSpace(value)
-	if !utf8.ValidString(nonce) {
-		return "", errors.New("nonce must be valid UTF-8")
-	}
-	if strings.IndexByte(nonce, 0) >= 0 {
-		return "", errors.New("nonce must not contain NUL")
-	}
-	if utf8.RuneCountInString(nonce) > 128 {
-		return "", errors.New("nonce is too long")
-	}
-	return nonce, nil
-}
-
 func getMessageByClientNonceTx(ctx context.Context, tx *sql.Tx, authorID, nonce string) (store.Message, error) {
 	if nonce == "" {
 		return store.Message{}, sql.ErrNoRows
@@ -163,35 +147,6 @@ func sameQuotedMessageID(message store.Message, quotedID string) bool {
 		return message.QuotedMessageID == nil || *message.QuotedMessageID == ""
 	}
 	return message.QuotedMessageID != nil && *message.QuotedMessageID == quotedID
-}
-
-var handlePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]{1,31}$`)
-
-func normalizeHandle(value string) (string, error) {
-	handle := strings.ToLower(strings.TrimSpace(value))
-	handle = strings.TrimPrefix(handle, "@")
-	if handle == "" {
-		return "", nil
-	}
-	if !handlePattern.MatchString(handle) {
-		return "", errors.New("handle must be 2-32 chars using letters, numbers, underscores, or dashes")
-	}
-	return handle, nil
-}
-
-func normalizeAvatarURL(value string) (string, error) {
-	avatarURL := strings.TrimSpace(value)
-	if avatarURL == "" {
-		return "", nil
-	}
-	if len(avatarURL) > 500 {
-		return "", errors.New("avatar_url is too long")
-	}
-	parsed, err := url.Parse(avatarURL)
-	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") || parsed.Host == "" {
-		return "", errors.New("avatar_url must be an http or https URL")
-	}
-	return avatarURL, nil
 }
 
 func resolveProfileAvatarURL(ctx context.Context, q *storedb.Queries, userID, avatarURL string) (string, error) {

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -230,7 +230,7 @@ func (s *Store) GetUserByEmail(ctx context.Context, email string) (store.User, e
 }
 
 func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserProfileInput) (store.User, error) {
-	displayName, handle, avatarURL, err := normalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
+	displayName, handle, avatarURL, err := store.NormalizeUserProfile(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {
 		return store.User{}, err
 	}
@@ -273,7 +273,7 @@ func (s *Store) UpdateUserProfile(ctx context.Context, input store.UpdateUserPro
 }
 
 func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrentUserInput) (store.CurrentUserState, error) {
-	displayName, handle, avatarURL, err := normalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
+	displayName, handle, avatarURL, err := store.NormalizeUserProfilePatch(input.DisplayName, input.Handle, input.AvatarURL)
 	if err != nil {
 		return store.CurrentUserState{}, err
 	}
@@ -379,56 +379,6 @@ func (s *Store) UpdateCurrentUser(ctx context.Context, input store.UpdateCurrent
 		return store.CurrentUserState{}, err
 	}
 	return store.CurrentUserState{User: user, AppearancePreferences: preferences}, nil
-}
-
-func normalizeUserProfilePatch(displayNameInput, handleInput, avatarURLInput *string) (*string, *string, *string, error) {
-	var displayName *string
-	if displayNameInput != nil {
-		normalized := strings.TrimSpace(*displayNameInput)
-		if normalized == "" {
-			return nil, nil, nil, errors.New("display_name is required")
-		}
-		if len(normalized) > 80 {
-			return nil, nil, nil, errors.New("display_name is too long")
-		}
-		displayName = &normalized
-	}
-	var handle *string
-	if handleInput != nil {
-		normalized, err := normalizeHandle(*handleInput)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		handle = &normalized
-	}
-	var avatarURL *string
-	if avatarURLInput != nil {
-		normalized, err := normalizeAvatarURL(*avatarURLInput)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		avatarURL = &normalized
-	}
-	return displayName, handle, avatarURL, nil
-}
-
-func normalizeUserProfile(displayNameInput, handleInput, avatarURLInput string) (string, string, string, error) {
-	displayName := strings.TrimSpace(displayNameInput)
-	if displayName == "" {
-		return "", "", "", errors.New("display_name is required")
-	}
-	if len(displayName) > 80 {
-		return "", "", "", errors.New("display_name is too long")
-	}
-	handle, err := normalizeHandle(handleInput)
-	if err != nil {
-		return "", "", "", err
-	}
-	avatarURL, err := normalizeAvatarURL(avatarURLInput)
-	if err != nil {
-		return "", "", "", err
-	}
-	return displayName, handle, avatarURL, nil
 }
 
 func profileUpdateError(err error) error {
@@ -663,7 +613,7 @@ func (s *Store) GetMessage(ctx context.Context, messageID, userID string) (store
 }
 
 func (s *Store) GetMessageByNonce(ctx context.Context, authorID, nonce string) (store.Message, error) {
-	normalized, err := normalizeClientNonce(nonce)
+	normalized, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.Message{}, err
 	}
@@ -724,7 +674,7 @@ func (s *Store) CreateMessage(ctx context.Context, input store.CreateMessageInpu
 	if body == "" {
 		return store.Message{}, store.Event{}, errors.New("message body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.Event{}, err
 	}
@@ -863,7 +813,7 @@ func (s *Store) CreateThreadReply(ctx context.Context, input store.CreateThreadR
 	if body == "" {
 		return store.Message{}, store.ThreadState{}, nil, errors.New("reply body is required")
 	}
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Message{}, store.ThreadState{}, nil, err
 	}

--- a/apps/api/internal/store/sqlite/uploads.go
+++ b/apps/api/internal/store/sqlite/uploads.go
@@ -14,7 +14,7 @@ import (
 const uploadQuotaReservationTTL = 15 * time.Minute
 
 func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, nonce string, byteSize int64) (store.UploadQuotaReservation, error) {
-	normalizedNonce, err := normalizeClientNonce(nonce)
+	normalizedNonce, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.UploadQuotaReservation{}, err
 	}
@@ -96,7 +96,7 @@ func (s *Store) ReserveUploadQuota(ctx context.Context, workspaceID, userID, non
 }
 
 func (s *Store) CreateReservedUpload(ctx context.Context, reservationID string, input store.CreateUploadInput) (store.Upload, error) {
-	nonce, err := normalizeClientNonce(input.Nonce)
+	nonce, err := store.NormalizeClientNonce(input.Nonce)
 	if err != nil {
 		return store.Upload{}, err
 	}
@@ -253,7 +253,7 @@ func (s *Store) GetUpload(ctx context.Context, uploadID, userID string) (store.U
 }
 
 func (s *Store) GetUploadByNonce(ctx context.Context, ownerID, nonce string) (store.Upload, error) {
-	normalized, err := normalizeClientNonce(nonce)
+	normalized, err := store.NormalizeClientNonce(nonce)
 	if err != nil {
 		return store.Upload{}, err
 	}


### PR DESCRIPTION
## What Problem This Solves

SQLite, Postgres, and the upload HTTP handlers separately implemented identical nonce and profile validation, so changes to accepted input could drift across storage backends.

## Why This Change Was Made

Share those pure rules in the internal store package and call them from the existing handlers and adapters. Validation order, error text, whitespace handling, optional patch fields, and byte/rune limits are preserved. Database transactions and authorization remain with their current owners.

## User Impact

No behavior or public API changes. Both storage backends use one implementation of the same input rules.

## Evidence

- Isolated Codex autoreview: scoped-clean at P0–P2.
- Extracted function bodies matched byte-for-byte before consolidation; existing nonce and profile tests remain in place.
- Built and ran the server against a fresh local SQLite database. Live requests created workspace/channel/message/reply/reaction records, read search and event replay, and served the SPA.
- A live profile update trimmed the display name and avatar URL, normalized `@Proof-Captain` to `proof-captain`, and rejected two invalid handles with HTTP 400.
- `go test ./apps/api/internal/store/... ./apps/api/internal/httpapi`: passed, including the existing nonce and profile tests.
- `git diff --check`: passed. All exact-head CI checks passed, including Go, TypeScript, Docker and Playwright: https://github.com/openclaw/clickclack/actions/runs/34726509162, plus CodeQL and all desktop platforms.
