### PR TITLE
fix(desktop): complete Cloudflare Access OTP in the app session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Hide OpenClaw ID sign-in when the server has not configured it, and show the correct sign-in guidance for OpenClaw-only servers.
 - Fixed saved choices to reveal agent commentary or tool calls being overridden by an older combined hide-activity setting after reload.
+- Fixed desktop sign-in behind Cloudflare Access One-time PIN by completing authentication in an isolated window sharing the app's session; multi-domain Access apps require Eager redirect cookie disabled. Thanks @sercada.
 - Patched `js-yaml` and `xmldom` advisories in the desktop packaging and OpenAPI tooling dependencies, and aligned the OpenAPI generator with its supported TypeScript compiler API.
 - Updated Vite, Electron 43, desktop packaging, Wrangler, pnpm and build image/tool pins while preserving Node.js 24, macOS 12 and Go 1.26.6 minimums; CI now covers web utilities on Node.js 24 and 26 and avoids duplicate Go tests and unnecessary job dependencies.
 

--- a/apps/desktop/resources/access-connecting.html
+++ b/apps/desktop/resources/access-connecting.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Connecting ClickClack</title>
+    <style>
+      body { background: #131419; color: #f7f3ed; font: 16px system-ui, sans-serif; margin: 0; }
+      main { margin: 18vh auto; max-width: 32rem; padding: 2rem; text-align: center; }
+      p { color: #c9c5bd; line-height: 1.5; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Finish sign-in in the Access window</h1>
+      <p>If you close it, use View → Reload or Settings to try again.</p>
+    </main>
+  </body>
+</html>

--- a/apps/desktop/scripts/access-auth.test.mjs
+++ b/apps/desktop/scripts/access-auth.test.mjs
@@ -1,0 +1,243 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { A, B, deferred, desktop, settle } from "./main-harness.mjs";
+
+const ACCESS = "https://example.cloudflareaccess.com";
+const login = `${ACCESS}/cdn-cgi/access/login/127.0.0.1?redirect_url=%2Fapp`;
+
+function navigate(window, url, name = "will-redirect", mainFrame = true) {
+  let prevented = false;
+  window.webContents.emit(
+    name,
+    {
+      preventDefault() {
+        prevented = true;
+      },
+    },
+    url,
+    false,
+    mainFrame,
+  );
+  return prevented;
+}
+
+function authWindow(d) {
+  return d.windows.findLast(
+    (window) =>
+      !window.destroyed &&
+      window.options.parent === d.main &&
+      !window.options.webPreferences.preload,
+  );
+}
+
+test("Access redirects use the app session in an isolated window, preserving the original route", async (t) => {
+  const d = await desktop(t);
+  const main = d.main;
+  d.send(main, "desktop:set-active-route", "/app/team/general");
+  main.url = `${A}/app/team/general`;
+  assert.equal(navigate(main, login), true);
+  await settle();
+  const auth = authWindow(d);
+  assert.ok(auth);
+  assert.equal(auth.options.webPreferences.session, main.webContents.session);
+  assert.equal(auth.options.webPreferences.preload, undefined);
+  assert.equal(auth.options.webPreferences.nodeIntegration, false);
+  assert.equal(auth.options.webPreferences.contextIsolation, true);
+  assert.equal(auth.options.webPreferences.sandbox, true);
+  assert.equal(auth.options.webPreferences.webSecurity, true);
+  assert.equal(d.session.permissionCheck(), false);
+  let permission;
+  d.session.permissionRequest(auth.webContents, "notifications", (allowed) => {
+    permission = allowed;
+  });
+  assert.equal(permission, false);
+  assert.deepEqual(d.browserURLs, []);
+  assert.equal(auth.openHandler({ url: "https://external.example/" }).action, "deny");
+
+  // Redirecting to the callback is not completion: its response must set the cookies first.
+  navigate(auth, `${A}/cdn-cgi/access/authorized?nonce=redacted`);
+  assert.equal(auth.destroyed, false);
+  navigate(auth, `${A}/app`);
+  assert.equal(auth.destroyed, false);
+  auth.webContents.emit("did-navigate", {}, `${A}/app`);
+  await settle();
+  assert.equal(auth.destroyed, true);
+  assert.equal(main.loads.at(-1), `${A}/app/team/general`);
+  assert.deepEqual(d.errors, []);
+});
+
+test("ordinary external links and non-Access redirects retain browser behavior", async (t) => {
+  const d = await desktop(t);
+  assert.equal(navigate(d.main, "https://external.example/"), true);
+  assert.equal(authWindow(d), undefined);
+  assert.equal(navigate(d.main, login, "will-navigate"), true);
+  assert.equal(authWindow(d), undefined);
+  assert.deepEqual(d.browserURLs, ["https://external.example/", login]);
+});
+
+test("subframe redirects cannot start Access and repeated redirects cannot spawn extra windows", async (t) => {
+  const d = await desktop(t);
+  assert.equal(navigate(d.main, login, "will-redirect", false), false);
+  assert.equal(authWindow(d), undefined);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  const count = d.windows.length;
+  navigate(d.main, login);
+  await settle();
+  assert.equal(authWindow(d), auth);
+  assert.equal(d.windows.length, count);
+});
+
+test("Access rejects unrelated origins and custom protocols without opening a browser", async (t) => {
+  for (const url of [
+    "https://idp.example/",
+    "http://example.cloudflareaccess.com/",
+    "file:///tmp/a",
+    "javascript:alert(1)",
+  ]) {
+    const d = await desktop(t);
+    navigate(d.main, login);
+    await settle();
+    const auth = authWindow(d);
+    assert.equal(navigate(auth, url, "will-navigate"), true);
+    await settle();
+    assert.deepEqual(d.browserURLs, []);
+    assert.ok(d.errors.length > 0);
+  }
+});
+
+test("Access windows cannot download or send desktop bridge messages", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  let prevented = false;
+  d.session.emit(
+    "will-download",
+    {
+      preventDefault() {
+        prevented = true;
+      },
+    },
+    { once() {} },
+    auth.webContents,
+  );
+  assert.equal(prevented, true);
+  d.send(auth, "desktop:set-unread", 99);
+  assert.equal(d.badges.includes(99), false);
+});
+
+test("server changes invalidate Access before a late callback can navigate the replacement", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  await d.save(B);
+  const replacement = d.main;
+  assert.equal(auth.destroyed, true);
+  auth.webContents.emit("did-navigate", {}, `${A}/app`);
+  await settle();
+  assert.deepEqual(replacement.loads, [`${B}/app`]);
+  assert.deepEqual(d.errors, []);
+});
+
+test("closing the main window invalidates an Access callback", async (t) => {
+  const d = await desktop(t);
+  const main = d.main;
+  navigate(main, login);
+  await settle();
+  const auth = authWindow(d);
+  const windowsBeforeClose = d.windows.length;
+  main.destroy();
+  assert.equal(auth.destroyed, true);
+  assert.equal(d.windows.length, windowsBeforeClose);
+  const count = main.loads.length;
+  auth.webContents.emit("did-navigate", {}, `${A}/app`);
+  await settle();
+  assert.equal(main.loads.length, count);
+  assert.deepEqual(d.errors, []);
+});
+
+test("cancelled Access reports recovery instructions without reloading or retaining the attempt", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  const count = d.main.loads.length;
+  auth.destroy();
+  await settle();
+  assert.equal(d.main.loads.length, count);
+  assert.ok(d.errors.length > 0);
+  navigate(d.main, login);
+  await settle();
+  assert.notEqual(authWindow(d), auth);
+});
+
+test("Reload recovers the server route after cancelled Access", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  authWindow(d).destroy();
+  await settle();
+  const view = d.applicationMenu.find((entry) => entry.label === "View");
+  view.submenu.find((entry) => entry.label === "Reload").click();
+  await settle();
+  assert.equal(d.main.loads.at(-1), `${A}/app`);
+});
+
+test("quitting clears Access without showing errors or recreating a window", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  const count = d.windows.length;
+  const shows = d.main.shows;
+  d.app.emit("before-quit");
+  await settle();
+  assert.equal(auth.destroyed, true);
+  assert.equal(d.windows.length, count);
+  assert.equal(d.main.shows, shows);
+  assert.deepEqual(d.errors, []);
+});
+
+test("later OTP navigation failures offer recovery without exposing the authentication URL", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  auth.webContents.emit("did-fail-load", {}, -3, "ERR_ABORTED", login, true);
+  assert.equal(auth.destroyed, false);
+  auth.webContents.emit(
+    "did-fail-load",
+    {},
+    -105,
+    "ERR_NAME_NOT_RESOLVED",
+    `${login}&token=secret`,
+    true,
+  );
+  await settle();
+  assert.equal(auth.destroyed, true);
+  assert.equal(d.errors.length, 1);
+  assert.equal(d.errors[0].includes("secret"), false);
+});
+
+for (const outcome of ["success", "error"]) {
+  test(`server changes during Access completion suppress stale ${outcome}`, async (t) => {
+    const d = await desktop(t);
+    const original = d.main;
+    navigate(original, login);
+    await settle();
+    const auth = authWindow(d);
+    const held = deferred();
+    d.controls.loadURL = (window) => (window === original ? held.promise : Promise.resolve());
+    auth.webContents.emit("did-navigate", {}, `${A}/app`);
+    await settle();
+    await d.save(B);
+    if (outcome === "error") held.reject(new Error("stale navigation failed"));
+    else held.resolve();
+    await settle();
+    assert.deepEqual(d.main.loads, [`${B}/app`]);
+    assert.deepEqual(d.errors, []);
+  });
+}

--- a/apps/desktop/scripts/access-auth.test.mjs
+++ b/apps/desktop/scripts/access-auth.test.mjs
@@ -10,6 +10,8 @@ function navigate(window, url, name = "will-redirect", mainFrame = true) {
   window.webContents.emit(
     name,
     {
+      url,
+      isMainFrame: mainFrame,
       preventDefault() {
         prevented = true;
       },
@@ -100,11 +102,33 @@ test("Access rejects unrelated origins and custom protocols without opening a br
     navigate(d.main, login);
     await settle();
     const auth = authWindow(d);
-    assert.equal(navigate(auth, url, "will-navigate"), true);
+    assert.equal(navigate(auth, url, "will-frame-navigate"), true);
     await settle();
     assert.deepEqual(d.browserURLs, []);
     assert.ok(d.errors.length > 0);
+    assert.match(d.errors[0], /turn off Eager redirect cookie/);
   }
+});
+
+test("Access guards subframe navigation and permits only the Turnstile frame exception", async (t) => {
+  const d = await desktop(t);
+  navigate(d.main, login);
+  await settle();
+  const auth = authWindow(d);
+  assert.equal(
+    navigate(auth, "https://challenges.cloudflare.com/turnstile", "will-frame-navigate", false),
+    false,
+  );
+  assert.equal(navigate(auth, "https://external.example/", "will-frame-navigate", false), true);
+  assert.equal(auth.destroyed, true);
+  assert.deepEqual(d.browserURLs, []);
+
+  navigate(d.main, login);
+  await settle();
+  assert.equal(
+    navigate(authWindow(d), "https://challenges.cloudflare.com/", "will-frame-navigate"),
+    true,
+  );
 });
 
 test("Access windows cannot download or send desktop bridge messages", async (t) => {

--- a/apps/desktop/scripts/main-harness.mjs
+++ b/apps/desktop/scripts/main-harness.mjs
@@ -62,6 +62,7 @@ export async function desktop(t) {
   const browserURLs = [];
   const requests = [];
   const handlers = new Map();
+  let applicationMenu;
   const timers = new Map();
   const ready = deferred();
   const app = new EventEmitter();
@@ -85,6 +86,7 @@ export async function desktop(t) {
     openExternal: async () => {},
     writeFile: fs.writeFile,
     rename: fs.rename,
+    loadURL: async () => {},
   };
   class Window extends EventEmitter {
     constructor(options) {
@@ -98,7 +100,10 @@ export async function desktop(t) {
       this.webContents = new EventEmitter();
       Object.assign(this.webContents, {
         id: windows.length + 1,
-        setWindowOpenHandler() {},
+        setWindowOpenHandler: (handler) => {
+          this.openHandler = handler;
+        },
+        session,
         getURL: () => this.url,
         isLoading: () => false,
         send: (...args) => this.messages.push(args),
@@ -110,6 +115,7 @@ export async function desktop(t) {
       this.loads.push(url);
       this.url = url;
       this.webContents.emit("did-navigate", {}, url);
+      await controls.loadURL(this, url);
       if (this.navigation) await this.navigation.promise;
     }
     async loadFile(file) {
@@ -142,8 +148,12 @@ export async function desktop(t) {
     setOverlayIcon() {}
   }
   const session = Object.assign(new EventEmitter(), {
-    setPermissionRequestHandler() {},
-    setPermissionCheckHandler() {},
+    setPermissionRequestHandler(handler) {
+      this.permissionRequest = handler;
+    },
+    setPermissionCheckHandler(handler) {
+      this.permissionCheck = handler;
+    },
     fetch: (url, options) => {
       requests.push({ url, options });
       return controls.fetch(url, options);
@@ -167,7 +177,12 @@ export async function desktop(t) {
     Tray,
     nativeTheme: new EventEmitter(),
     nativeImage: { createFromPath: () => nativeImage },
-    Menu: { buildFromTemplate: (value) => value, setApplicationMenu() {} },
+    Menu: {
+      buildFromTemplate: (value) => value,
+      setApplicationMenu(value) {
+        applicationMenu = value;
+      },
+    },
     screen: { getDisplayMatching: () => ({ workArea: { x: 0, y: 0, width: 3000, height: 2000 } }) },
     net: { fetch: (...args) => controls.probe(...args) },
     session: { defaultSession: session },
@@ -227,12 +242,16 @@ export async function desktop(t) {
   const settingsWindow = windows[1];
   return {
     app,
+    get applicationMenu() {
+      return applicationMenu;
+    },
     controls,
     windows,
     errors,
     logs,
     badges,
     requests,
+    session,
     browserURLs,
     destination,
     idle,

--- a/apps/desktop/scripts/test.mjs
+++ b/apps/desktop/scripts/test.mjs
@@ -36,6 +36,7 @@ const result = spawnSync(
     "--test",
     outfile,
     path.join(root, "scripts", "main.test.mjs"),
+    path.join(root, "scripts", "access-auth.test.mjs"),
     releaseArtifactsTest,
     macosSigningTest,
   ],

--- a/apps/desktop/src/contract.test.ts
+++ b/apps/desktop/src/contract.test.ts
@@ -4,6 +4,7 @@ import {
   appURL,
   clampUnreadCount,
   desktopBridgeAllowed,
+  desktopCloudflareAccessLoginURL,
   desktopMainWindowNavigationAllowed,
   desktopOAuthCallbackCode,
   desktopOAuthStartURL,
@@ -120,6 +121,42 @@ test("keeps integrated desktop chrome on app routes", () => {
       false,
     ),
     false,
+  );
+});
+
+test("recognizes only the configured Cloudflare Access login redirect", () => {
+  const serverUrl = "https://chat.example.com";
+  const loginURL = (host: string, query = "") =>
+    `https://${host}.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com${query}`;
+
+  assert.equal(desktopCloudflareAccessLoginURL(loginURL("tenant"), serverUrl), true);
+  assert.equal(
+    desktopCloudflareAccessLoginURL(
+      loginURL("tenant", "?redirect_url=https%3A%2F%2Fchat.example.com%2Fapp%2Fteam%2Fgeneral"),
+      serverUrl,
+    ),
+    true,
+  );
+
+  for (const input of [
+    "https://chat.example.com/cdn-cgi/access/login/chat.example.com",
+    "https://tenant.example.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com",
+    "https://tenant.cloudflareaccess.com:8443/cdn-cgi/access/login/chat.example.com",
+    "http://tenant.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com",
+    "https://user:pass@tenant.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com",
+    "https://tenant.cloudflareaccess.com/cdn-cgi/access/login/other.example.com",
+    "https://tenant.cloudflareaccess.com/cdn-cgi/access/authorize/chat.example.com",
+    "https://tenant.cloudflareaccess.com/cdn-cgi/access/login/chat.example.com?redirect_url=https%3A%2F%2Fevil.example%2Fapp%2Fteam",
+  ]) {
+    assert.equal(desktopCloudflareAccessLoginURL(input, serverUrl), false, input);
+  }
+
+  assert.equal(
+    desktopCloudflareAccessLoginURL(
+      "https://tenant.cloudflareaccess.com/cdn-cgi/access/login/127.0.0.1?redirect_url=http%3A%2F%2F127.0.0.1%3A8080%2Fapp",
+      "http://127.0.0.1:8080",
+    ),
+    true,
   );
 });
 

--- a/apps/desktop/src/contract.ts
+++ b/apps/desktop/src/contract.ts
@@ -177,6 +177,37 @@ export function desktopMainWindowNavigationAllowed(
   }
 }
 
+/**
+ * Identifies the narrow Cloudflare Access one-time-PIN entry point that may be
+ * opened by the desktop shell. It is intentionally not a general redirect or
+ * identity-provider allowlist.
+ */
+export function desktopCloudflareAccessLoginURL(input: string, serverUrl: string): boolean {
+  try {
+    const value = new URL(input);
+    const server = new URL(normalizeServerURL(serverUrl));
+    if (
+      value.protocol !== "https:" ||
+      value.username ||
+      value.password ||
+      value.port ||
+      !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.cloudflareaccess\.com$/i.test(value.hostname) ||
+      value.pathname !== `/cdn-cgi/access/login/${server.hostname}`
+    ) {
+      return false;
+    }
+    const redirect = value.searchParams.get("redirect_url");
+    if (!redirect) return true;
+    const destination = new URL(redirect, server.origin);
+    return (
+      destination.origin === server.origin &&
+      safeAppRoute(`${destination.pathname}${destination.search}${destination.hash}`) !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function deepLinkToRoute(input: string): string | null {
   let value: URL;
   try {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -392,8 +392,8 @@ async function beginCloudflareAccess(accessURL: string, window: BrowserWindow) {
     }
   });
   authWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
-  authWindow.webContents.on("will-navigate", (event, url, _isInPlace, isMainFrame) =>
-    guardCloudflareAccessNavigation(event, url, isMainFrame, pending),
+  authWindow.webContents.on("will-frame-navigate", (event) =>
+    guardCloudflareAccessNavigation(event, event.url, event.isMainFrame, pending),
   );
   authWindow.webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) =>
     guardCloudflareAccessNavigation(event, url, isMainFrame, pending),
@@ -444,19 +444,24 @@ function guardCloudflareAccessNavigation(
   isMainFrame: boolean,
   pending: CloudflareAccessAttempt,
 ) {
-  if (!isMainFrame || !isCurrentCloudflareAccess(pending)) return;
-  if (isCloudflareAccessNavigationAllowed(url, pending)) return;
+  if (!isCurrentCloudflareAccess(pending)) return;
+  if (isCloudflareAccessNavigationAllowed(url, isMainFrame, pending)) return;
   event.preventDefault();
   clearCloudflareAccess(pending);
-  void showCloudflareAccessError();
+  void showCloudflareAccessError(
+    "Access tried to leave the sign-in and ClickClack origins. For multi-domain Access applications, turn off Eager redirect cookie in the application's cookie settings.",
+  );
 }
 
 function isCloudflareAccessNavigationAllowed(
   input: string,
+  isMainFrame: boolean,
   pending: CloudflareAccessAttempt,
 ): boolean {
   try {
     const value = new URL(input);
+    // Access can embed Turnstile; it never becomes a top-level sign-in origin.
+    if (!isMainFrame && value.origin === "https://challenges.cloudflare.com") return true;
     if (value.protocol === "https:" && value.origin === pending.authOrigin) return true;
     return value.origin === normalizeServerURL(pending.serverUrl);
   } catch {
@@ -499,10 +504,11 @@ function logMainNavigationError(error: unknown) {
   console.error("ClickClack main navigation failed", error);
 }
 
-async function showCloudflareAccessError() {
+async function showCloudflareAccessError(detail = "") {
   const options: Electron.MessageBoxOptions = {
     message:
-      "Cloudflare Access one-time PIN sign-in could not complete. This desktop flow does not support external identity providers. Reload ClickClack or choose Settings to verify the server.",
+      "Cloudflare Access one-time PIN sign-in could not complete. This desktop flow does not support external identity providers. Reload ClickClack or choose Settings to verify the server." +
+      (detail ? ` ${detail}` : ""),
     title: "ClickClack sign-in failed",
     type: "error",
   };

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -27,6 +27,7 @@ import {
   desktopMainWindowNavigationAllowed,
   DESKTOP_SERVER_ORIGIN_ARG,
   DESKTOP_TITLEBAR_ARG,
+  desktopCloudflareAccessLoginURL,
   desktopOAuthCallbackCode,
   desktopOAuthStartURL,
   mergeSettings,
@@ -56,6 +57,15 @@ let pendingRoute: string | null = null;
 let pendingProtocolURL: string | null = null;
 type DesktopAuthAttempt = Readonly<{ serverUrl: string; verifier: string; window: BrowserWindow }>;
 let pendingDesktopAuth: DesktopAuthAttempt | null = null;
+type CloudflareAccessAttempt = Readonly<{
+  authOrigin: string;
+  authWindow: BrowserWindow;
+  main: BrowserWindow;
+  route: string;
+  serverUrl: string;
+}>;
+let pendingCloudflareAccess: CloudflareAccessAttempt | null = null;
+let completingCloudflareAccess: CloudflareAccessAttempt | null = null;
 let windowSaveTimer: NodeJS.Timeout | undefined;
 let saveQueue = Promise.resolve();
 let integratedTitleBar = false;
@@ -108,6 +118,7 @@ async function start() {
   app.on("activate", () => showMainWindow());
   app.on("before-quit", () => {
     quitting = true;
+    clearCloudflareAccess();
   });
   app.on("window-all-closed", () => {
     if (process.platform !== "darwin" && (!settings.closeToTray || quitting)) app.quit();
@@ -174,6 +185,7 @@ function createMainWindow(route = currentRoute): BrowserWindow {
     }
   });
   window.on("closed", () => {
+    if (pendingCloudflareAccess?.main === window) clearCloudflareAccess();
     if (mainWindow === window) mainWindow = null;
   });
   window.on("resize", scheduleWindowStateSave);
@@ -187,7 +199,7 @@ function createMainWindow(route = currentRoute): BrowserWindow {
   window.webContents.on("render-process-gone", (_event, details) => {
     if (details.reason !== "clean-exit") void window.webContents.reload();
   });
-  void window.loadURL(appURL(settings.serverUrl, route));
+  void window.loadURL(appURL(settings.serverUrl, route)).catch(logMainNavigationError);
   return window;
 }
 
@@ -249,7 +261,20 @@ function configureWebContents(window: BrowserWindow) {
     return { action: "deny" };
   });
   window.webContents.on("will-navigate", guardMainFrameNavigation);
-  window.webContents.on("will-redirect", guardMainFrameNavigation);
+  window.webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) => {
+    if (
+      isMainFrame &&
+      window === mainWindow &&
+      desktopCloudflareAccessLoginURL(url, settings.serverUrl)
+    ) {
+      event.preventDefault();
+      if (!pendingCloudflareAccess || !isCurrentCloudflareAccess(pendingCloudflareAccess)) {
+        void beginCloudflareAccess(url, window);
+      }
+      return;
+    }
+    guardMainFrameNavigation(event, url, _isInPlace, isMainFrame);
+  });
   window.webContents.on("context-menu", (_event, params) => {
     const template: MenuItemConstructorOptions[] = [];
     if (params.misspelledWord) {
@@ -312,6 +337,177 @@ function guardMainFrameNavigation(
   } else if (isExternalURL(url)) {
     void shell.openExternal(url);
   }
+}
+
+async function beginCloudflareAccess(accessURL: string, window: BrowserWindow) {
+  if (window !== mainWindow || window.isDestroyed()) return;
+  const serverUrl = normalizeServerURL(settings.serverUrl);
+  if (!desktopCloudflareAccessLoginURL(accessURL, serverUrl)) return;
+  if (pendingCloudflareAccess && isCurrentCloudflareAccess(pendingCloudflareAccess)) return;
+  clearCloudflareAccess();
+
+  const route = currentRoute;
+  const authOrigin = new URL(accessURL).origin;
+  const authWindow = new BrowserWindow({
+    backgroundColor: nativeTheme.shouldUseDarkColors ? "#131419" : "#f7f3ed",
+    height: 720,
+    icon: assetPath("icon.png"),
+    parent: window,
+    show: false,
+    title: "ClickClack sign-in",
+    width: 520,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      session: window.webContents.session,
+      webSecurity: true,
+    },
+  });
+  const pending: CloudflareAccessAttempt = {
+    authOrigin,
+    authWindow,
+    main: window,
+    route,
+    serverUrl,
+  };
+  pendingCloudflareAccess = pending;
+  authWindow.once("ready-to-show", () => {
+    if (isCurrentCloudflareAccess(pending)) authWindow.show();
+  });
+  authWindow.on("closed", () => {
+    const cancelled =
+      pendingCloudflareAccess === pending &&
+      completingCloudflareAccess !== pending &&
+      pending.main === mainWindow &&
+      !pending.main.isDestroyed() &&
+      pending.serverUrl === settings.serverUrl;
+    if (pendingCloudflareAccess === pending) {
+      pendingCloudflareAccess = null;
+      if (completingCloudflareAccess === pending) completingCloudflareAccess = null;
+    }
+    if (cancelled) {
+      showMainWindow();
+      void showCloudflareAccessError();
+    }
+  });
+  authWindow.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  authWindow.webContents.on("will-navigate", (event, url, _isInPlace, isMainFrame) =>
+    guardCloudflareAccessNavigation(event, url, isMainFrame, pending),
+  );
+  authWindow.webContents.on("will-redirect", (event, url, _isInPlace, isMainFrame) =>
+    guardCloudflareAccessNavigation(event, url, isMainFrame, pending),
+  );
+  authWindow.webContents.on("did-navigate", (_event, url) => {
+    if (isCloudflareAccessReturnURL(url, pending.serverUrl)) void completeCloudflareAccess(pending);
+  });
+  authWindow.webContents.on(
+    "did-fail-load",
+    (_event, errorCode, _errorDescription, _validatedURL, isMainFrame) => {
+      if (isMainFrame && errorCode !== -3 && isCurrentCloudflareAccess(pending)) {
+        clearCloudflareAccess(pending);
+        void showCloudflareAccessError();
+      }
+    },
+  );
+  try {
+    await window.loadFile(resourcePath("access-connecting.html"));
+    if (!isCurrentCloudflareAccess(pending)) return;
+    await authWindow.loadURL(accessURL);
+  } catch {
+    if (!isCurrentCloudflareAccess(pending)) return;
+    clearCloudflareAccess(pending);
+    await showCloudflareAccessError();
+  }
+}
+
+function isCurrentCloudflareAccess(pending: CloudflareAccessAttempt): boolean {
+  return (
+    pendingCloudflareAccess === pending &&
+    pending.serverUrl === settings.serverUrl &&
+    pending.main === mainWindow &&
+    !pending.main.isDestroyed() &&
+    !pending.authWindow.isDestroyed()
+  );
+}
+
+function clearCloudflareAccess(pending = pendingCloudflareAccess) {
+  if (!pending || pendingCloudflareAccess !== pending) return;
+  pendingCloudflareAccess = null;
+  if (completingCloudflareAccess === pending) completingCloudflareAccess = null;
+  if (!pending.authWindow.isDestroyed()) pending.authWindow.destroy();
+}
+
+function guardCloudflareAccessNavigation(
+  event: Electron.Event,
+  url: string,
+  isMainFrame: boolean,
+  pending: CloudflareAccessAttempt,
+) {
+  if (!isMainFrame || !isCurrentCloudflareAccess(pending)) return;
+  if (isCloudflareAccessNavigationAllowed(url, pending)) return;
+  event.preventDefault();
+  clearCloudflareAccess(pending);
+  void showCloudflareAccessError();
+}
+
+function isCloudflareAccessNavigationAllowed(
+  input: string,
+  pending: CloudflareAccessAttempt,
+): boolean {
+  try {
+    const value = new URL(input);
+    if (value.protocol === "https:" && value.origin === pending.authOrigin) return true;
+    return value.origin === normalizeServerURL(pending.serverUrl);
+  } catch {
+    return false;
+  }
+}
+
+function isCloudflareAccessReturnURL(input: string, serverUrl: string): boolean {
+  try {
+    const value = new URL(input);
+    return (
+      value.origin === normalizeServerURL(serverUrl) &&
+      safeAppRoute(`${value.pathname}${value.search}${value.hash}`) !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function completeCloudflareAccess(pending: CloudflareAccessAttempt) {
+  if (!isCurrentCloudflareAccess(pending) || completingCloudflareAccess === pending) return;
+  completingCloudflareAccess = pending;
+  pending.authWindow.hide();
+  try {
+    await pending.main.loadURL(appURL(pending.serverUrl, pending.route));
+    if (!isCurrentCloudflareAccess(pending) || completingCloudflareAccess !== pending) return;
+    pendingCloudflareAccess = null;
+    completingCloudflareAccess = null;
+    if (!pending.authWindow.isDestroyed()) pending.authWindow.destroy();
+    showMainWindow();
+  } catch {
+    if (!isCurrentCloudflareAccess(pending) || completingCloudflareAccess !== pending) return;
+    clearCloudflareAccess(pending);
+    await showCloudflareAccessError();
+  }
+}
+
+function logMainNavigationError(error: unknown) {
+  if (error instanceof Error && /ERR_ABORTED/.test(error.message)) return;
+  console.error("ClickClack main navigation failed", error);
+}
+
+async function showCloudflareAccessError() {
+  const options: Electron.MessageBoxOptions = {
+    message:
+      "Cloudflare Access one-time PIN sign-in could not complete. This desktop flow does not support external identity providers. Reload ClickClack or choose Settings to verify the server.",
+    title: "ClickClack sign-in failed",
+    type: "error",
+  };
+  if (mainWindow && !mainWindow.isDestroyed()) await dialog.showMessageBox(mainWindow, options);
+  else await dialog.showMessageBox(options);
 }
 
 function createSettingsWindow() {
@@ -417,6 +613,7 @@ function registerIPC() {
       settings = { ...next, window: settings.window };
       integratedTitleBar = titleBar;
       pendingDesktopAuth = null;
+      clearCloudflareAccess();
       applyLoginItemSetting();
       currentRoute = "/app";
       rememberWindowState();
@@ -462,7 +659,16 @@ function secureSession() {
 }
 
 function installDownloadHandling() {
-  session.defaultSession.on("will-download", (_event, item) => {
+  session.defaultSession.on("will-download", (event, item, webContents) => {
+    if (
+      pendingCloudflareAccess &&
+      !pendingCloudflareAccess.authWindow.isDestroyed() &&
+      webContents === pendingCloudflareAccess.authWindow.webContents
+    ) {
+      event.preventDefault();
+      item.cancel?.();
+      return;
+    }
     item.once("done", (_doneEvent, state) => {
       if (state !== "completed" || !Notification.isSupported()) return;
       const filePath = item.getSavePath();
@@ -527,7 +733,7 @@ function createApplicationMenu() {
     {
       label: "View",
       submenu: [
-        { role: "reload" },
+        { label: "Reload", accelerator: "CmdOrCtrl+R", click: reloadMainApp },
         { role: "forceReload" },
         { type: "separator" },
         { role: "resetZoom" },
@@ -540,6 +746,15 @@ function createApplicationMenu() {
     { label: "Window", submenu: [{ role: "minimize" }, { role: "zoom" }, { role: "close" }] },
   );
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+function reloadMainApp() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  if (isSameServerURL(mainWindow.webContents.getURL())) {
+    void mainWindow.webContents.reload();
+    return;
+  }
+  void mainWindow.loadURL(appURL(settings.serverUrl, currentRoute)).catch(logMainNavigationError);
 }
 
 function createTray() {

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -91,6 +91,17 @@ attempt. Errors from the current attempt still appear normally.
 Servers using namespaced cookies require desktop OAuth protocol 2. They return
 an update-required page before sending an older desktop client to GitHub.
 
+When a server redirects the app to Cloudflare Access, ClickClack opens the
+Cloudflare Access one-time-PIN page in a small, isolated sign-in window. It
+shares the selected server's Electron session so Access can set its cookies,
+but it has no preload bridge, Node access, or popup support. ClickClack accepts
+only the exact HTTPS Access login URL for the configured host and returns only
+after the sign-in window has committed a navigation back to that server's
+`/app` route. This flow does not support arbitrary external identity providers.
+If the PIN window is closed or cannot complete, the main window stays on a
+local connection page; use **View → Reload** to retry or **Settings** to check
+the server URL.
+
 ## Security model
 
 The app loads the selected ClickClack origin with Electron sandboxing,
@@ -105,6 +116,10 @@ opaque, short-lived grant: GitHub access tokens and ClickClack session tokens
 never appear in the callback URL. Redemption requires the verifier held by the
 initiating app, is single-use, survives server restart or replica handoff, and
 expires after five minutes. Permission requests from remote content are denied.
+The Cloudflare Access sign-in window denies permissions, downloads, custom
+protocols, and popups; navigation is limited to its Access origin and the configured
+ClickClack origin (including Access cookie callbacks). Only a committed `/app`
+navigation completes the sign-in.
 Server configuration is accepted only from the bundled local settings window
 and is written atomically with user-only permissions.
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -102,6 +102,13 @@ If the PIN window is closed or cannot complete, the main window stays on a
 local connection page; use **View → Reload** to retry or **Settings** to check
 the server URL.
 
+This flow supports the selected ClickClack hostname only. If the Access application
+covers multiple domains, turn off **Eager redirect cookie** under **Advanced settings
+→ Cookie settings** before using desktop sign-in. Cloudflare otherwise redirects
+through the other protected hostnames to set their cookies, which this isolated
+window deliberately blocks. With eager redirects off, Access issues each domain's
+cookie when that domain is visited. See [Cloudflare's cookie settings](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/#eager-redirect-cookie).
+
 ## Security model
 
 The app loads the selected ClickClack origin with Electron sandboxing,
@@ -120,6 +127,8 @@ The Cloudflare Access sign-in window denies permissions, downloads, custom
 protocols, and popups; navigation is limited to its Access origin and the configured
 ClickClack origin (including Access cookie callbacks). Only a committed `/app`
 navigation completes the sign-in.
+Subframe navigation has the same restriction, with `https://challenges.cloudflare.com`
+allowed only inside frames for Cloudflare Turnstile challenges.
 Server configuration is accepted only from the bundled local settings window
 and is written atomically with user-only permissions.
 


### PR DESCRIPTION
A fresh desktop profile behind Cloudflare Access opened a blank window because the navigation guard sent authentication to the system browser, whose cookies are separate from Electron. Access One-time PIN now completes in a sandboxed window sharing the app session, then returns to the original app route after the cookie callback commits.

The auth window has no preload or Node integration; permissions, downloads, popups and custom protocols are denied. Navigation is restricted to the initiating Access and ClickClack origins, with Cloudflare Turnstile allowed only in subframes. Cancellation, server changes, window destruction and quit retire stale attempts. A local connection page and Reload action provide recovery.

Multi-domain Access apps must disable **Eager redirect cookie**; the docs and cross-origin failure message explain this prerequisite. Arbitrary external identity providers and eager cross-domain cookie chains remain unsupported.

Validation: isolated Codex review reports no actionable P0–P2 findings. 60 desktop contracts pass, with TypeScript/build/format checks. Maintainer review corrected missing multi-domain guidance and subframe enforcement. The contributor reported a real Access OTP login; maintainer proof independently ran the built Electron app signed with the OpenClaw Foundation Developer ID, using separate fresh profiles and a synthetic Access redirect/cookie fixture. Baseline requested the external browser and stayed blank. The final app rendered the isolated sign-in, received the same-session cookie on committed /app navigation, loaded the production ClickClack workspace, and closed the auth window. A separate real Electron run inserted an unrelated-origin iframe: the guarded navigation closed the auth window and showed recovery guidance. This fixture validates Electron behavior without real credentials; it does not exercise a live Cloudflare tenant or realtime proxy transport.

Before: blocked redirect leaves a blank app:

![Before: blocked redirect leaves a blank app](https://github.com/user-attachments/assets/cdbfa40f-bd7d-400b-8d13-b3fcf1abc1f0)

Isolated synthetic Access page:

![Isolated synthetic Access page](https://github.com/user-attachments/assets/1331602a-8f76-4a6d-9ec1-c9086dfd6e0c)

After: production workspace loads with the shared cookie:

![After: production workspace loads with the shared cookie](https://github.com/user-attachments/assets/fa9f3bdf-96c7-4c76-9468-958257e6326b)
