### PR TITLE
refactor(api): use standard Go collection and error helpers

### DIFF
--- a/apps/api/internal/authpolicy/policy.go
+++ b/apps/api/internal/authpolicy/policy.go
@@ -165,7 +165,7 @@ func canonicalBasePath(value *url.URL) (string, error) {
 	if cleaned != trimmed || strings.Contains(value.Path, "//") {
 		return "", errors.New("public API URL base path must be normalized")
 	}
-	for _, segment := range strings.Split(strings.TrimPrefix(cleaned, "/"), "/") {
+	for segment := range strings.SplitSeq(strings.TrimPrefix(cleaned, "/"), "/") {
 		if segment == "" || segment == "." || segment == ".." {
 			return "", errors.New("public API URL base path must be normalized")
 		}

--- a/apps/api/internal/httpapi/access.go
+++ b/apps/api/internal/httpapi/access.go
@@ -258,7 +258,7 @@ func (j accessJWK) rsaPublicKey() (*rsa.PublicKey, error) {
 }
 
 func accessCacheExpiry(header http.Header, now time.Time) time.Time {
-	for _, directive := range strings.Split(header.Get("Cache-Control"), ",") {
+	for directive := range strings.SplitSeq(header.Get("Cache-Control"), ",") {
 		name, value, ok := strings.Cut(strings.TrimSpace(directive), "=")
 		if !ok || !strings.EqualFold(name, "max-age") {
 			continue

--- a/apps/api/internal/httpapi/access_log.go
+++ b/apps/api/internal/httpapi/access_log.go
@@ -60,7 +60,7 @@ type pathOnlyLogEntry struct {
 	mode    AccessLogMode
 }
 
-func (e *pathOnlyLogEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ interface{}) {
+func (e *pathOnlyLogEntry) Write(status, bytes int, _ http.Header, elapsed time.Duration, _ any) {
 	switch e.mode {
 	case AccessLogOff:
 		return
@@ -76,6 +76,6 @@ func (e *pathOnlyLogEntry) Write(status, bytes int, _ http.Header, elapsed time.
 	e.logger.Print(fmt.Sprintf("%sroute=%q status=%03d bytes=%d elapsed=%s", e.prefix, route, status, bytes, elapsed))
 }
 
-func (e *pathOnlyLogEntry) Panic(v interface{}, _ []byte) {
+func (e *pathOnlyLogEntry) Panic(v any, _ []byte) {
 	middleware.PrintPrettyStack(v)
 }

--- a/apps/api/internal/httpapi/actor.go
+++ b/apps/api/internal/httpapi/actor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/openclaw/clickclack/apps/api/internal/store"
@@ -97,10 +98,8 @@ func (a actor) requireScope(scope string) error {
 	if a.botTokenID == "" {
 		return nil
 	}
-	for _, candidate := range a.scopes {
-		if candidate == scope {
-			return nil
-		}
+	if slices.Contains(a.scopes, scope) {
+		return nil
 	}
 	return errors.New("bot token is missing scope " + scope)
 }

--- a/apps/api/internal/httpapi/auth.go
+++ b/apps/api/internal/httpapi/auth.go
@@ -433,7 +433,7 @@ func localDevBrowserOriginAllowed(r *http.Request) bool {
 
 func headerHostsAreLocal(values []string) bool {
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			if strings.TrimSpace(part) != "" && !isLocalHostPort(part) {
 				return false
 			}
@@ -444,8 +444,8 @@ func headerHostsAreLocal(values []string) bool {
 
 func forwardedHeaderIsLocal(values []string) bool {
 	for _, value := range values {
-		for _, hop := range strings.Split(value, ",") {
-			for _, field := range strings.Split(hop, ";") {
+		for hop := range strings.SplitSeq(value, ",") {
+			for field := range strings.SplitSeq(hop, ";") {
 				key, raw, ok := strings.Cut(strings.TrimSpace(field), "=")
 				if !ok {
 					continue

--- a/apps/api/internal/httpapi/origins.go
+++ b/apps/api/internal/httpapi/origins.go
@@ -81,7 +81,7 @@ func allowedCORSHeaders(value string) (string, bool) {
 		return "", true
 	}
 	var allowed []string
-	for _, header := range strings.Split(value, ",") {
+	for header := range strings.SplitSeq(value, ",") {
 		header = strings.ToLower(strings.TrimSpace(header))
 		if _, ok := corsHeaders[header]; !ok {
 			return "", false

--- a/apps/api/internal/httpapi/realtime.go
+++ b/apps/api/internal/httpapi/realtime.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -247,7 +248,7 @@ func (s *Server) websocket(w http.ResponseWriter, r *http.Request) {
 }
 
 func websocketBearerProtocol(r *http.Request) string {
-	for _, protocol := range strings.Split(r.Header.Get("Sec-WebSocket-Protocol"), ",") {
+	for protocol := range strings.SplitSeq(r.Header.Get("Sec-WebSocket-Protocol"), ",") {
 		protocol = strings.TrimSpace(protocol)
 		if strings.HasPrefix(protocol, websocketBearerProtocolPrefix) {
 			return protocol
@@ -268,12 +269,7 @@ func (s *Server) websocketOriginPatterns(r *http.Request) []string {
 // sessions and never leak to other workspace members.
 func shouldDeliverEvent(event store.Event, userID string) bool {
 	if len(event.RecipientUserIDs) > 0 {
-		for _, allowed := range event.RecipientUserIDs {
-			if allowed == userID {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(event.RecipientUserIDs, userID)
 	}
 	switch event.Type {
 	case "channel.read", "dm.read":

--- a/apps/api/internal/httpapi/responses.go
+++ b/apps/api/internal/httpapi/responses.go
@@ -98,8 +98,7 @@ func writeError(w http.ResponseWriter, status int, err error) {
 		status = http.StatusServiceUnavailable
 		err = errSessionLookupUnavailable
 	}
-	var maxBytesErr *http.MaxBytesError
-	if errors.As(err, &maxBytesErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 		status = http.StatusRequestEntityTooLarge
 	}
 	writeJSON(w, status, map[string]any{"error": err.Error()})

--- a/apps/api/internal/httpapi/server.go
+++ b/apps/api/internal/httpapi/server.go
@@ -20,7 +20,6 @@ import (
 type Server struct {
 	store                 store.Store
 	hub                   *realtime.Hub
-	uploadDir             string
 	uploadStorage         uploadstore.Store
 	githubOAuth           GitHubOAuthConfig
 	openclawID            OpenClawIDConfig
@@ -126,7 +125,6 @@ func New(st store.Store, hub *realtime.Hub, options Options) *Server {
 	return &Server{
 		store:                 st,
 		hub:                   hub,
-		uploadDir:             options.UploadDir,
 		uploadStorage:         uploadStorage,
 		githubOAuth:           options.GitHubOAuth.withDefaults(),
 		openclawID:            options.OpenClawID.withDefaults(),

--- a/apps/api/internal/httpapi/uploads.go
+++ b/apps/api/internal/httpapi/uploads.go
@@ -311,8 +311,7 @@ func writeUploadBodyError(w http.ResponseWriter, err error, fallbackStatus int) 
 		writeStoreError(w, err)
 		return
 	}
-	var maxBytesErr *http.MaxBytesError
-	if errors.As(err, &maxBytesErr) {
+	if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 		writeError(w, http.StatusRequestEntityTooLarge, err)
 		return
 	}

--- a/apps/api/internal/store/events.go
+++ b/apps/api/internal/store/events.go
@@ -1,5 +1,7 @@
 package store
 
+import "slices"
+
 // DurableEventTypes enumerates every event type persisted to the event log and
 // eligible for outgoing event subscriptions.
 var DurableEventTypes = []string{
@@ -22,10 +24,5 @@ var DurableEventTypes = []string{
 }
 
 func IsDurableEventType(value string) bool {
-	for _, eventType := range DurableEventTypes {
-		if value == eventType {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(DurableEventTypes, value)
 }

--- a/apps/api/internal/store/postgres/bots.go
+++ b/apps/api/internal/store/postgres/bots.go
@@ -975,7 +975,7 @@ func normalizeBotScopes(values []string) ([]string, error) {
 	seen := map[string]bool{}
 	var scopes []string
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			scope := strings.TrimSpace(part)
 			if scope == "" {
 				continue
@@ -1023,7 +1023,7 @@ func botSetupScopesMatch(values, stored, normalized []string) bool {
 	usesWriteBundle := false
 	hasScope := false
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			scope := strings.TrimSpace(part)
 			if scope == "" {
 				continue

--- a/apps/api/internal/store/postgres/dms.go
+++ b/apps/api/internal/store/postgres/dms.go
@@ -111,7 +111,7 @@ func (s *Store) CreateDirectConversation(ctx context.Context, input store.Create
 	}
 	dm := store.DirectConversation{ID: newID("dm"), WorkspaceID: input.WorkspaceID, CreatedAt: now()}
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('D')
 		if err != nil {
 			return store.DirectConversation{}, err

--- a/apps/api/internal/store/postgres/helpers.go
+++ b/apps/api/internal/store/postgres/helpers.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"maps"
 	"regexp"
 	"slices"
 	"strings"
@@ -315,9 +316,7 @@ func eventPayload(ctx context.Context, base map[string]string, nonce string) map
 		return base
 	}
 	out := make(map[string]string, len(base)+2)
-	for k, v := range base {
-		out[k] = v
-	}
+	maps.Copy(out, base)
 	if nonce != "" {
 		out["nonce"] = nonce
 	}

--- a/apps/api/internal/store/postgres/members.go
+++ b/apps/api/internal/store/postgres/members.go
@@ -270,7 +270,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 		workspace = store.Workspace{ID: newID("wsp"), Name: "ClickClack", Slug: "clickclack", CreatedAt: now()}
 		insertedWorkspace := false
 		createdWorkspace := false
-		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+		for range routeIDInsertAttempts {
 			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
@@ -310,7 +310,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 		if createdWorkspace {
 			channelID := newID("chn")
 			insertedChannel := false
-			for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+			for range routeIDInsertAttempts {
 				channelRouteID, err := store.NewRouteID('C')
 				if err != nil {
 					return store.Workspace{}, err
@@ -361,7 +361,7 @@ func (s *Store) EnsureDefaultGuestWorkspaceMember(ctx context.Context, userID, r
 	if err == sql.ErrNoRows {
 		workspace = store.Workspace{ID: newID("wsp"), Name: "Guests", Slug: "guests", CreatedAt: now()}
 		insertedWorkspace := false
-		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+		for range routeIDInsertAttempts {
 			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
@@ -424,7 +424,7 @@ func postgresEnsureNamedChannelTx(ctx context.Context, tx *sql.Tx, workspaceID, 
 	if err != sql.ErrNoRows {
 		return err
 	}
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return err

--- a/apps/api/internal/store/postgres/moderation.go
+++ b/apps/api/internal/store/postgres/moderation.go
@@ -213,10 +213,7 @@ func postsRemainingTx(ctx context.Context, q storedb.DBTX, workspaceID, userID, 
 	if err != nil {
 		return 0, 0, err
 	}
-	remaining := store.GuestPostLimit - int(count)
-	if remaining < 0 {
-		remaining = 0
-	}
+	remaining := max(store.GuestPostLimit-int(count), 0)
 	return remaining, store.GuestPostLimit, nil
 }
 

--- a/apps/api/internal/store/postgres/placeholders.go
+++ b/apps/api/internal/store/postgres/placeholders.go
@@ -7,7 +7,7 @@ import (
 
 func pgPlaceholders(n, start int) string {
 	var b strings.Builder
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if i > 0 {
 			b.WriteByte(',')
 		}

--- a/apps/api/internal/store/postgres/postgres.go
+++ b/apps/api/internal/store/postgres/postgres.go
@@ -404,7 +404,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	}
 	qtx := s.q.WithTx(tx)
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('T')
 		if err != nil {
 			return store.Workspace{}, err
@@ -515,7 +515,7 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 		ch.Kind = "public"
 	}
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return store.Channel{}, store.Event{}, err

--- a/apps/api/internal/store/postgres/route_ids.go
+++ b/apps/api/internal/store/postgres/route_ids.go
@@ -95,7 +95,7 @@ func (s *Store) backfillTableRouteIDs(ctx context.Context, table, prefix, where 
 }
 
 func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte) error {
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
@@ -119,7 +119,7 @@ func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte
 }
 
 func assignRouteIDTx(ctx context.Context, tx *sql.Tx, table, id string, prefix byte) error {
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err

--- a/apps/api/internal/store/sqlite/bots.go
+++ b/apps/api/internal/store/sqlite/bots.go
@@ -921,7 +921,7 @@ func normalizeBotScopes(values []string) ([]string, error) {
 	seen := map[string]bool{}
 	var scopes []string
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			scope := strings.TrimSpace(part)
 			if scope == "" {
 				continue
@@ -969,7 +969,7 @@ func botSetupScopesMatch(values, stored, normalized []string) bool {
 	usesWriteBundle := false
 	hasScope := false
 	for _, value := range values {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			scope := strings.TrimSpace(part)
 			if scope == "" {
 				continue

--- a/apps/api/internal/store/sqlite/dms.go
+++ b/apps/api/internal/store/sqlite/dms.go
@@ -111,7 +111,7 @@ func (s *Store) CreateDirectConversation(ctx context.Context, input store.Create
 	}
 	dm := store.DirectConversation{ID: newID("dm"), WorkspaceID: input.WorkspaceID, CreatedAt: now()}
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('D')
 		if err != nil {
 			return store.DirectConversation{}, err

--- a/apps/api/internal/store/sqlite/helpers.go
+++ b/apps/api/internal/store/sqlite/helpers.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"maps"
 	"regexp"
 	"strings"
 	"sync"
@@ -294,9 +295,7 @@ func eventPayload(ctx context.Context, base map[string]string, nonce string) map
 		return base
 	}
 	out := make(map[string]string, len(base)+2)
-	for k, v := range base {
-		out[k] = v
-	}
+	maps.Copy(out, base)
 	if nonce != "" {
 		out["nonce"] = nonce
 	}

--- a/apps/api/internal/store/sqlite/members.go
+++ b/apps/api/internal/store/sqlite/members.go
@@ -271,7 +271,7 @@ func (s *Store) EnsureDefaultWorkspaceMember(ctx context.Context, userID string)
 		workspace = store.Workspace{ID: newID("wsp"), Name: "ClickClack", Slug: "clickclack", CreatedAt: now()}
 		insertedWorkspace := false
 		createdWorkspace := false
-		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+		for range routeIDInsertAttempts {
 			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
@@ -340,7 +340,7 @@ func (s *Store) EnsureDefaultGuestWorkspaceMember(ctx context.Context, userID, r
 	if err == sql.ErrNoRows {
 		workspace = store.Workspace{ID: newID("wsp"), Name: "Guests", Slug: "guests", CreatedAt: now()}
 		insertedWorkspace := false
-		for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+		for range routeIDInsertAttempts {
 			workspaceRouteID, err := store.NewRouteID('T')
 			if err != nil {
 				return store.Workspace{}, err
@@ -402,7 +402,7 @@ func sqliteEnsureNamedChannelTx(ctx context.Context, tx *sql.Tx, workspaceID, na
 	if err != sql.ErrNoRows {
 		return err
 	}
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return err

--- a/apps/api/internal/store/sqlite/moderation.go
+++ b/apps/api/internal/store/sqlite/moderation.go
@@ -205,10 +205,7 @@ func postsRemainingTx(ctx context.Context, q storedb.DBTX, workspaceID, userID, 
 	if err != nil {
 		return 0, 0, err
 	}
-	remaining := store.GuestPostLimit - int(count)
-	if remaining < 0 {
-		remaining = 0
-	}
+	remaining := max(store.GuestPostLimit-int(count), 0)
 	return remaining, store.GuestPostLimit, nil
 }
 

--- a/apps/api/internal/store/sqlite/route_ids.go
+++ b/apps/api/internal/store/sqlite/route_ids.go
@@ -95,7 +95,7 @@ func (s *Store) backfillTableRouteIDs(ctx context.Context, table, prefix, where 
 }
 
 func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte) error {
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err
@@ -119,7 +119,7 @@ func (s *Store) assignRouteID(ctx context.Context, table, id string, prefix byte
 }
 
 func assignRouteIDTx(ctx context.Context, tx *sql.Tx, table, id string, prefix byte) error {
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID(prefix)
 		if err != nil {
 			return err

--- a/apps/api/internal/store/sqlite/sqlite.go
+++ b/apps/api/internal/store/sqlite/sqlite.go
@@ -418,7 +418,7 @@ func (s *Store) CreateWorkspace(ctx context.Context, input store.CreateWorkspace
 	}
 	qtx := s.q.WithTx(tx)
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('T')
 		if err != nil {
 			return store.Workspace{}, err
@@ -529,7 +529,7 @@ func (s *Store) CreateChannel(ctx context.Context, input store.CreateChannelInpu
 		ch.Kind = "public"
 	}
 	inserted := false
-	for attempt := 0; attempt < routeIDInsertAttempts; attempt++ {
+	for range routeIDInsertAttempts {
 		routeID, err := store.NewRouteID('C')
 		if err != nil {
 			return store.Channel{}, store.Event{}, err

--- a/apps/api/internal/store/types.go
+++ b/apps/api/internal/store/types.go
@@ -776,7 +776,7 @@ func hasURLLikePrefix(value string) bool {
 	if separator <= 0 {
 		return false
 	}
-	for i := 0; i < separator; i++ {
+	for i := range separator {
 		char := value[i]
 		if !(char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' ||
 			(char >= '0' && char <= '9' && i > 0) || char == '+' || char == '-' || char == '.') {


### PR DESCRIPTION
## What Problem This Solves

The backend repeated collection membership, map-copy, split iteration, bounds and typed-error boilerplate that the declared Go version already supports directly. Server state also retained an upload-directory field that was assigned but never read.

## Why This Change Was Made

Apply the Go toolchain's production-source modernization suggestions: standard collection/error helpers and integer iteration preserve the same validation, scope checks, tokenization, retry counts and clamps. Remove only the unused stored field; the `Options.UploadDir` initializer still creates local upload storage.

## User Impact

No behavior, configuration, database format or runtime-floor changes. The Go minimum remains 1.26.6 and the normal toolchain remains 1.27.1.

## Evidence

- Isolated Codex autoreview: scoped-clean at P0–P2.
- Built with the pinned normal toolchain and ran a fresh SQLite server: health/readiness, embedded SPA, profiles, workspace/channel/message/reply/reaction creation, search and durable replay passed.
- Live profile normalization and invalid-handle rejection also passed.
- `GOTOOLCHAIN=go1.26.6 go test ./...`: passed again for the independent main-based candidate across the complete module. Final exact-head CI is green: https://github.com/openclaw/clickclack/actions/runs/34727196471, plus CodeQL and all desktop platforms.
- `git diff --check`: passed. No tests were removed or weakened.

After integration with the validation and client refactors, the final Go source exactly matches the originally reviewed and minimum-version-tested combined candidate (`git diff --exit-code` excluding only embedded web assets). A fresh built-server smoke on the combined result also passed.
